### PR TITLE
docs(kuma-cp) Install instructions missing versions

### DIFF
--- a/docs/docs/1.2.3/installation/docker.md
+++ b/docs/docs/1.2.3/installation/docker.md
@@ -120,7 +120,7 @@ and extract the archive with:
 $ tar xvzf kuma-*.tar.gz
 ```
 
-You will then find the `kumactl` executable in the `kuma-/bin` folder.
+You will then find the `kumactl` executable in the `kuma-1.2.3/bin` folder.
 
 :::
 ::::

--- a/docs/docs/1.3.0/installation/amazonlinux.md
+++ b/docs/docs/1.3.0/installation/amazonlinux.md
@@ -31,12 +31,12 @@ $ tar xvzf kuma-*.tar.gz
 
 ### 2. Run Kuma
 
-Once downloaded, you will find the contents of Kuma in the `kuma-` folder. In this folder, you will find - among other files - the `bin` directory that stores all the executables for Kuma. 
+Once downloaded, you will find the contents of Kuma in the `kuma-1.3.0` folder. In this folder, you will find - among other files - the `bin` directory that stores all the executables for Kuma. 
 
 So we enter the `bin` folder by executing:
 
 ```sh
-$ cd kuma-/bin
+$ cd kuma-1.3.0/bin
 ```
 
 Finally we can run Kuma in either **standalone** or **multi-zone** mode:

--- a/docs/docs/1.3.0/installation/centos.md
+++ b/docs/docs/1.3.0/installation/centos.md
@@ -26,12 +26,12 @@ $ tar xvzf kuma-*.tar.gz
 
 ### 2. Run Kuma
 
-Once downloaded, you will find the contents of Kuma in the `kuma-` folder. In this folder, you will find - among other files - the `bin` directory that stores all the executables for Kuma. 
+Once downloaded, you will find the contents of Kuma in the `kuma-1.3.0` folder. In this folder, you will find - among other files - the `bin` directory that stores all the executables for Kuma. 
 
 So we enter the `bin` folder by executing:
 
 ```sh
-$ cd kuma-/bin
+$ cd kuma-1.3.0/bin
 ```
 
 Finally we can run Kuma in either **standalone** or **multi-zone** mode:

--- a/docs/docs/1.3.0/installation/debian.md
+++ b/docs/docs/1.3.0/installation/debian.md
@@ -26,12 +26,12 @@ $ tar xvzf kuma-*.tar.gz
 
 ### 2. Run Kuma
 
-Once downloaded, you will find the contents of Kuma in the `kuma-` folder. In this folder, you will find - among other files - the `bin` directory that stores all the executables for Kuma. 
+Once downloaded, you will find the contents of Kuma in the `kuma-1.3.0` folder. In this folder, you will find - among other files - the `bin` directory that stores all the executables for Kuma. 
 
 So we enter the `bin` folder by executing:
 
 ```sh
-$ cd kuma-/bin
+$ cd kuma-1.3.0/bin
 ```
 
 Finally we can run Kuma in either **standalone** or **multi-zone** mode:

--- a/docs/docs/1.3.0/installation/docker.md
+++ b/docs/docs/1.3.0/installation/docker.md
@@ -120,7 +120,7 @@ and extract the archive with:
 $ tar xvzf kuma-*.tar.gz
 ```
 
-You will then find the `kumactl` executable in the `kuma-/bin` folder.
+You will then find the `kumactl` executable in the `kuma-1.3.0/bin` folder.
 
 :::
 ::::

--- a/docs/docs/1.3.0/installation/eks.md
+++ b/docs/docs/1.3.0/installation/eks.md
@@ -48,7 +48,7 @@ $ tar xvzf kuma-*.tar.gz
 
 ### 2. Run Kuma
 
-Once downloaded, you will find the contents of Kuma in the `kuma-` folder. In this folder, you will find - among other files - the `bin` directory that stores the executables for Kuma, including the CLI client [`kumactl`](/docs/1.3.0/documentation/cli/#kumactl).
+Once downloaded, you will find the contents of Kuma in the `kuma-1.3.0` folder. In this folder, you will find - among other files - the `bin` directory that stores the executables for Kuma, including the CLI client [`kumactl`](/docs/1.3.0/documentation/cli/#kumactl).
 
 ::: tip
 **Note**: On Kubernetes - of all the Kuma binaries in the `bin` folder - we only need `kumactl`.
@@ -57,7 +57,7 @@ Once downloaded, you will find the contents of Kuma in the `kuma-` folder. In th
 So we enter the `bin` folder by executing:
 
 ```sh
-$ cd kuma-/bin
+$ cd kuma-1.3.0/bin
 ```
 
 Finally we can install and run Kuma in either **standalone** or **multi-zone** mode:

--- a/docs/docs/1.3.0/installation/kubernetes.md
+++ b/docs/docs/1.3.0/installation/kubernetes.md
@@ -48,7 +48,7 @@ $ tar xvzf kuma-*.tar.gz
 
 ### 2. Run Kuma
 
-Once downloaded, you will find the contents of Kuma in the `kuma-` folder. In this folder, you will find - among other files - the `bin` directory that stores the executables for Kuma, including the CLI client [`kumactl`](/docs/1.3.0/documentation/cli/#kumactl).
+Once downloaded, you will find the contents of Kuma in the `kuma-1.3.0` folder. In this folder, you will find - among other files - the `bin` directory that stores the executables for Kuma, including the CLI client [`kumactl`](/docs/1.3.0/documentation/cli/#kumactl).
 
 ::: tip
 **Note**: On Kubernetes - of all the Kuma binaries in the `bin` folder - we only need `kumactl`.
@@ -57,7 +57,7 @@ Once downloaded, you will find the contents of Kuma in the `kuma-` folder. In th
 So we enter the `bin` folder by executing:
 
 ```sh
-$ cd kuma-/bin
+$ cd kuma-1.3.0/bin
 ```
 
 Finally we can install and run Kuma in either **standalone** or **multi-zone** mode:

--- a/docs/docs/1.3.0/installation/macos.md
+++ b/docs/docs/1.3.0/installation/macos.md
@@ -48,12 +48,12 @@ $ brew install kumactl
 
 ### 2. Run Kuma
 
-Once downloaded, you will find the contents of Kuma in the `kuma-` folder. In this folder, you will find - among other files - the `bin` directory that stores all the executables for Kuma. 
+Once downloaded, you will find the contents of Kuma in the `kuma-1.3.0` folder. In this folder, you will find - among other files - the `bin` directory that stores all the executables for Kuma. 
 
 So we enter the `bin` folder by executing:
 
 ```sh
-$ cd kuma-/bin
+$ cd kuma-1.3.0/bin
 ```
 
 Finally we can run Kuma in either **standalone** or **multi-zone** mode:

--- a/docs/docs/1.3.0/installation/openshift.md
+++ b/docs/docs/1.3.0/installation/openshift.md
@@ -43,7 +43,7 @@ $ tar xvzf kuma-*.tar.gz
 
 ### 2. Run Kuma
 
-Once downloaded, you will find the contents of Kuma in the `kuma-` folder. In this folder, you will find - among other files - the `bin` directory that stores the executables for Kuma, including the CLI client [`kumactl`](/docs/1.3.0/documentation/cli/#kumactl).
+Once downloaded, you will find the contents of Kuma in the `kuma-1.3.0` folder. In this folder, you will find - among other files - the `bin` directory that stores the executables for Kuma, including the CLI client [`kumactl`](/docs/1.3.0/documentation/cli/#kumactl).
 
 ::: tip
 **Note**: On OpenShift - of all the Kuma binaries in the `bin` folder - we only need `kumactl`.
@@ -52,7 +52,7 @@ Once downloaded, you will find the contents of Kuma in the `kuma-` folder. In th
 So we enter the `bin` folder by executing:
 
 ```sh
-$ cd kuma-/bin
+$ cd kuma-1.3.0/bin
 ```
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:

--- a/docs/docs/1.3.0/installation/redhat.md
+++ b/docs/docs/1.3.0/installation/redhat.md
@@ -26,12 +26,12 @@ $ tar xvzf kuma-*.tar.gz
 
 ### 2. Run Kuma
 
-Once downloaded, you will find the contents of Kuma in the `kuma-` folder. In this folder, you will find - among other files - the `bin` directory that stores all the executables for Kuma. 
+Once downloaded, you will find the contents of Kuma in the `kuma-1.3.0` folder. In this folder, you will find - among other files - the `bin` directory that stores all the executables for Kuma. 
 
 So we enter the `bin` folder by executing:
 
 ```sh
-$ cd kuma-/bin
+$ cd kuma-1.3.0/bin
 ```
 
 Finally we can run Kuma in either **standalone** or **multi-zone** mode:

--- a/docs/docs/1.3.0/installation/ubuntu.md
+++ b/docs/docs/1.3.0/installation/ubuntu.md
@@ -26,12 +26,12 @@ $ tar xvzf kuma-*.tar.gz
 
 ### 2. Run Kuma
 
-Once downloaded, you will find the contents of Kuma in the `kuma-` folder. In this folder, you will find - among other files - the `bin` directory that stores all the executables for Kuma. 
+Once downloaded, you will find the contents of Kuma in the `kuma-1.3.0` folder. In this folder, you will find - among other files - the `bin` directory that stores all the executables for Kuma. 
 
 So we enter the `bin` folder by executing:
 
 ```sh
-$ cd kuma-/bin
+$ cd kuma-1.3.0/bin
 ```
 
 Finally we can run Kuma in either **standalone** or **multi-zone** mode:


### PR DESCRIPTION
Looks like we forgot to replace version number in a bunch of install docs for 1.3.0, as well as docker install in 1.2.3.

Signed-off-by: Paul Parkanzky <paul.parkanzky@konghq.com>