### PR TITLE
fix misplaced tip section that broke tabs

### DIFF
--- a/docs/docs/1.2.3/policies/traffic-trace.md
+++ b/docs/docs/1.2.3/policies/traffic-trace.md
@@ -27,6 +27,7 @@ While most commonly we want all the traces to be sent to the same tracing backen
 ::: tip
 On Kubernetes you can deploy Jaeger automatically in a `kuma-tracing` namespace with `kumactl install tracing | kubectl apply -f -`.
 :::
+
 ```yaml
 apiVersion: kuma.io/v1alpha1
 kind: Mesh


### PR DESCRIPTION
Signed-off-by: Jennifer Rondeau <jennifer.rondeau@konghq.com>

Fixes #496 

VuePress does not like tips nested inside tabs (and I checked only the K8s tab for initial PR :-( )

PTAL @jpeach 