### PR TITLE
OpenShift improvements

### DIFF
--- a/docs/docs/0.7.2/installation/openshift.md
+++ b/docs/docs/0.7.2/installation/openshift.md
@@ -190,11 +190,17 @@ $ kumactl config control-planes add --name=XYZ --address=http://{address-to-kuma
 
 You will notice that Kuma automatically creates a [`Mesh`](../../policies/mesh) entity with name `default`.
 
-::: warning
-Kuma explicitly specifies UID for `kuma-dp` to avoid capturing traffic from `kuma-dp` itself. For that reason, special privilege has to be granted to application namespace:
+::: tip
+Kuma explicitly specifies UID for `kuma-dp` sidecar to avoid capturing traffic from `kuma-dp` itself. For that reason, `nonroot` [Security Context Constraint](https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html) has to be granted to the application namespace:
 ```sh
-$ oc adm policy add-scc-to-user anyuid -z APPLICATION_SERVICE_ACCOUNT -n APPLICATION_NAMESPACE
+$ oc adm policy add-scc-to-group nonroot system:serviceaccounts:<app-namespace>
 ```
+
+If namespace is not configured properly, we will see following error on the `Deployment` or `DeploymentConfig`
+```
+'pods "kuma-demo-backend-v0-cd6b68b54-" is forbidden: unable to validate against any security context constraint: [spec.containers[1].securityContext.securityContext.runAsUser: Invalid value: 5678: must be in the ranges: [1000540000, 1000549999]]'
+```
+
 :::
 
 ### 4. Quickstart
@@ -202,3 +208,11 @@ $ oc adm policy add-scc-to-user anyuid -z APPLICATION_SERVICE_ACCOUNT -n APPLICA
 Congratulations! You have successfully installed Kuma on OpenShift 🚀. 
 
 In order to start using Kuma, it's time to check out the [quickstart guide for Kubernetes](/docs/0.7.2/quickstart/kubernetes/) deployments.
+
+::: tip
+Before running Kuma Demo in the Quickstart, remember to run following command
+```sh
+$ oc adm policy add-scc-to-group anyuid system:serviceaccounts:kuma-demo
+```
+In case of Kuma Demo, one of the component requires root access therefore we use `anyuid` instead of `nonroot` permission.
+:::

--- a/docs/docs/0.7.2/installation/openshift.md
+++ b/docs/docs/0.7.2/installation/openshift.md
@@ -210,7 +210,7 @@ Congratulations! You have successfully installed Kuma on OpenShift 🚀.
 In order to start using Kuma, it's time to check out the [quickstart guide for Kubernetes](/docs/0.7.2/quickstart/kubernetes/) deployments.
 
 ::: tip
-Before running Kuma Demo in the Quickstart, remember to run following command
+Before running Kuma Demo in the Quickstart, remember to run the following command
 ```sh
 $ oc adm policy add-scc-to-group anyuid system:serviceaccounts:kuma-demo
 ```


### PR DESCRIPTION
A couple of findings.

1) We don't actually need `anyuid`, we are not using root user. We need `nonroot`
2) It's less confusing to apply this on the namespace (when I started openshift for the first time I wasn't sure what to put in service account)
3) I think this should be a tip, not a warning. Warning sounds really negative in installation procedure
4) I added sample error what it looks like if you forget to do this. I was confused when I first started OpenShift and forget to do it
5) For Kuma Demo we actually need `anyuid` because of postgres