### PR TITLE
fix broken link

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -68,6 +68,6 @@ policies:
         url: /docs/latest/policies/proxy-template/
         icon: /images/icons/policies/icon-proxy-template@2x.png
       - title: DP/CP Security
-        url: /docs/latest/documentation/security/#dataplane-token
+        url: /docs/latest/security/certificates/#data-plane-proxy-to-control-plane-communication
         icon: /images/icons/policies/icon-dc-cp-security@2x.png
 ---


### PR DESCRIPTION
### Summary

Pushed to kick off netlify build bc it appears that the `latest` value in a URL doesn't map to the actual latest docs directory in a local build :-(

All good on netlify: https://deploy-preview-403--kuma.netlify.app/docs/1.1.1/security/certificates/#data-plane-proxy-to-control-plane-communication
