### PR TITLE
docs(kuma-cp) Add datadog APM service example.

### DIFF
--- a/docs/docs/1.2.2/policies/traffic-trace.md
+++ b/docs/docs/1.2.2/policies/traffic-trace.md
@@ -72,7 +72,7 @@ Apply the configuration with `kumactl apply -f [..]` or with the [HTTP API](/doc
 1. Set up [APM](https://docs.datadoghq.com/tracing/).
    - For Kubernetes, see [the datadog documentation for setting up Kubernetes](https://docs.datadoghq.com/agent/kubernetes/apm/).
 
-If datadog is running within Kubernetes, you can expose the APM agent port to Kuma via Kubernetes service.
+If Datadog is running within Kubernetes, you can expose the APM agent port to Kuma via Kubernetes service.
 
 :::: tabs :options="{ useUrlFragment: false }"
 ::: tab "Kubernetes"

--- a/docs/docs/1.2.2/policies/traffic-trace.md
+++ b/docs/docs/1.2.2/policies/traffic-trace.md
@@ -72,6 +72,27 @@ Apply the configuration with `kumactl apply -f [..]` or with the [HTTP API](/doc
 1. Set up [APM](https://docs.datadoghq.com/tracing/).
    - For Kubernetes, see [the datadog documentation for setting up Kubernetes](https://docs.datadoghq.com/agent/kubernetes/apm/).
 
+If datadog is running within Kubernetes, you can expose the APM agent port to Kuma via Kubernetes service.
+
+:::: tabs :options="{ useUrlFragment: false }"
+::: tab "Kubernetes"
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: trace-svc
+spec:
+  selector:
+    app: datadog
+  ports:
+    - protocol: TCP
+      port: 8126
+      targetPort: 8126
+```
+Apply the configuration with `kubectl apply -f [..]`.
+:::
+::::
+
 ### Set up in Kuma
 
 :::: tabs :options="{ useUrlFragment: false }"


### PR DESCRIPTION
Add instructions for exposing the APM port in a Kubernetes service for consumption by Kuma.