### PR TITLE
FOR NEXT docs(*) http health checks

### DIFF
--- a/docs/docs/1.0.3/documentation/http-api.md
+++ b/docs/docs/1.0.3/documentation/http-api.md
@@ -877,7 +877,30 @@ curl http://localhost:5681/meshes/mesh-1/health-checks/web-to-backend
   "interval": "10s",
   "timeout": "2s",
   "unhealthyThreshold": 3,
-  "healthyThreshold": 1
+  "healthyThreshold": 1,
+  "http": {
+   "path": "/health",
+   "requestHeadersToAdd": [
+    {
+     "append": false,
+     "header": {
+      "key": "Content-Type",
+      "value": "application/json"
+     }
+    },
+    {
+     "header": {
+      "key": "Accept",
+      "value": "application/json"
+     }
+    }
+   ],
+   "expectedStatuses": [
+    200,
+    201
+   ],
+   "useHttp1": true
+  }
  }
 }
 ```
@@ -914,7 +937,30 @@ curl -XPUT http://localhost:5681/meshes/mesh-1/health-checks/web-to-backend --da
   "interval": "10s",
   "timeout": "2s",
   "unhealthyThreshold": 3,
-  "healthyThreshold": 1
+  "healthyThreshold": 1,
+  "http": {
+   "path": "/health",
+   "requestHeadersToAdd": [
+    {
+     "append": false,
+     "header": {
+      "key": "Content-Type",
+      "value": "application/json"
+     }
+    },
+    {
+     "header": {
+      "key": "Accept",
+      "value": "application/json"
+     }
+    }
+   ],
+   "expectedStatuses": [
+    200,
+    201
+   ],
+   "useHttp1": true
+  }
  }
 }
 ```
@@ -955,7 +1001,30 @@ curl http://localhost:5681/meshes/mesh-1/health-checks
     "interval": "10s",
     "timeout": "2s",
     "unhealthyThreshold": 3,
-    "healthyThreshold": 1
+    "healthyThreshold": 1,
+    "http": {
+     "path": "/health",
+     "requestHeadersToAdd": [
+      {
+       "append": false,
+       "header": {
+        "key": "Content-Type",
+        "value": "application/json"
+       }
+      },
+      {
+       "header": {
+        "key": "Accept",
+        "value": "application/json"
+       }
+      }
+     ],
+     "expectedStatuses": [
+      200,
+      201
+     ],
+     "useHttp1": true
+    }
    }
   }
  ],


### PR DESCRIPTION
Modified API documentation by adding additional configuration block
(http) to HealthChecks and also modified HealthCheck Policy
documentation but introducing additional example for policy configured
to use HTTP protocol for health checks

Signed-off-by: Bart Smykla <bartek@smykla.com>