### PR TITLE
docs(*) add windows deployments docs

### DIFF
--- a/docs/.vuepress/public/installer.ps1
+++ b/docs/.vuepress/public/installer.ps1
@@ -1,0 +1,50 @@
+# Copyright 2021 Kuma authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+$Arch             = If ($Arch) {$Arch} Else {"amd64"}
+$ProductName      = If ($ProductName) {$ProductName} Else {"Kuma"}
+$LatestVersionUrl = If ($LatestVersionUrl) {$LatestVersionUrl} Else {"https://kuma.io/latest_version"}
+$Version          = If ($Version) {$Version} Else {(Invoke-WebRequest -Uri $LatestVersionUrl).Content}
+$RepoPrefix       = If ($RepoPrefix) {$RepoPrefix} Else {"kuma"}
+$Distro           = If ($Distro) {$Distro} Else {"windows"}
+$ArchiveName      = "$RepoPrefix-$Version-$Distro-$Arch.tar.gz"
+$Pwd              = (Get-Item .).FullName
+$Url              = "https://download.konghq.com/mesh-alpine/$ArchiveName"
+$ArchivePath      = "${Pwd}\$ArchiveName"
+$UnarchivePath    = "${Pwd}\$RepoPrefix-$Version"
+
+Write-Host ""
+Write-Host "Welcome to the $ProductName automated download!"
+
+([PSCustomObject]@{
+    "$ProductName Version" = $Version
+    "Architecture"         = $Arch
+    "Operating System"     = $Distro
+    "Downloading From"     = $Url
+    "Downloading To"       = $ArchivePath
+} | Format-List | Out-String).Trim()
+
+Write-Host ""
+Write-Host "Downloading $Url"
+
+Try {
+    Invoke-WebRequest -Uri $Url -OutFile $ArchivePath
+    tar xzf $ArchivePath
+    Write-Host "$ProductName $Version has been downloaded`r`n"
+    Get-Content -Path "${UnarchivePath}\README" -Encoding utf8
+    Write-Host ""
+} Catch {
+    Write-Error "Unable to download $ProductName $Version from ${Url}: $_.Exception.Message"
+    Return
+}

--- a/docs/.vuepress/site-config/sidebar-nav.js
+++ b/docs/.vuepress/site-config/sidebar-nav.js
@@ -1742,6 +1742,7 @@ module.exports = {
         "installation/debian",
         "installation/ubuntu",
         "installation/macos",
+        "installation/windows",
       ]
     },
     {

--- a/docs/.vuepress/theme/styles/vuepress-core/code.scss
+++ b/docs/.vuepress/theme/styles/vuepress-core/code.scss
@@ -170,10 +170,15 @@ div[class~='language-python']:before {
   content: 'py';
 }
 
-div[class~='language-bash']:before {
+div[class~='language-bash']:before,
+div[class~='language-shell']:before {
   content: 'sh';
 }
 
 div[class~='language-php']:before {
   content: 'php';
+}
+
+div[class~='language-powershell']:before {
+  content: 'PowerShell';
 }

--- a/docs/docs/4.4.4/installation/windows.md
+++ b/docs/docs/4.4.4/installation/windows.md
@@ -1,0 +1,138 @@
+# Windows
+
+To install and run Kuma on Windows execute the following steps:
+
+* [1. Download Kuma](#_1-download-kuma)
+* [2. Run Kuma](#_2-run-kuma)
+* [3. Use Kuma](#_3-use-kuma)
+
+Finally, you can follow the [Quickstart](#_4-quickstart) to take it from here and continue your Kuma journey.
+
+### 1. Download Kuma
+
+To run Kuma on Windows you can choose among different installation methods:
+
+:::: tabs :options="{ useUrlFragment: false }"
+::: tab "Powershell Script"
+
+Run in Powershell the following script to automatically detect the operating system and download Kuma:
+
+```powershell
+Invoke-Expression (Invoke-WebRequest -Uri https://kuma.io/installer.ps1).Content
+```
+
+:::
+::: tab "Direct Link"
+
+You can also download the distribution manually:
+
+* [Download Kuma](https://download.konghq.com/mesh-alpine/kuma-1.3.0-windows-amd64.tar.gz)
+
+Then extract the archive with:
+
+```powershell
+tar xzvf kuma-1.3.0-windows-amd64.tar.gz
+```
+::::
+
+### 2. Run Kuma
+
+Once downloaded, you will find the contents of Kuma in the `kuma-1.3.0` folder. In this folder, you will find - among other files - the `bin` directory that stores all the executables for Kuma.
+
+So we enter the `bin` folder by executing:
+
+```powershell
+cd kuma-1.3.0\bin
+```
+
+Finally, we can run Kuma in either **standalone** or **multi-zone** mode:
+
+:::: tabs :options="{ useUrlFragment: false }"
+::: tab "Standalone"
+
+Standalone mode is perfect when running Kuma in a single cluster across one environment (Powershell):
+
+```powershell
+& .\kuma-cp run
+```
+
+To learn more, read about the [deployment modes available](/docs/1.3.0/documentation/deployments/).
+
+:::
+::: tab "Multi-Zone"
+
+Multi-zone mode is perfect when running one deployment of Kuma that spans across multiple Kubernetes clusters, clouds and VM environments under the same Kuma deployment.
+
+This mode also supports hybrid Kubernetes + VMs deployments.
+
+To learn more, read the [multi-zone installation instructions](/docs/1.3.0/documentation/deployments/).
+
+:::
+::::
+
+We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory (Powershell as Administrator):
+
+```powershell
+New-Item -ItemType SymbolicLink -Path C:\Windows\kumactl.exe -Target .\kumactl.exe
+```
+
+::: tip
+**Note**: By default this will run Kuma with a `memory` [backend](../../documentation/backends), but you can use a persistent storage like PostgreSQL by updating the `conf\kuma-cp.conf` file.
+:::
+
+### 3. Use Kuma
+
+Kuma (`kuma-cp`) is now running! Now that Kuma has been installed you can access the control-plane via either the GUI, the HTTP API, or the CLI:
+
+:::: tabs :options="{ useUrlFragment: false }"
+::: tab "GUI (Read-Only)"
+
+Kuma ships with a **read-only** GUI that you can use to retrieve Kuma resources. By default the GUI listens on the API port and defaults to `:5681/gui`.
+
+To access Kuma you can navigate to [`127.0.0.1:5681/gui`](http://127.0.0.1:5681/gui) to see the GUI.
+
+:::
+::: tab "HTTP API (Read & Write)"
+
+Kuma ships with a **read and write** HTTP API that you can use to perform operations on Kuma resources. By default, the HTTP API listens on port `5681`.
+
+To access Kuma you can navigate to [`127.0.0.1:5681`](http://127.0.0.1:5681) to see the HTTP API.
+
+:::
+::: tab "kumactl (Read & Write)"
+
+You can use the `kumactl` CLI to perform **read and write** operations on Kuma resources. The `kumactl` binary is a client to the Kuma HTTP API. For example:
+
+```powershell
+kumactl get meshes
+# NAME          mTLS      METRICS      LOGGING   TRACING
+# default       off       off          off       off
+```
+
+or you can enable mTLS on the `default` Mesh with:
+
+```powershell
+echo "type: Mesh
+name: default
+mtls:
+  enabledBackend: ca-1
+  backends:
+  - name: ca-1
+    type: builtin" | kumactl apply -f -
+```
+
+You can configure `kumactl` to point to any zone `kuma-cp` instance by running:
+
+```powershell
+kumactl config control-planes add --name=XYZ --address=http://{address-to-kuma}:5681
+```
+:::
+::::
+
+You will notice that Kuma automatically creates a [`Mesh`](../../policies/mesh) entity with name `default`.
+
+### 4. Quickstart
+
+Congratulations! You have successfully installed Kuma on Windows 🚀.
+
+In order to start using Kuma, it's time to check out the [quickstart guide for Universal](/docs/1.3.0/quickstart/universal/) deployments.

--- a/docs/docs/4.4.4/networking/dns.md
+++ b/docs/docs/4.4.4/networking/dns.md
@@ -2,6 +2,18 @@
 
 As of Kuma version 1.2.0, DNS on the data plane proxy is enabled by default on Kubernetes. You can also continue to deploy with [DNS on the control plane](#control-plane-dns).
 
+::: warning
+**Warning**: Dataplane proxy DNS server is currently not supported for **Windows** deployments, which means you have to manually disable it when starting `kuma-dp` process
+
+```powershell
+& kuma-dp run `
+      --cp-address=[...] `
+      --dataplane-file=[...] `
+      --dataplane-token-file=[...] `
+      --dns-enabled=false
+```
+:::
+
 ## Data plane proxy DNS
 
 In this mode, all name lookups are handled locally by the data plane proxy. This approach allows for more robust handling of name resolution.

--- a/docs/docs/4.4.4/networking/transparent-proxying.md
+++ b/docs/docs/4.4.4/networking/transparent-proxying.md
@@ -1,6 +1,10 @@
 # Transparent Proxying
 
-In order to interecept traffic from and to a service through a `kuma-dp` data plane proxy instance, Kuma utilizes a variety of patterns.
+::: warning
+**Warning**: Transparent Proxying is currently not supported for **Windows** deployments
+:::
+
+In order to intercept traffic from and to a service through a `kuma-dp` data plane proxy instance, Kuma utilizes a variety of patterns.
 
 * On **Kubernetes** `kuma-dp` leverages transparent proxying automatically via `iptables` or CNI, for all incoming and outgoing traffic that is automatically intercepted by `kuma-dp` without having to change the application code.
 * On **Universal** `kuma-dp` leverages the [data plane proxy specification](/docs/1.3.0/documentation/dps-and-data-model/) associated to it for receiving incoming requests on a pre-defined port, while it can leverage both transparent proxying and explicit `outbound` entries in the same data plane proxy specification for all outgoing traffic.
@@ -13,7 +17,7 @@ There are several advantages for using transparent proxying in universal mode:
 
 ### Preparing the Kuma Control plane
 
-The Kuma control plane exposes a DNS service which handles the name resolution in the `.mesh` DNS zone. By default it listens on port `UDP/5653`. For this setup we need it to listen on port `UDP/53`, therefore make sure that this environment variable is set before running `kuma-cp`: `KUMA_DNS_SERVER_PORT=53`.
+The Kuma control plane exposes a DNS service which handles the name resolution in the `.mesh` DNS zone. By default, it listens on port `UDP/5653`. For this setup we need it to listen on port `UDP/53`, therefore make sure that this environment variable is set before running `kuma-cp`: `KUMA_DNS_SERVER_PORT=53`.
 
 :::tip
 The IP address of the host that runs Kuma Control plane will be used in the next section. Make sure to have it once, `kuma-cp` is started.
@@ -27,7 +31,7 @@ The host that will run the `kuma-dp` process in transparent proxying mode needs 
  2. Redirect all the relevant inbound and outbound traffic to the Kuma data plane proxy.
  3. Point the DNS resolving for `.mesh` to the `kuma-cp` embedded DNS server.
 
-Kuma comes with [`kumactl` executable](/docs/1.3.0/documentation/cli/#kumactl) which can help us preparing the host. Due to the wide variety of Linux setup options, these steps may vary and may need to be adjusted for the specifics of the particular deployment. However, the common steps would be to execute the following commands as `root`:
+Kuma comes with [`kumactl` executable](/docs/1.3.0/documentation/cli/#kumactl) which can help us to prepare the host. Due to the wide variety of Linux setup options, these steps may vary and may need to be adjusted for the specifics of the particular deployment. However, the common steps would be to execute the following commands as `root`:
 
 ```sh
 # create a dedicated user called kuma-dp-user
@@ -42,7 +46,7 @@ $ kumactl install transparent-proxy \
 Where `kuma-dp-user` is the name of the dedicated user that will be used to run the `kuma-dp` process and `<kuma-cp IP>` is the IP address of the Kuma control plane (`kuma-cp`). 
 
 :::warning
-Please note that this command **will change** both the host `iptables` rules as well as modify `/etc/resolv.conf`, while keeping a backup copy of the original file.
+Please note that this command **will change** both the host `iptables` rules and modify `/etc/resolv.conf`, while keeping a backup copy of the original file.
 :::
 
 The command has several other options which allow to change the default inbound and outbound redirect ports, add ports for exclusion and also disable the iptables or `resolve.conf` modification steps. The command's help has enumerated and documented the available options.


### PR DESCRIPTION
- also modified scss file to add PowerShell subtitle to code
  blocks annotated with `powershell`
- as some of shell code block were annotated with `sh` and some
  with `shell` types, and `sh` subtitle was present only for
  `bash` and `sh` blocks, I modified scss to also add `sh` subtitle
  for `shell` blocks
- added warnings for dns and transparent-proxying sections,
  mentioning that transparent proxying and dataplane proxy dns
  servers are not supported for windows deployments
- wrote installer.ps1 powershell script which can be used to
  automatically download and unpack the kuma archives on windows
- fixed few typos and added few styling changes