### PR TITLE
Reword warning on arbitrary tags in destination selectors

### DIFF
--- a/docs/docs/1.2.0/policies/general-notes-about-kuma-policies.md
+++ b/docs/docs/1.2.0/policies/general-notes-about-kuma-policies.md
@@ -80,7 +80,7 @@ conf:
 ::: warning
 While all policies support arbitrary tags in `sources` selectors, it's not generally the case for `destinations` selectors.
 
-E.g., policies that get appied on the client side of a connection between 2 `Dataplane`s - such as `TrafficRoute`, `TrafficLog`, `HealthCheck` - only support `service` tag in `destinations` selectors.
+For example, policies that get applied on the client side of a connection between two `Dataplane`s - such as `TrafficRoute`, `TrafficLog`, `HealthCheck` - do not support arbitrary tags in their `destinations` selector; only the `service` tag is supported.
 
 In some cases there is a fundamental technical cause for that (e.g., `TrafficRoute`), in other cases it's a simplification of the initial implementation (e.g., `TrafficLog` and `HealthCheck`).
 


### PR DESCRIPTION
This PR rewords and clarifies the warning regarding the use of arbitrary tags on `destinations` selectors for Kuma policies. It also fixes a typo in the same warning.