### PR TITLE
fix(*) fix build

### DIFF
--- a/docs/.vuepress/theme/components/SidebarLinks.vue
+++ b/docs/.vuepress/theme/components/SidebarLinks.vue
@@ -43,7 +43,7 @@ export default {
     }
   },
 
-  created () {
+  mounted () {
     this.refreshIndex()
   },
 

--- a/docs/.vuepress/theme/layouts/Redirect.vue
+++ b/docs/.vuepress/theme/layouts/Redirect.vue
@@ -16,7 +16,7 @@ import { mapGetters } from 'vuex'
 
 export default {
   name: 'Redirect',
-  created () {
+  mounted () {
     this.redirectToLatestReleaseDocs()
   },
   render() {},

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,4 +2,4 @@
 [build]
   # command = "node ./bin/setup-redirects && node ./bin/curl-endpoints && vuepress build docs"
   # 4096 or 8192 for memory
-  command = "node ./bin/setup-redirects && node ./bin/curl-endpoints && node --max_old_space_size=4096 ./node_modules/vuepress/cli.js build docs"
+  command = "node ./bin/setup-redirects && node ./bin/curl-endpoints && node --max_old_space_size=8192 ./node_modules/vuepress/cli.js build docs"


### PR DESCRIPTION
- 4096 MB of memory was not enough so I bumped it to 8192 MB
- Changed `created` lifecycle hooks to `mounted` as `created`
  is unavailable in the SSR environment

Signed-off-by: Bart Smykla <bartek@smykla.com>