### PR TITLE
style(docs) smaller padding in code blocks

### DIFF
--- a/docs/.vuepress/theme/styles/custom/base/_structure.scss
+++ b/docs/.vuepress/theme/styles/custom/base/_structure.scss
@@ -44,3 +44,7 @@ body {
     display: flex;
   }
 }
+
+.theme-default-content code {
+  padding: 0.15rem 0.5rem;
+}


### PR DESCRIPTION
I'm lowering the padding in `code` blocks which looks more elegant end
is easier to read (I think) when you have two or more code block on top
of each other as before it was looking as one, solid block and it was
hard to differenciate the items between each other.

Before:
<img width="269" src="https://user-images.githubusercontent.com/11655498/102871276-82ea8200-443e-11eb-87f8-81381b6b3115.png">
![image](https://user-images.githubusercontent.com/11655498/102871375-a57c9b00-443e-11eb-9851-2f8d483a213d.png)

After:
<img width="239" src="https://user-images.githubusercontent.com/11655498/102871489-c93fe100-443e-11eb-8b3a-175af5142dab.png">
![image](https://user-images.githubusercontent.com/11655498/102871404-af9e9980-443e-11eb-8773-853fe55fe54c.png)

Signed-off-by: Bart Smykla <bartek@smykla.com>