### PR TITLE
[wip] move page content around, rename some things

### DIFF
--- a/docs/.vuepress/site-config/sidebar-nav.js
+++ b/docs/.vuepress/site-config/sidebar-nav.js
@@ -2050,13 +2050,29 @@ module.exports = {
       children: [
         "overview/what-is-kuma",
         "overview/what-is-a-service-mesh",
-        "overview/why-kuma",
-        "overview/kuma-vs-xyz",
-        "overview/vm-and-k8s-support"
+        "overview/why-kuma"
       ]
     },
     {
-      title: "Quickstart",
+      title: "Install",
+      collapsable: true,
+      sidebarDepth: sidebarDepth,
+      path: "",
+      children: [
+        "installation/kubernetes",
+        "installation/helm",
+        "installation/openshift",
+        "installation/docker",
+        "installation/redhat",
+        "installation/centos",
+        "installation/amazonlinux",
+        "installation/debian",
+        "installation/ubuntu",
+        "installation/macos",
+      ]
+    },
+    {
+      title: "Get started",
       collapsable: true,
       sidebarDepth: sidebarDepth,
       path: "",
@@ -2066,12 +2082,11 @@ module.exports = {
       ]
     },
     {
-      title: "Documentation",
+      title: "Core components",
       collapsable: true,
       sidebarDepth: sidebarDepth,
       path: "",
       children: [
-        "documentation/introduction",
         "documentation/overview",
         "documentation/backends",
         "documentation/dependencies",
@@ -2112,24 +2127,6 @@ module.exports = {
         "policies/proxy-template",
         "policies/external-services",
         "policies/retry",
-      ]
-    },
-    {
-      title: "Install",
-      collapsable: true,
-      sidebarDepth: sidebarDepth,
-      path: "",
-      children: [
-        "installation/kubernetes",
-        "installation/helm",
-        "installation/openshift",
-        "installation/docker",
-        "installation/redhat",
-        "installation/centos",
-        "installation/amazonlinux",
-        "installation/debian",
-        "installation/ubuntu",
-        "installation/macos",
       ]
     },
     {

--- a/docs/docs/1.0.6/README.md
+++ b/docs/docs/1.0.6/README.md
@@ -4,11 +4,7 @@ title: Overview
 
 # Welcome to Kuma
 
-::: tip
-**Protip**: Use `#kumamesh` on Twitter to chat about Kuma, and join the official [Kuma Slack](/community)!
-:::
-
-Welcome to the official documentation for Kuma, a modern distributed **Control Plane** with a bundled Envoy Proxy integration.
+Welcome to the documentation for Kuma, a modern distributed **Control Plane** with a bundled Envoy Proxy integration.
 
 The word "Kuma" means "bear" in Japanese (クマ).
 
@@ -16,8 +12,12 @@ The word "Kuma" means "bear" in Japanese (クマ).
 <img src="/images/diagrams/main-diagram@2x.png" alt="" style="width: 450px; padding-top: 10px"/>
 </center>
 
-Here you will find all you need to know about the product. While Kuma is ideal for Service Mesh and Microservices, you will soon realize that it can be used to implement modern service connectivity across any architecture.
-
 The core maintainer of Kuma is **Kong**, the maker of the popular open-source Kong Gateway 🦍.
 
-As a next step, [learn what is Kuma](/docs/1.0.6/overview/what-is-kuma/).
+## Get started
+
+[Read about service mesh]()
+[Read about Kuma](/docs/1.0.6/overview/what-is-kuma/)
+[Install Kuma]()
+[Jump to the quickstart](/docs/1.0.6/quickstart/)
+[Explore the API]()

--- a/docs/docs/1.0.6/documentation/overview.md
+++ b/docs/docs/1.0.6/documentation/overview.md
@@ -1,34 +1,37 @@
 # Overview
 
-As we have [already learned](../introduction), Kuma is a universal control plane that can run across both modern environments like Kubernetes and more traditional VM-based ones.
+For high-level background and context, see [the introductory overview](docs/1.0.6/overview/what-is-kuma/) and the explanation of [how Kuma works with the sidecar proxy model](/docs/1.0.6/overview/why-kuma/).
 
-The first step is obviously to [download and install Kuma](/install/) on the platform of your choice. Different distributions will present different installation instructions that follow the best practices for the platform you have selected.
+Kuma includes the following components:
 
-Regardless of what platform you decide to use, the fundamental behavior of Kuma at runtime will not change across different distributions. These fundamentals are important to explore in order to understand what Kuma is and how it works.
+* `kuma-cp`: main Kuma executable that runs the control plane (CP).
+* `kuma-dp`: Kuma data plane proxy executable, which invokes `envoy`. A set of `kuma-dp` proxies that share a single configuration comprises a data plane. 
+* `envoy`: Envoy executable included in the Kuma archive.
+* `kumactl`: CLI for managing Kuma (`kuma-cp`) and its data.
+* `kuma-prometheus-sd`: helper tool that enables native integration with Prometheus. Enables `Prometheus` to automatically find all data planes in your Mesh and scrape metrics from them.
+* `kuma-tcp-echo`: sample application that echos back requests, used for demo purposes.
+
+A minimal Kuma deployment involves one or more instances of the control-plane (`kuma-cp`), and one or more instances of the data plane proxies (`kuma-dp`) that connect to the control plane when they start. 
+
+After the `kuma-cp` process starts, it waits for [data plane proxies](../dps-and-data-model) to connect. It accepts user-defined configurations to create service meshes and apply Kuma [Policies](../../policies/introduction) to them.
+
+High-level view of a typical Kuma installation:
+
+<center>
+<img src="/images/docs/0.4.0/diagram-06.jpg" alt="" style="padding-top: 20px; padding-bottom: 10px;"/>
+</center>
+
+And a more detailed view:
+
+<center>
+<img src="/images/docs/0.4.0/diagram-07.jpg" alt="" style="padding-top: 20px; padding-bottom: 10px;"/>
+</center>
 
 ::: tip
-Installing Kuma on Kubernetes is fully automated, while installing Kuma on Linux requires the user to run the Kuma executables. Both ways are very simple, and can be explored from the [installation page](/install/).
+**xDS APIs**: Kuma implements the [xDS](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol) APIs of Envoy in the `kuma-cp` application so that the Envoy DPs can connect to it and retrieve their configuration.
 :::
 
-There are two main components of Kuma that are very important to understand:
-
-* **Control Plane**: Kuma is first and foremost a control-plane that will accept user input (you are the user) in order to create and configure [Policies](../../policies/introduction) like [Service Meshes](../../policies/mesh), and in order to add services and configure their behavior within the Meshes you have created.
-* **Data Plane Proxy**: Kuma also bundles a data plane proxy implementation based on top of [Envoy](https://www.envoyproxy.io/). An instance of the data plane proxy will must run alongside every instance of our services (or on every Kubernetes Pod as a sidecar container) and it will process both incoming and outgoing requests for the service.
-
-::: tip
-**Multi-Mesh**: Kuma ships with multi-tenancy support since day one. This means you can create and configure multiple isolated Service Meshes from **one** control-plane. By doing so we lower the complexity and the operational cost of supporting multiple meshes. [Explore Kuma's Policies](/policies).
-:::
-
-Since Kuma bundles a data-plane in addition to the control-plane, we decided to call the executables `kuma-cp` and `kuma-dp` to differentiate them. Let's take a look at all the executables that ship with Kuma:
-
-* `kuma-cp`: this is the main Kuma executable that runs the control plane (CP).
-* `kuma-dp`: this is the Kuma data-plane executable that - under the hood - invokes `envoy`.
-* `envoy`: this is the Envoy executable that we bundle for convenience into the archive.
-* `kumactl`: this is the the user CLI to interact with Kuma (`kuma-cp`) and its data.
-* `kuma-prometheus-sd`: this is a helper tool that enables native integration between `Kuma` and `Prometheus`. Thanks to it, `Prometheus` will be able to automatically find all dataplanes in your Mesh and scrape metrics out of them.
-* `kuma-tcp-echo`: this is a sample application that echos back the requests we are making, used for demo purposes.
-
-A minimal Kuma deployment involves one or more instances of the control-plane (`kuma-cp`), and one or more instances of the data-planes (`kuma-dp`) which will connect to the control-plane as soon as they startup. Kuma supports two modes:
+Kuma supports two modes:
 
 * `universal`: when it's being installed on a Linux compatible machine like MacOS, Virtual Machine or Bare Metal. This also includes those instances where Kuma is being installed on a Linux base machine (ie, a Docker image).
 * `kubernetes`: when it's being deployed - well - on Kubernetes.
@@ -110,24 +113,4 @@ metadata:
 
 ::: tip
 **Full CRD support**: When using Kuma in Kubernetes mode you can create [Policies](../../policies/introduction) with Kuma's CRDs applied via `kubectl`.
-:::
-
-## Last but not least
-
-Once the `kuma-cp` process is started, it waits for [data-planes](../dps-and-data-model) to connect, while at the same time accepting user-defined configuration to start creating Service Meshes and configuring the behavior of those meshes via Kuma [Policies](../../policies/introduction).
-
-When we look at a typical Kuma installation, at a higher level it works like this:
-
-<center>
-<img src="/images/docs/0.4.0/diagram-06.jpg" alt="" style="padding-top: 20px; padding-bottom: 10px;"/>
-</center>
-
-When we unpack the underlying behavior, it looks like this:
-
-<center>
-<img src="/images/docs/0.4.0/diagram-07.jpg" alt="" style="padding-top: 20px; padding-bottom: 10px;"/>
-</center>
-
-::: tip
-**xDS APIs**: Kuma implements the [xDS](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol) APIs of Envoy in the `kuma-cp` application so that the Envoy DPs can connect to it and retrieve their configuration.
 :::

--- a/docs/docs/1.0.6/installation/kubernetes.md
+++ b/docs/docs/1.0.6/installation/kubernetes.md
@@ -6,7 +6,7 @@ To install and run Kuma on Kubernetes execute the following steps:
 * [2. Run Kuma](#_2-run-kuma)
 * [3. Use Kuma](#_3-use-kuma)
 
-Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and continue your Kuma journey.
+Finally you can follow the [Quickstart](/docs/1.0.6/quickstart/kubernetes) to take it from here and continue your Kuma journey.
 
 ::: tip
 Kuma also provides [Helm charts](/docs/1.0.6/installation/helm/) that we can use instead of this distribution.
@@ -183,8 +183,3 @@ $ kumactl config control-planes add --name=XYZ --address=http://{address-to-kuma
 
 You will notice that Kuma automatically creates a [`Mesh`](../../policies/mesh) entity with name `default`.
 
-### 4. Quickstart
-
-Congratulations! You have successfully installed Kuma on Kubernetes 🚀. 
-
-In order to start using Kuma, it's time to check out the [quickstart guide for Kubernetes](/docs/1.0.6/quickstart/kubernetes/) deployments.

--- a/docs/docs/1.0.6/overview/what-is-kuma.md
+++ b/docs/docs/1.0.6/overview/what-is-kuma.md
@@ -1,45 +1,35 @@
 ---
-title: What is Kuma?
+title: Introduction to Kuma
 ---
 
-# What is Kuma?
+# Overview
 
-::: tip
-**Need help?** Don't forget to check the [Community](/community) section! 
-:::
-
-Kuma is a platform agnostic open-source control plane for Service Mesh and Microservices. It can run and be operated natively across both Kubernetes and VM environments, making it easy to adopt by every team in the organization.
-
-::: tip
-Kuma is a CNCF Sandbox project, open source and vendor neutral.
-:::
+Kuma is a platform agnostic open-source control plane for service mesh and microservices management, with support for Kubernetes, VM, and bare metal environments.
 
 <center>
 <img src="/images/diagrams/main-diagram@2x.png" alt="" style="width: 550px; padding-top: 10px"/>
 </center>
 
-Bundling [Envoy](https://envoyproxy.io/) as a data-plane, Kuma can instrument any L4/L7 traffic to secure, observe, route and enhance connectivity between any service or database. It can be used natively in Kubernetes via CRDs or via a RESTful API across other environments like VMs and Bare Metal.
+Kuma helps implement a service mesh approach to distributed deployments as part of the move from monolithic architectures to microservices. You can run a service mesh with Kuma before you start decomposing your monolith, which helps keep your network secure and observable as your architecture changes. Kuma is:
 
-While being simple to use for most use-cases, Kuma also provides policies to configure the underlying Envoy data-planes in a more fine-grained manner. By doing so, Kuma can be used by both first-time users of Service Mesh, as well as the most experienced ones.
+* **Universal and Kubernetes-native**: Platform-agnostic, can run and operate anywhere.
+* **Standalone and multi-zone**: Supports multiple clouds, regions, and Kubernetes clusters with native DNS service discovery and ingress capability.
+  * [Read more about standalone deployments](/docs/1.0.6/documentation/deployments/#standalone-mode)
+  * [Read more about multi-zone deployments](/docs/1.0.6/documentation/deployments/#multi-zone-mode)
+* **Multi-mesh**: Supports multiple individual meshes with one control plane, lowering the operational costs of supporting the entire organization.
+* **Attribute-based policies**: Lets you apply fine grained service and traffic policies with any arbitrary tag selector for `sources` and `destinations`.
+* **Envoy-based**: Powered by Envoy sidecar proxies, without exposing the complexity of Envoy itself.
+* **Horizontally scalable**
+* **Enterprise-ready**: Supports mission critical enterprise use cases that require uptime and stability.
 
-Kong built Kuma with feedback from 100+ enterprise organizations running Service Mesh in production. As such, Kuma implements a pragmatic approach that is very different from other control plane implementations:  
+Bundling [Envoy](https://envoyproxy.io/) as the data plane, Kuma can instrument any L4/L7 traffic to secure, observe, route and enhance connectivity between any services or databases. It can be used natively in Kubernetes via CRDs or via a RESTful API across other environments.
 
-- **Universal**: Kuma runs on every platform, including Kubernetes and VMs and a hybrid of both.
-- **Simple**: To deploy and to use, Kuma provides easy to use policies for various use-cases.
-- **Scalable**: Kuma supports multi-tenancy, attribute based policies and scalable multi-cluster support.
-- **Envoy-based**: Kuma is built on top of Envoy, the most adopted proxy for Service Mesh.
-
-## Flat and Distributed deployments
-
-Kuma supports different deployment models:
-
-* [Standalone Deployment](/docs/1.0.6/documentation/deployments/#standalone-mode) with one control plane being in charge of multiple data plane proxies.
-* [Multi-Zone Deployment](/docs/1.0.6/documentation/deployments/#multi-zone-mode) with a global control plane and remote control planes for each underlying cluster.
-
-Below an example of a multi-zone deployment, which also enables Kuma to setup a Service Mesh that runs simoultaneously on multiple Kubernetes clusters, or on a hybrid Kubernetes/VM cluster:
+Example of a multi-zone deployment for multiple Kubernetes clusters, or a hybrid Kubernetes/VM cluster:
 
 <center>
 <img src="/images/docs/0.6.0/distributed-deployment.jpg" alt="" style="width: 700px; padding-top: 20px; padding-bottom: 10px;"/>
 </center>
 
-In both deployment modes service-to-service connectivity is abstracted away via Kuma Ingress resources and DNS Service Discovery that makes service-to-service connectivity completely automated. Supporting complex deployments while still making the Service Mesh easy to use has been a main driver in the adoption of Kuma.
+The core maintainer of Kuma is **Kong**, the maker of the popular open-source Kong Gateway 🦍.
+
+

--- a/docs/docs/1.0.6/overview/why-kuma.md
+++ b/docs/docs/1.0.6/overview/why-kuma.md
@@ -1,8 +1,8 @@
 ---
-title: Why Kuma?
+title: How Kuma works
 ---
 
-# Why Kuma?
+# How Kuma works
 
 When building any modern digital application, we will inevitably introduce services that will communicate with each other by making requests on the network.
 

--- a/docs/docs/1.0.6/quickstart/kubernetes.md
+++ b/docs/docs/1.0.6/quickstart/kubernetes.md
@@ -2,52 +2,46 @@
 title: Kubernetes Quickstart
 ---
 
-# Quickstart in Kubernetes Mode
+# Quickstart guide for Kubernetes
 
-Congratulations! After [installing](/install) Kuma, you can get up and running with a few easy steps.
+The quickstart gets you up and running with a demo marketplace application. Here's what you'll do:
 
-:::tip
-Kuma can run in both **Kubernetes** (Containers) and **Universal** mode (for VMs and Bare Metal). You are now looking at the quickstart for Kubernetes mode, but you can also check out the [Universal one](/docs/1.0.6/quickstart/universal).
-:::
+* Install and run the marketplace application
+* Enable mutual TLS and traffic permissions
+* Explore visualized traffic metrics
 
-In order to simulate a real-world scenario, we have built a simple demo application that resembles a marketplace. In this tutorial we will:
-
-* [1. Run the Marketplace application](#_1-run-the-marketplace-application)
-* [2. Enable Mutual TLS and Traffic Permissions](#_2-enable-mutual-tls-and-traffic-permissions)
-* [3. Visualize Traffic Metrics](#_3-visualize-traffic-metrics)
-
-You can also access the Kuma marketplace demo repository [on Github](https://github.com/kumahq/kuma-demo) to try more features and policies in addition to the ones described in this quickstart.
+The demo repository [on Github](https://github.com/kumahq/kuma-demo) includes more features and policies.
 
 :::tip
 **Community Chat**: If you need help, you can chat with the [Community](/community) where you can ask questions, contribute back to Kuma and send feedback.
 :::
 
-### 1. Run the Marketplace application
+## Install
 
-First, Kuma must be [installed and running](/docs/latest/installation/kubernetes) in your Kubernetes cluster.
+1.  [Install and start Kuma](/docs/1.0.6/installation/kubernetes) on your Kubernetes cluster.
 
-To install the marketplace demo application you can run:
+1.  Install the demo application:
 
-```sh
-$ kubectl apply -f https://bit.ly/demokuma
-```
+    ```sh
+    $ kubectl apply -f https://bit.ly/demokuma
+    ```
 
-This will provision a new `kuma-demo` namespace with all the services required to run the application, in this case:
+    The demo provisions a new `kuma-demo` namespace with the following services:
 
-* `frontend`: the entry-point service that serves the web application.
-* `backend`: the underlying backend component that powers the `frontend` service.
-* `postgres`: the database that stores the marketplace items.
-* `redis`: the backend storage for items reviews.
+    * `frontend`: the entry-point service that serves the web application.
+    * `backend`: the underlying backend component that powers the `frontend` service.
+    * `postgres`: the database that stores the marketplace items.
+    * `redis`: the backend storage for item reviews.
 
-You can then access the application by executing:
+1.  Access the demo application:
 
 ```sh
 $ kubectl port-forward svc/frontend -n kuma-demo 8080:8080
 ```
 
-And navigate to [127.0.0.1:8080](http://127.0.0.1:8080). 
+And navigate to [127.0.0.1:8080](http://127.0.0.1:8080).
 
-#### See the connected dataplanes
+## Connected dataplanes
 
 Since the demo application already comes with the `kuma.io/sidecar-injection` annotation enabled on the `kuma-demo` namespace, Kuma [already knows](/docs/1.0.6/documentation/dps-and-data-model/#kubernetes) that it needs to automatically inject a sidecar proxy to every Kubernetes deployment in the `default` [Mesh](/docs/1.0.6/policies/mesh/) resource:
 
@@ -117,7 +111,7 @@ $ kumactl config control-planes add --name=XYZ --address=http://{address-to-kuma
 :::
 ::::
 
-### 2. Enable Mutual TLS and Traffic Permissions
+## mTLS and traffic permissions
 
 By default the network is unsecure and not encrypted. We can change this with Kuma by enabling the [Mutual TLS](/docs/1.0.6/policies/mutual-tls/) policy to provision a dynamic Certificate Authority (CA) on the `default` [Mesh](/docs/1.0.6/policies/mesh/) resource that will automatically assign TLS certificates to our services (more specifically to the injected dataplane proxies running alongside the services).
 
@@ -166,11 +160,11 @@ By doing so every request we now make on our demo application at [`127.0.0.1:808
 As usual, you can visualize the Mutual TLS configuration and the Traffic Permission policies we have just applied via the GUI, the HTTP API or `kumactl`.
 :::
 
-### 3. Visualize Traffic Metrics
+## Traffic metrics dashboards
 
 Among the [many policies](/policies) that Kuma provides out of the box, one of the most important ones is [Traffic Metrics](/docs/1.0.6/policies/traffic-metrics/).
 
-With Traffic Metrics we can leverage Prometheus and Grafana to visualize powerful dashboards that show the overall traffic activity of our application and the status of the Service Mesh.
+With Traffic Metrics we can leverage Prometheus and Grafana to provide powerful dashboards that show the overall traffic activity of our application and the status of the Service Mesh.
 
 To enable traffic metrics we need to first install Prometheus and Grafana:
 

--- a/docs/docs/1.0.6/quickstart/universal.md
+++ b/docs/docs/1.0.6/quickstart/universal.md
@@ -2,47 +2,41 @@
 title: Universal Quickstart
 ---
 
-# Quickstart in Universal Mode
+# Quickstart guide for universal mode
 
-Congratulations! After [installing](/install) Kuma, you can get up and running with a few easy steps.
+The quickstart gets you up and running with a demo marketplace application. Here's what you'll do:
 
-:::tip
-Kuma can run in both **Kubernetes** (Containers) and **Universal** mode (for VMs and Bare Metal). You are now looking at the quickstart for Universal mode, but you can also check out the [Kubernetes one](/docs/1.0.6/quickstart/kubernetes).
-:::
+* Install and run the marketplace application
+* Enable mutual TLS and traffic permissions
+* Explore traffic metrics
 
-In order to simulate a real-world scenario, we have built a simple demo application that resembles a marketplace. In this tutorial we will:
-
-* [1. Run the Marketplace application](#_1-run-the-marketplace-application)
-* [2. Enable Mutual TLS and Traffic Permissions](#_2-enable-mutual-tls-and-traffic-permissions)
-* [3. Visualize Traffic Metrics](#_3-visualize-traffic-metrics)
-
-You can also access the Kuma marketplace demo repository [on Github](https://github.com/kumahq/kuma-demo) to try more features and policies in addition to the ones described in this quickstart.
+The demo repository [on Github](https://github.com/kumahq/kuma-demo) includes more features and policies.
 
 :::tip
 **Community Chat**: If you need help, you can chat with the [Community](/community) where you can ask questions, contribute back to Kuma and send feedback.
 :::
 
-### 1. Run the Marketplace application
+## Install
 
-First, [Vagrant](https://www.vagrantup.com/docs/installation/) must be installed on your machine.
+1.  [Install and start Kuma on your platform](/install/latest/).
 
-You then need to clone the demo repository which contains all necessary files to deploy the application with Vagrant:
+1.  If it's not already installed, [install Vagrant](https://www.vagrantup.com/downloads).
 
-```sh
-$ git clone https://github.com/kumahq/kuma-demo.git
-```
+1.  Clone the demo repository and move to the universal demo directory:
 
-Once cloned, you will find the contents of universal demo in the `kuma-demo/vagrant` folder. Enter the `vagrant` folder by running:
+    ```sh
+    $ git clone https://github.com/kumahq/kuma-demo.git
+    ```
 
-```sh
-$ cd kuma-demo/vagrant
-```
+    ```sh
+    $ cd kuma-demo/vagrant
+    ```
 
-Next, to install the marketplace demo application you can run:
+1.  And start the demo app by running:
 
-```sh
-$ vagrant up
-```
+    ```sh
+    $ vagrant up
+    ```
 
 This will create virtual machines for each services required to run the application, in this case:
 


### PR DESCRIPTION
Hi all, pushing this branch and making a PR for y'all to see what I've been doing with the docs. With thanks to @bloqhead, here's the netlify preview: https://docs-initial-reorg--kuma.netlify.app/docs/1.0.6/ 

Summary:

- renamed and moved sections in left nav
- removed some top-level pages but added their content to existing pages, to support:
  - tightening and focusing overview pages
  - pulling high-level overview content out of what's now called "core components" (temporary name but working on improving over "documentation")
- inline copyedits, but not systematic yet

Current list of TODOs:

- find better homes for some of the content still under "core components" (dependencies, for example)
- develop content model for core components pages, policies pages. options:
  - standalone "how to apply declarative YAML" page + individual pages that explain what's going on in each config, provide working YAML example
  - include "how to apply" content on each page
- content model options assume we remove current approach of putting command + config in single snippet
- another option to consider: include all the example YAML in the repository as standalone files, pull into docs w/ script (can enumerate pros and cons separately)
- clarify quickstart and how it relates (or doesn't) to a production config
- figure out better home for top-level GUI doc?