### PR TITLE
feat(*) docs for healthcheck changes

### DIFF
--- a/docs/docs/1.1.5/documentation/http-api.md
+++ b/docs/docs/1.1.5/documentation/http-api.md
@@ -1030,6 +1030,14 @@ curl http://localhost:5681/meshes/mesh-1/health-checks/web-to-backend
   "timeout": "2s",
   "unhealthyThreshold": 3,
   "healthyThreshold": 1,
+  "reuseConnection": false,
+  "tcp": {
+   "send": "Zm9v",
+   "receive": [
+    "YmFy",
+    "YmF6"
+   ]
+  },
   "http": {
    "path": "/health",
    "requestHeadersToAdd": [
@@ -1090,6 +1098,14 @@ curl -XPUT http://localhost:5681/meshes/mesh-1/health-checks/web-to-backend --da
   "timeout": "2s",
   "unhealthyThreshold": 3,
   "healthyThreshold": 1,
+  "reuseConnection": false,
+  "tcp": {
+   "send": "Zm9v",
+   "receive": [
+    "YmFy",
+    "YmF6"
+   ]
+  },
   "http": {
    "path": "/health",
    "requestHeadersToAdd": [
@@ -1154,6 +1170,14 @@ curl http://localhost:5681/meshes/mesh-1/health-checks
     "timeout": "2s",
     "unhealthyThreshold": 3,
     "healthyThreshold": 1,
+    "reuseConnection": false,
+    "tcp": {
+     "send": "Zm9v",
+     "receive": [
+      "YmFy",
+      "YmF6"
+     ]
+    },
     "http": {
      "path": "/health",
      "requestHeadersToAdd": [

--- a/docs/docs/1.1.5/policies/health-check.md
+++ b/docs/docs/1.1.5/policies/health-check.md
@@ -12,13 +12,13 @@ As usual, we can apply `sources` and `destinations` selectors to determine how h
 
 The `HealthCheck` policy supports both L4/TCP (default) and L7/HTTP checks.
 
+If you want to add two health checks - one `TCP` and other `HTTP` you can specify both in one manifest.
+
 ### Examples
 
 :::: tabs :options="{ useUrlFragment: false }"
 ::: tab "Kubernetes"
 
-**TCP**
-
 ```yaml
 apiVersion: kuma.io/v1alpha1
 kind: HealthCheck
@@ -45,41 +45,12 @@ spec:
     noTrafficInterval: 10s # optional, by default 60s
     eventLogPath: "/tmp/health-check.log" # optional
     alwaysLogHealthCheckFailures: true # optional, by default false
+    reuseConnection: false # optional, by default true
     tcp:
       send: Zm9v
       receive:
       - YmFy
       - YmF6
-```
-
-**HTTP**
-
-```yaml
-apiVersion: kuma.io/v1alpha1
-kind: HealthCheck
-mesh: default
-metadata:
-  name: web-to-backend-check
-spec:
-  sources:
-  - match:
-      kuma.io/service: web
-  destinations:
-  - match:
-      kuma.io/service: backend
-  conf:
-    interval: 10s
-    timeout: 2s
-    unhealthyThreshold: 3
-    healthyThreshold: 1
-    initialJitter: 5s # optional
-    intervalJitter: 6s # optional
-    intervalJitterPercent: 10 # optional
-    healthyPanicThreshold: 60 # optional, by default 50
-    failTrafficOnPanic: true # optional, by default false
-    noTrafficInterval: 10s # optional, by default 60s
-    eventLogPath: "/tmp/health-check.log" # optional
-    alwaysLogHealthCheckFailures: true # optional, by default false
     http:
       path: /health
       requestHeadersToAdd:
@@ -97,8 +68,6 @@ We will apply the configuration with `kubectl apply -f [..]`.
 
 ::: tab "Universal"
 
-**TCP**
-
 ```yaml
 type: HealthCheck
 name: web-to-backend-check
@@ -122,38 +91,12 @@ conf:
   noTrafficInterval: 10s # optional, by default 60s
   eventLogPath: "/tmp/health-check.log" # optional
   alwaysLogHealthCheckFailures: true # optional, by default false
+  reuseConnection: false # optional, by default true
   tcp:
     send: Zm9v
     receive:
     - YmFy
     - YmF6
-```
-
-**HTTP**
-
-```yaml
-type: HealthCheck
-name: web-to-backend-check
-mesh: default
-sources:
-- match:
-    kuma.io/service: web
-destinations:
-- match:
-    kuma.io/service: backend
-conf:
-  interval: 10s
-  timeout: 2s
-  unhealthyThreshold: 3
-  healthyThreshold: 1
-  initialJitter: 5s # optional
-  intervalJitter: 6s # optional
-  intervalJitterPercent: 10 # optional
-  healthyPanicThreshold: 60 # optional, by default 50
-  failTrafficOnPanic: true # optional, by default false
-  noTrafficInterval: 10s # optional, by default 60s
-  eventLogPath: "/tmp/health-check.log" # optional
-  alwaysLogHealthCheckFailures: true # optional, by default false
   http:
     path: /health
     requestHeadersToAdd:
@@ -166,7 +109,6 @@ conf:
         value: application/json
     expectedStatuses: [200, 201]
 ```
-
 We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP API](/docs/1.1.5/documentation/http-api).
 :::
 ::::


### PR DESCRIPTION
- Updated HealthCheck policy docs - combined http and tcp
  manifests in one, as with the last changes you can specify
  both in one manifest, also added `reuseConnection` to examples
- Updated API reference