### PR TITLE
Docs/external ratelimit matching

### DIFF
--- a/docs/.vuepress/site-config/sidebar-nav.js
+++ b/docs/.vuepress/site-config/sidebar-nav.js
@@ -1563,6 +1563,7 @@ module.exports = {
         "policies/retry",
         "policies/timeout",
         "policies/rate-limit",
+        "policies/virtual-outbound"
       ]
     },
     {

--- a/docs/docs/1.2.3/documentation/http-api.md
+++ b/docs/docs/1.2.3/documentation/http-api.md
@@ -572,11 +572,20 @@ curl http://localhost:5681/mesh-insights/default
     "partiallyDegraded": 1
    }
   },
-  "mTLSBackends": {
-    "ca-1": {
-      "total": 1,
-      "online": 1,
-      "partiallyDegraded": 1
+  "mTLS": {
+    "issuedBackends": {
+      "ca-1": {
+        "total": 1,
+        "online": 1,
+        "partiallyDegraded": 1
+      }
+    },
+    "supportedBackends": {
+      "ca-1": {
+        "total": 1,
+        "online": 1,
+        "partiallyDegraded": 1
+      }
     }
   }
  }
@@ -648,11 +657,20 @@ curl http://localhost:5681/mesh-insights
       "partiallyDegraded": 1
      }
     },
-    "mTLSBackends": {
-      "ca-1": {
-        "total": 1,
-        "online": 1,
-        "partiallyDegraded": 1
+    "mTLS": {
+      "issuedBackends": {
+        "ca-1": {
+          "total": 1,
+          "online": 1,
+          "partiallyDegraded": 1
+        }
+      },
+      "supportedBackends": {
+        "ca-1": {
+          "total": 1,
+          "online": 1,
+          "partiallyDegraded": 1
+        }
       }
     }
    }
@@ -709,11 +727,20 @@ curl http://localhost:5681/mesh-insights
       "partiallyDegraded": 1
      }
     },
-    "mTLSBackends": {
-      "ca-1": {
-        "total": 1,
-        "online": 1,
-        "partiallyDegraded": 1
+    "mTLS": {
+      "issuedBackends": {
+        "ca-1": {
+          "total": 1,
+          "online": 1,
+          "partiallyDegraded": 1
+        }
+      },
+      "supportedBackends": {
+        "ca-1": {
+          "total": 1,
+          "online": 1,
+          "partiallyDegraded": 1
+        }
       }
     }
    }
@@ -912,7 +939,8 @@ curl http://localhost:5681/meshes/default/dataplanes+insights/example
     "certificateExpirationTime": "2019-10-24T14:04:57.832482Z", 
     "lastCertificateRegeneration": "2019-10-24T12:04:57.832482Z",
     "certificateRegenerations": 3,
-    "backend": "ca-1"
+    "issuedBackend": "ca-1",
+    "supportedBackends": ["ca-1"]
   },
   "subscriptions": [
    {
@@ -990,7 +1018,8 @@ curl http://localhost:5681/meshes/default/dataplanes+insights
         "certificateExpirationTime": "2019-10-24T14:04:57.832482Z",
         "lastCertificateRegeneration": "2019-10-24T12:04:57.832482Z",
         "certificateRegenerations": 3,
-        "backend": "ca-1"
+        "issuedBackend": "ca-1",
+        "supportedBackends": ["ca-1"]
       },
       "subscriptions": [
        {

--- a/docs/docs/1.2.3/documentation/http-api.md
+++ b/docs/docs/1.2.3/documentation/http-api.md
@@ -571,6 +571,13 @@ curl http://localhost:5681/mesh-insights/default
     "online": 1,
     "partiallyDegraded": 1
    }
+  },
+  "mTLSBackends": {
+    "ca-1": {
+      "total": 1,
+      "online": 1,
+      "partiallyDegraded": 1
+    }
   }
  }
 }
@@ -640,6 +647,13 @@ curl http://localhost:5681/mesh-insights
       "online": 1,
       "partiallyDegraded": 1
      }
+    },
+    "mTLSBackends": {
+      "ca-1": {
+        "total": 1,
+        "online": 1,
+        "partiallyDegraded": 1
+      }
     }
    }
   },
@@ -694,6 +708,13 @@ curl http://localhost:5681/mesh-insights
       "online": 1,
       "partiallyDegraded": 1
      }
+    },
+    "mTLSBackends": {
+      "ca-1": {
+        "total": 1,
+        "online": 1,
+        "partiallyDegraded": 1
+      }
     }
    }
   }
@@ -887,6 +908,12 @@ curl http://localhost:5681/meshes/default/dataplanes+insights/example
   }
  },
  "dataplaneInsight": {
+  "mTLS": {
+    "certificateExpirationTime": "2019-10-24T14:04:57.832482Z", 
+    "lastCertificateRegeneration": "2019-10-24T12:04:57.832482Z",
+    "certificateRegenerations": 3,
+    "backend": "ca-1"
+  },
   "subscriptions": [
    {
     "id": "426fe0d8-f667-11e9-b081-acde48001122",
@@ -959,6 +986,12 @@ curl http://localhost:5681/meshes/default/dataplanes+insights
       }
      },
      "dataplaneInsight": {
+      "mTLS": {
+        "certificateExpirationTime": "2019-10-24T14:04:57.832482Z",
+        "lastCertificateRegeneration": "2019-10-24T12:04:57.832482Z",
+        "certificateRegenerations": 3,
+        "backend": "ca-1"
+      },
       "subscriptions": [
        {
         "id": "426fe0d8-f667-11e9-b081-acde48001122",

--- a/docs/docs/1.2.3/policies/external-services.md
+++ b/docs/docs/1.2.3/policies/external-services.md
@@ -26,6 +26,7 @@ spec:
     tls: # optional
       enabled: true
       allowRenegotiation: false
+      sni: httpbin.org # optional
       caCert: # one of inline, inlineString, secret
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t... # Base64 encoded cert
       clientCert: # one of inline, inlineString, secret
@@ -51,6 +52,7 @@ networking:
   tls:
     enabled: true
     allowRenegotiation: false
+    sni: httpbin.org # optional
     caCert: # one of inline, inlineString, secret
       inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t... # Base64 encoded cert
     clientCert: # one of inline, inlineString, secret
@@ -106,6 +108,7 @@ The first approach has an advantage that we can apply HTTP based policies, becau
         * `enabled` turns on and off the TLS origination.
         * `allowRenegotiation` turns on and off TLS renegotiation. It's not recommended enabling this for [security reasons](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/tls.proto).
           However, some servers require this setting to fetch client certificate after TLS handshake. TLS renegotiation is not available in TLS v1.3.
+        * `sni` overrides the default Server Name Indication. Set this value to empty string to disable SNI.
         * `caCert` the CA certificate for the external service TLS verification
         * `clientCert` the client certificate for mTLS
         * `clientKey` the client key for mTLS

--- a/docs/docs/1.2.3/policies/mutual-tls.md
+++ b/docs/docs/1.2.3/policies/mutual-tls.md
@@ -191,12 +191,11 @@ A few considerations:
 
 When using an arbitrary certificate and key for a `provided` backend, we must make sure that we comply with the following requirements:
 
-1. It MUST be a self-signed Root CA certificate (Intermediate CA certificates are not allowed)
-2. It MUST have basic constraint `CA` set to `true` (see [X509-SVID: 4.1. Basic Constraints](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#41-basic-constraints))
-3. It MUST have key usage extension `keyCertSign` set (see [X509-SVID: 4.3. Key Usage](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#43-key-usage))
-4. It MUST NOT have key usage extension 'digitalSignature' set (see [X509-SVID: Appendix A. X.509 Field Reference](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#appendix-a-x509-field-reference))
-5. It MUST NOT have key usage extension 'keyAgreement' set (see [X509-SVID: Appendix A. X.509 Field Reference](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#appendix-a-x509-field-reference))
-6. It MUST NOT have key usage extension 'keyEncipherment' set (see [X509-SVID: Appendix A. X.509 Field Reference](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#appendix-a-x509-field-reference))
+1. It MUST have basic constraint `CA` set to `true` (see [X509-SVID: 4.1. Basic Constraints](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#41-basic-constraints))
+2. It MUST have key usage extension `keyCertSign` set (see [X509-SVID: 4.3. Key Usage](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#43-key-usage))
+3. It MUST NOT have key usage extension 'digitalSignature' set (see [X509-SVID: Appendix A. X.509 Field Reference](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#appendix-a-x509-field-reference))
+4. It MUST NOT have key usage extension 'keyAgreement' set (see [X509-SVID: Appendix A. X.509 Field Reference](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#appendix-a-x509-field-reference))
+5. It MUST NOT have key usage extension 'keyEncipherment' set (see [X509-SVID: Appendix A. X.509 Field Reference](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#appendix-a-x509-field-reference))
 
 :::warning
 Do not use the following example in production, instead generate valid and compliant certificates. This example is intended for usage in a development environment.
@@ -283,6 +282,10 @@ mtls:
 ```
 :::
 ::::
+
+### Intermediate CA
+
+It is possible to use Intermediate CA with Provided backend. In `cert` section, put Intermediate CA first and then Root CA. Separate those certificates by an empty line. 
 
 ## Certificate Rotation
 

--- a/docs/docs/1.2.3/policies/mutual-tls.md
+++ b/docs/docs/1.2.3/policies/mutual-tls.md
@@ -193,9 +193,8 @@ When using an arbitrary certificate and key for a `provided` backend, we must ma
 
 1. It MUST have basic constraint `CA` set to `true` (see [X509-SVID: 4.1. Basic Constraints](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#41-basic-constraints))
 2. It MUST have key usage extension `keyCertSign` set (see [X509-SVID: 4.3. Key Usage](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#43-key-usage))
-3. It MUST NOT have key usage extension 'digitalSignature' set (see [X509-SVID: Appendix A. X.509 Field Reference](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#appendix-a-x509-field-reference))
-4. It MUST NOT have key usage extension 'keyAgreement' set (see [X509-SVID: Appendix A. X.509 Field Reference](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#appendix-a-x509-field-reference))
-5. It MUST NOT have key usage extension 'keyEncipherment' set (see [X509-SVID: Appendix A. X.509 Field Reference](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#appendix-a-x509-field-reference))
+3. It MUST NOT have key usage extension 'keyAgreement' set (see [X509-SVID: Appendix A. X.509 Field Reference](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#appendix-a-x509-field-reference))
+4. It SHOULD NOT set key usage extension 'digitalSignature' and 'keyEncipherment' to be SPIFFE compliant (see [X509-SVID: Appendix A. X.509 Field Reference](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#appendix-a-x509-field-reference))
 
 :::warning
 Do not use the following example in production, instead generate valid and compliant certificates. This example is intended for usage in a development environment.

--- a/docs/docs/1.2.3/policies/rate-limit.md
+++ b/docs/docs/1.2.3/policies/rate-limit.md
@@ -7,6 +7,8 @@ to allow for per-instance service request limiting. All HTTP/HTTP2 based request
 You can configure how many requests are allowed in a specified time period, and how the service responds when the limit is reached.
 
 The policy is applied per service instance. This means that if a service `backend` has 3 instances rate limited to 100 requests per second, the overall service is rate limited to 300 requests per second.
+
+When rate limiting to an [ExternalService](policies/external-services.md), the policy is applied per sending service instance.`
 ## Usage
 
 :::: tabs :options="{ useUrlFragment: false }"
@@ -147,3 +149,10 @@ The service `backend` is configured with the following rate limiting hierarchy:
  - `rate-limit-frontend-zone-eu`
  - `rate-limit-frontend`
  - `rate-limit-all-to-backend`
+
+
+## Matching destinations
+
+`RateLimit`, when applied to a dataplane proxy bound Kuma service, is an [Inbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#inbound-connection-policy).
+
+When applied to an [ExternalService](policies/external-services.md), `RateLimit` is an [Outbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#outbound-connection-policy). In this case, the only supported value for `destinations.match` is `kuma.io/service`.

--- a/docs/docs/1.2.3/policies/virtual-outbound.md
+++ b/docs/docs/1.2.3/policies/virtual-outbound.md
@@ -1,0 +1,251 @@
+# Virtual Outbound
+
+This policy lets you customize hostnames and ports for communicating with dataplanes.
+
+Possible use cases are:
+
+1) Preserving hostnames when migrating to service mesh.
+2) Providing multiple hostnames for reaching the same service, for example when renaming or for usability.
+3) Providing specific routes, for example to reach a specific pod in a service with StatefulSets on Kubernetes, or to add a URL to reach a specific version of a service.
+4) Expose multiple inbounds on different ports.
+
+Limitations:
+
+- Complex virtual outbounds do not work for cross-zone traffic. This is because only service tags are propagated across zones.
+- When duplicate `(hostname, port)` combinations are detected, the virtual outbound with the highest priority takes over. For more information, see [the documentation on ow Kuma chooses the right poliy](../../1.2.3/policies/how-kuma-chooses-the-right-policy-to-apply.md). All duplicate instances are logged.
+
+`conf.host` and `conf.port` are processed as [go text templates](https://pkg.go.dev/text/template) with a key-value pair derived from `conf.parameters`.
+
+`conf.selectors` are used to specify which dataplanes this policy applies to.
+
+For example a dataplane with this definition:
+
+```yaml
+type: Dataplane
+mesh: default
+name: backend-1
+networking:
+  address: 192.168.0.2
+inbound:
+  - port: 9000
+    servicePort: 6379
+    tags:
+      kuma.io/service: backend
+      version: v1
+      port: 1800
+```
+
+and a virtual outbound with this definition:
+
+```yaml
+type: VirtualOutbound
+mesh: default
+name: test
+selectors:
+  - match:
+      kuma.io/service: "*"
+conf:
+  host: "{{.v}}.{{.service}}.mesh"
+  port: "{{.port}}"
+  parameters:
+    - name: service
+      tagKey: "kuma.io/service"
+    - name: port
+      tagKey: port
+    - name: v
+      tagKey: version
+```
+
+produce the hostname: `v1.backend.mesh` with port: `1800`.
+
+Additional requirements:
+
+- [Transparent proxy](/docs/1.2.3/networking/transparent-proxying).
+- Either [data plane proxy DNS](/docs/1.2.3/networking/dns.md#data-plane-proxy-dns), or else the value of `conf.host` must end with the value of `dns_server.domain` (default value `.mesh`).
+- `name` must be alphanumeric. (Used as a go template key).
+- Each value of `name` must be unique.
+- `kuma.io/service` must be specified even if it's unused in the template. (Prevents defining hostnames that spans services).
+
+The default value of `tagKey` is the value of `name`.
+
+For each virtual outbound the Kuma control plane processes all dataplanes that match the selector.
+It then applies the templates for `conf.host` and `conf.port` and assigns a virtual IP address for each hostname.
+
+## Examples
+
+The following examples show how to use virtual outbounds for different use cases.
+
+### Same as the default DNS
+
+:::: tabs :options="{ useUrlFragment: false }"
+::: tab "Kubernetes"
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+type: VirtualOutbound
+mesh: default
+name: default
+selectors:
+  - match:
+      kuma.io/service: "*"
+conf:
+  host: "{{.service}}.mesh"
+  port: 80
+  parameters:
+    - name: service
+      tagKey: "kuma.io/service"
+```
+:::
+::: tab "Universal"
+```yaml
+type: VirtualOutbound
+mesh: default
+name: default
+selectors:
+  - match:
+      kuma.io/service: "*"
+conf:
+  host: "{{.service}}.mesh"
+  port: 80
+  parameters:
+    - name: service
+      tagKey: "kuma.io/service"
+```
+:::
+::::
+
+### One hostname per version
+
+:::: tabs :options="{ useUrlFragment: false }"
+::: tab "Kubernetes"
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+type: VirtualOutbound
+mesh: default
+name: default
+selectors:
+  - match:
+      kuma.io/service: "*"
+conf:
+  host: "{{.service}}.{{.version}}.mesh"
+  port: 80
+  parameters:
+    - name: service
+      tagKey: "kuma.io/service"
+    - name: version
+      tagKey: "kuma.io/version"
+```
+:::
+::: tab "Universal"
+```yaml
+type: VirtualOutbound
+mesh: default
+name: default
+selectors:
+  - match:
+      kuma.io/service: "*"
+conf:
+  host: "{{.service}}.{{.version}}.mesh"
+  port: 80
+  parameters:
+    - name: service
+      tagKey: "kuma.io/service"
+    - name: version
+      tagKey: "kuma.io/version"
+```
+:::
+::::
+
+### Custom tag to define the hostname and port
+
+:::: tabs :options="{ useUrlFragment: false }"
+::: tab "Kubernetes"
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+type: VirtualOutbound
+mesh: default
+name: default
+selectors:
+  - match:
+      kuma.io/service: "*"
+conf:
+  host: "{{.hostname}}"
+  port: "{{.port}}"
+  parameters:
+    - name: hostname
+      tagKey: "my.mesh/hostname"
+    - name: port
+      tagKey: "my.mesh/port"
+```
+:::
+::: tab "Universal"
+```yaml
+type: VirtualOutbound
+mesh: default
+name: default
+selectors:
+  - match:
+      kuma.io/service: "*"
+conf:
+  host: "{{.hostname}}"
+  port: "{{.port}}"
+  parameters:
+    - name: hostname
+      tagKey: "my.mesh/hostname"
+    - name: port
+      tagKey: "my.mesh/port"
+    - name: service
+```
+:::
+::::
+
+### One hostname per instance
+
+This enables reaching specific dataplanes in a service.
+This is especially useful for running distributed databases such as Kafka or Zookeeper.
+
+:::: tabs :options="{ useUrlFragment: false }"
+::: tab "Kubernetes"
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: VirtualOutbound
+mesh: default
+metadata:
+  name: instance
+spec:
+  selectors:
+    - match:
+        kuma.io/service: "*"
+        statefulset.kubernetes.io/pod-name: "*"
+  conf:
+    host: "{{.svc}}.{{.inst}}.mesh"
+    port: "8080"
+    parameters:
+      - name: "svc"
+        tagKey: "kuma.io/service"
+      - name: "inst"
+        tagKey: "statefulset.kubernetes.io/pod-name"
+```
+:::
+::: tab "Universal"
+```yaml
+type: VirtualOutbound
+mesh: default
+name: default
+selectors:
+  - match:
+      kuma.io/service: "*"
+      kuma.io/instance: "*"
+conf:
+  host: "inst-{{.instance}}.{{.service}}.mesh"
+  port: 80
+  parameters:
+    - name: service
+      tagKey: "kuma.io/service"
+    - name: instance
+      tagKey: "kuma.io/instance"
+```
+:::
+::::

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -50,6 +50,9 @@ policies:
       - title: Rate Limit
         url: /docs/latest/policies/rate-limit/
         icon: /images/icons/policies/icon-rate-limits.png
+      - title: Virtual Outbound
+        url: /docs/latest/policies/virtual-outbound/
+        icon: /images/icons/policies/icon-external-services.png
   - section: observability
     sectionTitle: Observability
     sectionSubTitle: Metrics, Logs and Traces


### PR DESCRIPTION
RateLimit can now be appleid to an ExternalService, but there are some caveats. RateLimit was previously an exclusively inbound policy. Now, if RateLimit is applied to an ExternalService that policy is applied on the outbound.