### PR TITLE
fix(http-api) /dataplane+insights contain total field

### DIFF
--- a/docs/docs/1.2.3/documentation/http-api.md
+++ b/docs/docs/1.2.3/documentation/http-api.md
@@ -989,6 +989,7 @@ curl http://localhost:5681/meshes/default/dataplanes+insights
      }
     }
   ],
+  "total": 2,
   "next": "http://localhost:5681/meshes/default/dataplanes+insights?offset=1"
 }
 ```


### PR DESCRIPTION
Noticed that we are missing one field in api docs

Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>