### PR TITLE
cleaned up Health Check examples

### DIFF
--- a/docs/docs/0.6.0/policies/health-check.md
+++ b/docs/docs/0.6.0/policies/health-check.md
@@ -26,7 +26,6 @@ mesh: default
 metadata:
   namespace: default
   name: web-to-backend-check
-mesh: default
 spec:
   sources:
   - match:
@@ -35,6 +34,10 @@ spec:
   - match:
       service: backend
   conf:
+    interval: 10s
+    timeout: 2s
+    unhealthyThreshold: 3
+    healthyThreshold: 1
     activeChecks:
       interval: 10s
       timeout: 2s
@@ -59,6 +62,10 @@ destinations:
 - match:
     service: backend
 conf:
+  interval: 10s
+  timeout: 2s
+  unhealthyThreshold: 3
+  healthyThreshold: 1
   activeChecks:
     interval: 10s
     timeout: 2s


### PR DESCRIPTION
Cleaned up Health Check example:
```
The HealthCheck "proxy-to-random-sports-team" is invalid: 
* spec.conf.interval: must have a positive value
* spec.conf.timeout: must have a positive value
* spec.conf.unhealthyThreshold: must have a positive value
* spec.conf.healthyThreshold: must have a positive value
```

- removed double reference of kind
- fixed conf key in HealthCheck type


