### PR TITLE
docs(http-api) adjust zones+insights fields

### DIFF
--- a/docs/docs/1.2.3/documentation/http-api.md
+++ b/docs/docs/1.2.3/documentation/http-api.md
@@ -2547,6 +2547,14 @@ curl http://localhost:5681/zones+insights/cluster-1
     "disconnectTime": "2020-07-28T16:08:09.743194Z",
     "status": {
      "total": {}
+    },
+    "version": {
+      "kumaCp": {
+       "version": "1.2.0-rc2-211-g823fe8ce",
+       "gitTag": "1.0.0-rc2-211-g823fe8ce",
+       "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+       "buildDate": "2021-02-18T13:22:30Z"
+     }
     }
    },
    {
@@ -2620,7 +2628,7 @@ Response: `200 OK` with Zone entities including insight
 
 Example:
 ```bash
-curl http://localhost:5681/zones
+curl http://localhost:5681/zones+insights
 ```
 ```json
 {
@@ -2646,6 +2654,14 @@ curl http://localhost:5681/zones
       "disconnectTime": "2020-07-28T16:08:09.743194Z",
       "status": {
        "total": {}
+      },
+      "version": {
+       "kumaCp": {
+         "version": "1.2.0-rc2-211-g823fe8ce",
+         "gitTag": "1.0.0-rc2-211-g823fe8ce",
+         "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+         "buildDate": "2021-02-18T13:22:30Z"
+        }
       }
      },
      {
@@ -2704,6 +2720,14 @@ curl http://localhost:5681/zones
          "responsesAcknowledged": "1"
         }
        }
+      },
+      "version": {
+       "kumaCp": {
+         "version": "1.2.0-rc2-211-g823fe8ce",
+         "gitTag": "1.0.0-rc2-211-g823fe8ce",
+         "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+         "buildDate": "2021-02-18T13:22:30Z"
+        }
       }
      }
     ]


### PR DESCRIPTION
We were missing `version` field in `zones+insights` docs.
Also adjusted curl URL to be the correct one.

Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>