### PR TITLE
Fix typo and linking to older docu versions

### DIFF
--- a/docs/docs/0.7.1/documentation/deployments.md
+++ b/docs/docs/0.7.1/documentation/deployments.md
@@ -50,7 +50,7 @@ $ kuma-cp run
 :::
 ::::
 
-Once Kuma is up and running, data plane proxies can now [connect](/docs/0.7.0/documentation/dps-and-data-model) directly to it. 
+Once Kuma is up and running, data plane proxies can now [connect](/docs/0.7.1/documentation/dps-and-data-model) directly to it. 
 
 :::tip
 When the mode is not specified, Kuma will always start in `standalone` mode by default.
@@ -89,7 +89,7 @@ To implement easy service connectivity, Kuma ships with:
 * **Ingress Data Plane**: Kuma provides an out of the box `ingress` data plane mode that will be used to enable traffic to enter a zone from another zone. It can be scaled horizontally. Each zone must have an `ingress` data plane deployed. 
 
 :::tip
-An `ingress` data plane is specific to internal communication within a mesh and it is not to be considered an API gateway. API gateways are supported via Kuma's [gateway mode](/docs/0.7.0/documentation/dps-and-data-model/#gateway) which can be deployed **in addition** to `ingress` data planes.
+An `ingress` data plane is specific to internal communication within a mesh and it is not to be considered an API gateway. API gateways are supported via Kuma's [gateway mode](/docs/0.7.1/documentation/dps-and-data-model/#gateway) which can be deployed **in addition** to `ingress` data planes.
 :::
 
 The global control plane and the remote control planes communicate with each other via xDS in order to synchronize the resources that are being created to configure Kuma, like policies.

--- a/docs/docs/0.7.1/documentation/dps-and-data-model.md
+++ b/docs/docs/0.7.1/documentation/dps-and-data-model.md
@@ -129,7 +129,7 @@ A data-plane can have many labels that define its role within your architecture.
 There is one special tag, the `kuma.io/service` tag, that must always be set.
 :::
 
-Tags are important because can be used later on by any [Policy](../../policies/introduction) that Kuma supports now and in the future. For example, it will be possible to route requests from one region to another assuming there is a `region` tag associated to the data-planes.
+Tags are important because they can be used later on by any [Policy](../../policies/introduction) that Kuma supports now and in the future. For example, it will be possible to route requests from one region to another assuming there is a `region` tag associated to the data-planes.
 
 ## Dataplane Specification
 
@@ -291,7 +291,7 @@ For an in-depth example on deploying Kuma with [Kong for Kubernetes](https://git
 
 ## Ingress
 
-To implement cross-zone communication when Kuma is deployed in a [multi-zone](/docs/0.7.0/documentation/deployments/) mode, the `Dataplane` model introduces the `Ingress` mode. Such dataplane is not attached to any particular workload, but instead it is bound to that particular zone.
+To implement cross-zone communication when Kuma is deployed in a [multi-zone](/docs/0.7.1/documentation/deployments/#multi-zone-mode) mode, the `Dataplane` model introduces the `Ingress` mode. Such dataplane is not attached to any particular workload, but instead it is bound to that particular zone.
 The specifics of the `Ingress` dataplane are described in the `networking.ingress` dictionary in the YAML resource. For the time being this one is empty, instead it denotes the `Ingress` mode of the dataplane.
 
 ### Universal
@@ -315,7 +315,7 @@ The `networking.address` is and externally accessible IP or one behind a LoadBal
 
 ### Kubernetes
 
-The recommended way to deploy an `Ingress` dataplane in Kubernetes is to use `kumactl`, or the Helm charts as specified in [multi-zone](/docs/0.7.0/documentation/deployments/#remote-control-plane). It works as a separate deployment of a single-container pod.
+The recommended way to deploy an `Ingress` dataplane in Kubernetes is to use `kumactl`, or the Helm charts as specified in [multi-zone](/docs/0.7.1/documentation/deployments/#remote-control-plane). It works as a separate deployment of a single-container pod.
 
 ## Direct access to services
 

--- a/docs/docs/0.7.1/documentation/secrets.md
+++ b/docs/docs/0.7.1/documentation/secrets.md
@@ -2,7 +2,7 @@
 
 Kuma provides a built-in interface to store sensitive information such as TLS keys and tokens that can be used later on by any policy at runtime. This functionality is being implemented by introducing a `Secret` resource.
 
-Secrets belong to a specific [`Mesh`](/docs/0.4.0/policies/mesh) resource, and cannot be shared across different `Meshes`.
+Secrets belong to a specific [`Mesh`](/docs/0.7.1/policies/mesh) resource, and cannot be shared across different `Meshes`.
 
 :::tip
 Kuma will also leverage `Secret` resources internally for certain operations, for example when storing auto-generated certificates and keys when Mutual TLS is enabled.
@@ -75,7 +75,7 @@ sample-secret   system.kuma.io/secret   1      3m12s
 Like any other Kuma resources, if `kuma.io/mesh` is not specified then the `Secret` will automatically belong to the `default` Mesh. 
 :::
 
-Kubernetes Secrets always belongs to a specific [`Mesh`](/docs/0.4.0/policies/mesh) resource and they are internally they are identified with the `name + namespace` format, therefore **it is not possible** to have a `Secret` with the same name in multiple meshes (since multiple `Meshes` always belong to one Kuma CP that always runs in one Namespace).
+Kubernetes Secrets always belongs to a specific [`Mesh`](/docs/0.7.1/policies/mesh) resource and they are internally they are identified with the `name + namespace` format, therefore **it is not possible** to have a `Secret` with the same name in multiple meshes (since multiple `Meshes` always belong to one Kuma CP that always runs in one Namespace).
 
 In order to reassign a `Secret` to another `Mesh` you need to delete the `Secret` resource and apply it again.
 
@@ -93,7 +93,7 @@ $ echo "value" | base64
 
 ## Usage
 
-Here is example of how you can use a Kuma `Secret` with a `provided` [Mutual TLS](/docs/0.4.0/policies/mutual-tls) backend.
+Here is example of how you can use a Kuma `Secret` with a `provided` [Mutual TLS](/docs/0.7.1/policies/mutual-tls) backend.
 
 The examples below assume that the `Secret` object has already been created before-hand.
 


### PR DESCRIPTION
Just saw that some links pointing to an older version of the documentation (yellow banner) and fixed this quickly. Tested it locally with yarn docs:dev. 