### PR TITLE
Canonical links for all blog posts that were missing it

### DIFF
--- a/docs/_blog/2021-2-10-kuma-1-0-7.md
+++ b/docs/_blog/2021-2-10-kuma-1-0-7.md
@@ -4,18 +4,19 @@ description: Kuma 1.0.7 Released with Jobs and Service-less Support
 date: 2021-2-10
 tags:
   - Release
+canonicalUrl: 'https://konghq.com/blog/kuma-1-0-7-released'
 ---
 
 We are happy to announce a new release of Kuma - v1.0.7 - that ships with new features, performance improvements and fixes! We highly suggest to upgrade to this new version.
 
 ## Improvements in 1.0.7
 
-* 🚀 Support for Service-less pods.
-* 🚀 Support for Kubernetes jobs.
-* 🚀 New charts in the embedded GUI.
-* Performance improvements in multi-zone.
-* Performance improvements in DNS resolutions.
-* And much more!
+- 🚀 Support for Service-less pods.
+- 🚀 Support for Kubernetes jobs.
+- 🚀 New charts in the embedded GUI.
+- Performance improvements in multi-zone.
+- Performance improvements in DNS resolutions.
+- And much more!
 
 For a complete list of features and updates, take a look at the [full changelog](https://github.com/kumahq/kuma/blob/master/CHANGELOG.md).
 

--- a/docs/_blog/2021-2-19-kuma-1-0-8.md
+++ b/docs/_blog/2021-2-19-kuma-1-0-8.md
@@ -4,16 +4,17 @@ description: Kuma 1.0.8 Released
 date: 2021-2-19
 tags:
   - Release
+canonicalUrl: 'https://konghq.com/blog/kuma-1-0-8-released'
 ---
 
 We are happy to announce a new release of Kuma - v1.0.8 - that ships with new health checking features and several improvements! We highly suggest to upgrade to this new version.
 
 ## Improvements in 1.0.8
 
-* 🚀 Support for jitter and custom strings in health checks.
-* Fixed charts in the GUI in multi-zone.
-* CNI and VM improvements.
-* And much more!
+- 🚀 Support for jitter and custom strings in health checks.
+- Fixed charts in the GUI in multi-zone.
+- CNI and VM improvements.
+- And much more!
 
 For a complete list of features and updates, take a look at the [full changelog](https://github.com/kumahq/kuma/blob/master/CHANGELOG.md).
 


### PR DESCRIPTION
When writing blog posts, we can do this in the top frontmatter part of the markdown file:

```md
---
title: Kuma 1.0.7 Released with Jobs and Service-less Support
description: Kuma 1.0.7 Released with Jobs and Service-less Support
date: 2021-2-10
tags:
  - Release
canonicalUrl: 'https://konghq.com/blog/kuma-1-0-7-released'
---
```

The tl;dr on canonical URLs from Google:

>A canonical URL is the URL of the page that Google thinks is most representative from a set of duplicate pages on your site.