### PR TITLE
(docs) Add Disallow statements to robots.txt for old versions

### DIFF
--- a/docs/.vuepress/public/robots.txt
+++ b/docs/.vuepress/public/robots.txt
@@ -1,5 +1,7 @@
 User-agent: *
 Disallow: /latest_version
 Disallow: /latest_version.html
+Disallow: /docs/1.0*
+Disallow: /docs/1.1*
 
 Sitemap: https://kuma.io/sitemap.xml


### PR DESCRIPTION
This fix removes old versions of Kong documentation from search
results. When users search for Kuma documenatation the top
result is frequently an old version of Kuma cached by the search
engine. This change, on the next crawl, will remove those.

Follows Google Robot Spec
https://developers.google.com/search/docs/advanced/robots/robots_txt