### PR TITLE
fix(*) add missing 1.2.3 version to download links

### DIFF
--- a/docs/docs/1.2.3/installation/amazonlinux.md
+++ b/docs/docs/1.2.3/installation/amazonlinux.md
@@ -21,7 +21,7 @@ $ yum install -y tar gzip
 $ curl -L https://kuma.io/installer.sh | sh -
 ```
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma--centos-amd64.tar.gz) the distribution manually.
+or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.2.3-centos-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/docs/docs/1.2.3/installation/centos.md
+++ b/docs/docs/1.2.3/installation/centos.md
@@ -16,7 +16,7 @@ Run the following script to automatically detect the operating system and downlo
 $ curl -L https://kuma.io/installer.sh | sh -
 ```
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma--centos-amd64.tar.gz) the distribution manually.
+or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.2.3-centos-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/docs/docs/1.2.3/installation/debian.md
+++ b/docs/docs/1.2.3/installation/debian.md
@@ -16,7 +16,7 @@ Run the following script to automatically detect the operating system and downlo
 $ curl -L https://kuma.io/installer.sh | sh -
 ```
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma--debian-amd64.tar.gz) the distribution manually.
+or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.2.3-debian-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/docs/docs/1.2.3/installation/docker.md
+++ b/docs/docs/1.2.3/installation/docker.md
@@ -108,11 +108,11 @@ $ curl -L https://kuma.io/installer.sh | sh -
 
 or you can download the distribution manually:
 
-* [CentOS](https://download.konghq.com/mesh-alpine/kuma--centos-amd64.tar.gz)
-* [RedHat](https://download.konghq.com/mesh-alpine/kuma--rhel-amd64.tar.gz)
-* [Debian](https://download.konghq.com/mesh-alpine/kuma--debian-amd64.tar.gz)
-* [Ubuntu](https://download.konghq.com/mesh-alpine/kuma--ubuntu-amd64.tar.gz)
-* [macOS](https://download.konghq.com/mesh-alpine/kuma--darwin-amd64.tar.gz)
+* [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-centos-amd64.tar.gz)
+* [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.2.3-rhel-amd64.tar.gz)
+* [Debian](https://download.konghq.com/mesh-alpine/kuma-1.2.3-debian-amd64.tar.gz)
+* [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.2.3-ubuntu-amd64.tar.gz)
+* [macOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-darwin-amd64.tar.gz)
 
 and extract the archive with:
 

--- a/docs/docs/1.2.3/installation/eks.md
+++ b/docs/docs/1.2.3/installation/eks.md
@@ -31,11 +31,11 @@ $ curl -L https://kuma.io/installer.sh | sh -
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access Kubernetes:
 
-* [CentOS](https://download.konghq.com/mesh-alpine/kuma--centos-amd64.tar.gz)
-* [RedHat](https://download.konghq.com/mesh-alpine/kuma--rhel-amd64.tar.gz)
-* [Debian](https://download.konghq.com/mesh-alpine/kuma--debian-amd64.tar.gz)
-* [Ubuntu](https://download.konghq.com/mesh-alpine/kuma--ubuntu-amd64.tar.gz)
-* [macOS](https://download.konghq.com/mesh-alpine/kuma--darwin-amd64.tar.gz) or run `brew install kumactl`
+* [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-centos-amd64.tar.gz)
+* [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.2.3-rhel-amd64.tar.gz)
+* [Debian](https://download.konghq.com/mesh-alpine/kuma-1.2.3-debian-amd64.tar.gz)
+* [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.2.3-ubuntu-amd64.tar.gz)
+* [macOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-darwin-amd64.tar.gz) or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/docs/docs/1.2.3/installation/kubernetes.md
+++ b/docs/docs/1.2.3/installation/kubernetes.md
@@ -31,11 +31,11 @@ $ curl -L https://kuma.io/installer.sh | sh -
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access Kubernetes:
 
-* [CentOS](https://download.konghq.com/mesh-alpine/kuma--centos-amd64.tar.gz)
-* [RedHat](https://download.konghq.com/mesh-alpine/kuma--rhel-amd64.tar.gz)
-* [Debian](https://download.konghq.com/mesh-alpine/kuma--debian-amd64.tar.gz)
-* [Ubuntu](https://download.konghq.com/mesh-alpine/kuma--ubuntu-amd64.tar.gz)
-* [macOS](https://download.konghq.com/mesh-alpine/kuma--darwin-amd64.tar.gz) or run `brew install kumactl`
+* [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-centos-amd64.tar.gz)
+* [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.2.3-rhel-amd64.tar.gz)
+* [Debian](https://download.konghq.com/mesh-alpine/kuma-1.2.3-debian-amd64.tar.gz)
+* [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.2.3-ubuntu-amd64.tar.gz)
+* [macOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-darwin-amd64.tar.gz) or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/docs/docs/1.2.3/installation/macos.md
+++ b/docs/docs/1.2.3/installation/macos.md
@@ -26,7 +26,7 @@ $ curl -L https://kuma.io/installer.sh | sh -
 
 You can also download the distribution manually:
 
-* [Download Kuma](https://download.konghq.com/mesh-alpine/kuma--darwin-amd64.tar.gz)
+* [Download Kuma](https://download.konghq.com/mesh-alpine/kuma-1.2.3-darwin-amd64.tar.gz)
 
 Then extract the archive with:
 

--- a/docs/docs/1.2.3/installation/openshift.md
+++ b/docs/docs/1.2.3/installation/openshift.md
@@ -26,11 +26,11 @@ $ curl -L https://kuma.io/installer.sh | sh -
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access OpenShift:
 
-* [CentOS](https://download.konghq.com/mesh-alpine/kuma--centos-amd64.tar.gz)
-* [RedHat](https://download.konghq.com/mesh-alpine/kuma--rhel-amd64.tar.gz)
-* [Debian](https://download.konghq.com/mesh-alpine/kuma--debian-amd64.tar.gz)
-* [Ubuntu](https://download.konghq.com/mesh-alpine/kuma--ubuntu-amd64.tar.gz)
-* [macOS](https://download.konghq.com/mesh-alpine/kuma--darwin-amd64.tar.gz) or `brew install kumactl`
+* [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-centos-amd64.tar.gz)
+* [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.2.3-rhel-amd64.tar.gz)
+* [Debian](https://download.konghq.com/mesh-alpine/kuma-1.2.3-debian-amd64.tar.gz)
+* [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.2.3-ubuntu-amd64.tar.gz)
+* [macOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-darwin-amd64.tar.gz) or `brew install kumactl`
 
 and extract the archive with:
 

--- a/docs/docs/1.2.3/installation/redhat.md
+++ b/docs/docs/1.2.3/installation/redhat.md
@@ -16,7 +16,7 @@ Run the following script to automatically detect the operating system and downlo
 $ curl -L https://kuma.io/installer.sh | sh -
 ```
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma--rhel-amd64.tar.gz) the distribution manually.
+or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.2.3-rhel-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/docs/docs/1.2.3/installation/ubuntu.md
+++ b/docs/docs/1.2.3/installation/ubuntu.md
@@ -16,7 +16,7 @@ Run the following script to automatically detect the operating system and downlo
 $ curl -L https://kuma.io/installer.sh | sh -
 ```
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma--ubuntu-amd64.tar.gz) the distribution manually.
+or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.2.3-ubuntu-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 


### PR DESCRIPTION
The 1.2.3 docs were cut with a missing version number from the download
URLs. This change fixes the URLs but not the underlying problem that
caused the version to be absent.

This updates #492.

Signed-off-by: James Peach <james.peach@konghq.com>