### PR TITLE
Correct outdated doc on kuma-prometheus-sd

### DIFF
--- a/docs/docs/1.0.7/policies/traffic-metrics.md
+++ b/docs/docs/1.0.7/policies/traffic-metrics.md
@@ -158,11 +158,11 @@ First, you need to run `kuma-prometheus-sd`, e.g. by using the following command
 
 ```shell
 kuma-prometheus-sd run \
-  --cp-address=http://kuma-control-plane.internal:5676 \
+  --cp-address=grpcs://kuma-control-plane.internal:5676 \
   --output-file=/var/run/kuma-prometheus-sd/kuma.file_sd.json
 ```
 
-The above configuration tells `kuma-prometheus-sd` to talk to `Kuma` Control Plane at [http://kuma-control-plane.internal:5676](http://kuma-control-plane.internal:5676) and save the list of dataplanes to `/var/run/kuma-prometheus-sd/kuma.file_sd.json`.
+The above configuration tells `kuma-prometheus-sd` to talk to `Kuma` Control Plane at [grpcs://kuma-control-plane.internal:5676](grpcs://kuma-control-plane.internal:5676) and save the list of dataplanes to `/var/run/kuma-prometheus-sd/kuma.file_sd.json`.
 
 Then, you need to set up `Prometheus` to read from that file, e.g. by using `prometheus.yml` config with the following contents:
 


### PR DESCRIPTION
The doc was still mentioning `http` when the api is `grpcs` now.

Fix: https://github.com/kumahq/kuma/issues/1515
Signed-off-by: Charly Molter <charly@koyeb.com>