### PR TITLE
Tabs fix

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -215,6 +215,9 @@ module.exports = {
     //   }
     // },
     "@vuepress/nprogress": {},
+    "tabs": {
+      dedupeIds: true
+    },
     "@vuepress/plugin-blog": {
       sitemap: {
         hostname: productData.hostname


### PR DESCRIPTION
This fix restores the tabs plugin used for the docs, but also addresses a conflict between the blog, tabs, and possibly the reading time plugins. Their registration order in the VuePress config was causing tabs to stop working.