### PR TITLE
doc(kuma-cp) Add notes on external service rate limits

### DIFF
--- a/docs/docs/1.2.3/policies/rate-limit.md
+++ b/docs/docs/1.2.3/policies/rate-limit.md
@@ -7,6 +7,8 @@ to allow for per-instance service request limiting. All HTTP/HTTP2 based request
 You can configure how many requests are allowed in a specified time period, and how the service responds when the limit is reached.
 
 The policy is applied per service instance. This means that if a service `backend` has 3 instances rate limited to 100 requests per second, the overall service is rate limited to 300 requests per second.
+
+When rate limiting to an [ExternalService](policies/external-services.md), the policy is applied per sending service instance.`
 ## Usage
 
 :::: tabs :options="{ useUrlFragment: false }"
@@ -147,3 +149,10 @@ The service `backend` is configured with the following rate limiting hierarchy:
  - `rate-limit-frontend-zone-eu`
  - `rate-limit-frontend`
  - `rate-limit-all-to-backend`
+
+
+## Matching destinations
+
+`RateLimit`, when applied to a dataplane proxy bound Kuma service, is an [Inbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#inbound-connection-policy).
+
+When applied to an [ExternalService](policies/external-services.md), `RateLimit` is an [Outbound Connection Policy](how-kuma-chooses-the-right-policy-to-apply.md#outbound-connection-policy). In this case, the only supported value for `destinations.match` is `kuma.io/service`.


### PR DESCRIPTION
RateLimit can now be appleid to an ExternalService, but there are some caveats. RateLimit was previously an exclusively inbound policy. Now, if RateLimit is applied to an ExternalService that policy is applied on the outbound.