### PR TITLE
rewrite policy matching

### DIFF
--- a/docs/docs/1.1.6/policies/circuit-breaker.md
+++ b/docs/docs/1.1.6/policies/circuit-breaker.md
@@ -222,3 +222,8 @@ Alongside the detectors, CircuitBreaker allows configuring thresholds:
 - `maxPendingRequests` - the maximum number of pending requests that Envoy will allow to the upstream cluster. If not specified, the default is 1024.
 - `maxRequests` - the maximum number of parallel requests that Envoy will make to the upstream cluster. If not specified, the default is 1024.
 - `maxRetries` - the maximum number of parallel retries that Envoy will allow to the upstream cluster. If not specified, the default is 3.
+
+## Matching
+
+`CircuitBreaker` is an [Outbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#outbound-connection-policy).
+You can only use `kuma.io/service` in the `destinations` section.

--- a/docs/docs/1.1.6/policies/circuit-breaker.md
+++ b/docs/docs/1.1.6/policies/circuit-breaker.md
@@ -226,4 +226,4 @@ Alongside the detectors, CircuitBreaker allows configuring thresholds:
 ## Matching
 
 `CircuitBreaker` is an [Outbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#outbound-connection-policy).
-You can only use `kuma.io/service` in the `destinations` section.
+The only supported value for `destinations.match` is `kuma.io/service`.

--- a/docs/docs/1.1.6/policies/fault-injection.md
+++ b/docs/docs/1.1.6/policies/fault-injection.md
@@ -12,23 +12,23 @@ type: FaultInjection
 mesh: default
 name: fi1
 sources:
-    - match:
-        kuma.io/service: frontend
-        version: "0.1"
+  - match:
+      kuma.io/service: frontend
+      version: "0.1"
 destinations:
-    - match:
-        kuma.io/service: backend
-        kuma.io/protocol: http
+  - match:
+      kuma.io/service: backend
+      kuma.io/protocol: http
 conf:        
-    abort:
-        httpStatus: 500
-        percentage: 50
-    delay:
-        percentage: 50.5
-        value: 5s
-    responseBandwidth:
-        limit: 50 mbps
-        percentage: 50    
+  abort:
+    httpStatus: 500
+    percentage: 50
+  delay:
+    percentage: 50.5
+    value: 5s
+  responseBandwidth:
+    limit: 50 mbps
+    percentage: 50    
 ```
 
 On Kubernetes:
@@ -40,32 +40,32 @@ mesh: default
 metadata:
   name: fi1
 spec:
-    sources:
-        - match:
-            kuma.io/service: frontend
-            version: "0.1"
-            kuma.io/protocol: http
-    destinations:
-        - match:
-            kuma.io/service: backend
-            kuma.io/protocol: http
-    conf:        
-        abort:
-            httpStatus: 500
-            percentage: 50
-        delay:
-            percentage: 50.5
-            value: 5s
-        responseBandwidth:
-            limit: 50 mbps
-            percentage: 50 
+  sources:
+    - match:
+        kuma.io/service: frontend
+        version: "0.1"
+        kuma.io/protocol: http
+  destinations:
+    - match:
+        kuma.io/service: backend
+        kuma.io/protocol: http
+  conf:        
+    abort:
+      httpStatus: 500
+      percentage: 50
+    delay:
+      percentage: 50.5
+      value: 5s
+    responseBandwidth:
+      limit: 50 mbps
+      percentage: 50 
 ```
 
 ### Sources & Destinations
 `FaultInjection` is a policy, which is applied to the connection between dataplanes. As most of the policies, `FaultInjection` supports the powerful mechanism of matching, which allows you to precisely match source and destination dataplanes.
 
 ::: warning
-`FaultInjection` policy available only for L7 HTTP traffic, `kuma.io/protocol: http` is mandatory tag both for the destination selector.
+`FaultInjection` policy available only for L7 HTTP traffic, `kuma.io/protocol: http` is mandatory tag for the destination selector.
 :::
 
 ### HTTP Faults
@@ -92,3 +92,8 @@ ResponseBandwidth defines a configuration to limit the speed of responding to th
 
 - `limit` - represented by value measure in gbps, mbps, kbps or bps, e.g. 10kbps
 - `percentage` - percentage of requests on which response bandwidth limit will be injected, has to be in [0.0 - 100.0] range
+
+## Matching
+
+`FaultInjection` is an [Inbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#inbound-connection-policy).
+You can use all the tags in both `sources` and `destinations` sections.

--- a/docs/docs/1.1.6/policies/health-check.md
+++ b/docs/docs/1.1.6/policies/health-check.md
@@ -147,4 +147,4 @@ HTTP health checks are executed using HTTP 2
 ## Matching
 
 `HealthCheck` is an [Outbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#outbound-connection-policy).
-You can only use `kuma.io/service` in the `destination` section.
+The only supported value for `destinations.match` is `kuma.io/service`.

--- a/docs/docs/1.1.6/policies/health-check.md
+++ b/docs/docs/1.1.6/policies/health-check.md
@@ -143,3 +143,8 @@ HTTP health checks are executed using HTTP 2
   - if **`receive`** section won't be provided or will be empty, checks
     will be performed as "connect only" and will be marked as successful
     when TCP connection will be successfully established.
+
+## Matching
+
+`HealthCheck` is an [Outbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#outbound-connection-policy).
+You can only use `kuma.io/service` in the `destination` section.

--- a/docs/docs/1.1.6/policies/proxy-template.md
+++ b/docs/docs/1.1.6/policies/proxy-template.md
@@ -790,3 +790,7 @@ conf:
 ```
 :::
 ::::
+
+## Matching
+
+`ProxyTemplate` is a [Dataplane policy](how-kuma-chooses-the-right-policy-to-apply.md#dataplane-policy). You can use all the tags in the `selectors` section.

--- a/docs/docs/1.1.6/policies/retry.md
+++ b/docs/docs/1.1.6/policies/retry.md
@@ -175,3 +175,8 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
   :::tip
   This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
   :::
+
+## Matching
+
+`Retry` is an [Outbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#outbound-connection-policy).
+You can only use `kuma.io/service` in the `destinations` section.

--- a/docs/docs/1.1.6/policies/retry.md
+++ b/docs/docs/1.1.6/policies/retry.md
@@ -179,4 +179,4 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
 ## Matching
 
 `Retry` is an [Outbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#outbound-connection-policy).
-You can only use `kuma.io/service` in the `destinations` section.
+The only supported value for `destinations.match` is `kuma.io/service`.

--- a/docs/docs/1.1.6/policies/timeout.md
+++ b/docs/docs/1.1.6/policies/timeout.md
@@ -79,4 +79,4 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
 ## Matching
 
 `Retry` is an [Outbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#outbound-connection-policy).
-You can only use `kuma.io/service` in the `destinations` section.
+The only supported value for `destinations.match` is `kuma.io/service`.

--- a/docs/docs/1.1.6/policies/timeout.md
+++ b/docs/docs/1.1.6/policies/timeout.md
@@ -75,3 +75,8 @@ conf:
 ```
 We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP API](/docs/1.1.6/documentation/http-api).
 :::
+
+## Matching
+
+`Retry` is an [Outbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#outbound-connection-policy).
+You can only use `kuma.io/service` in the `destinations` section.

--- a/docs/docs/1.1.6/policies/traffic-log.md
+++ b/docs/docs/1.1.6/policies/traffic-log.md
@@ -334,3 +334,8 @@ To use it with Logstash, use `json_lines` codec and make sure your JSON is forma
 
 When running Kuma on Kubernetes you can also log the traffic to external services. To do it, the matched `TrafficPermission` destination section has to have wildcard `*` value.
 In such case `%KUMA_DESTINATION_SERVICE%` will have value `external` and `%UPSTREAM_HOST%` will have an IP of the service.  
+
+## Matching
+
+`TrafficLog` is an [Outbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#outbound-connection-policy).
+You can only use `kuma.io/service` in the `destinations` section.

--- a/docs/docs/1.1.6/policies/traffic-log.md
+++ b/docs/docs/1.1.6/policies/traffic-log.md
@@ -338,4 +338,4 @@ In such case `%KUMA_DESTINATION_SERVICE%` will have value `external` and `%UPSTR
 ## Matching
 
 `TrafficLog` is an [Outbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#outbound-connection-policy).
-You can only use `kuma.io/service` in the `destinations` section.
+The only supported value for `destinations.match` is `kuma.io/service`.

--- a/docs/docs/1.1.6/policies/traffic-permissions.md
+++ b/docs/docs/1.1.6/policies/traffic-permissions.md
@@ -57,3 +57,8 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
 ::::
 
 You can use any [Tag](/docs/1.1.6/documentation/dps-and-data-model/#tags) in both `sources` and `destinations` selector, which makes `TrafficPermissions` quite powerful when it comes to creating a secure environment for our services.
+
+## Matching
+
+`TrafficPermission` is an [Inbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#inbound-connection-policy).
+You can use all the tags in both `sources` and `destinations` sections.

--- a/docs/docs/1.1.6/policies/traffic-route.md
+++ b/docs/docs/1.1.6/policies/traffic-route.md
@@ -181,3 +181,8 @@ There are different load balancing algorithms that can be used to determine how 
   loadBalancer:
     maglev: {}
   ```
+
+## Matching
+
+`TrafficRoute` is an [Outbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#outbound-connection-policy).
+You can only use `kuma.io/service` in the `destinations` section. However, you can use all the tags in `conf.split.destination`.

--- a/docs/docs/1.1.6/policies/traffic-trace.md
+++ b/docs/docs/1.1.6/policies/traffic-trace.md
@@ -122,3 +122,7 @@ It is important that we instrument our services to preserve the trace chain betw
 * `x-b3-flags`
 
 As noted before, Envoy's Zipkin tracer is also [compatible with Jaeger through Zipkin V2 HTTP API.](https://www.jaegertracing.io/docs/1.13/features/#backwards-compatibility-with-zipkin).
+
+## Matching
+
+`TrafficTrace` is a [Dataplane policy](how-kuma-chooses-the-right-policy-to-apply.md#dataplane-policy). You can use all the tags in the `selectors` section.


### PR DESCRIPTION
Docs on matching were stale.
TrafficPermission is also matched by the most specific one, it was "aggregate" back in the early days.

I added a description of the types of policy (mirroring some concepts from the codebase).
I added a note to every policy which kind of policy it is so the user has more knowledge of how it matches and where it is applied.