### PR TITLE
Fix Timeout Matching section

### DIFF
--- a/docs/docs/1.2.0/policies/timeout.md
+++ b/docs/docs/1.2.0/policies/timeout.md
@@ -78,5 +78,5 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
 
 ## Matching
 
-`Retry` is an [Outbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#outbound-connection-policy).
+`Timeout` is an [Outbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#outbound-connection-policy).
 The only supported value for `destinations.match` is `kuma.io/service`.


### PR DESCRIPTION
This PR fixes an incorrect reference in the "Matching" section for the Timeout policy. This section incorrectly referenced the Retry policy.