### PR TITLE
(feat) adjust sidebar

### DIFF
--- a/docs/.vuepress/theme/components/SidebarGroup.vue
+++ b/docs/.vuepress/theme/components/SidebarGroup.vue
@@ -27,11 +27,12 @@
       </span>
     </router-link>
 
-    <p
+    <button
       v-else
       class="sidebar-heading"
       :class="{ open }"
       @click="$emit('toggle')"
+      :aria-expanded="open"
     >
       <span>{{ item.title }}</span>
       <span
@@ -39,7 +40,7 @@
         v-if="collapsable"
         :class="open ? 'down' : 'right'">
       </span>
-    </p>
+    </button>
 
     <DropdownTransition>
       <SidebarLinks

--- a/docs/.vuepress/theme/styles/vuepress-core/sidebar-group.scss
+++ b/docs/.vuepress/theme/styles/vuepress-core/sidebar-group.scss
@@ -35,25 +35,36 @@
 }
 
 .sidebar-heading {
-  color: $textColor;
+  background-color: transparent;
+  box-shadow: none;
+  color: $textColor !important;
   transition: color 0.15s ease;
   cursor: pointer;
   font-size: 1.1em;
   font-weight: bold;
+  text-align: left;
 
+  border-radius: 0;
   padding: 0.35rem 1.5rem 0.35rem 1.25rem;
   width: 100%;
+  height: auto;
+  line-height: 1.7;
   box-sizing: border-box;
   margin: 0;
   border-left: 0.25rem solid transparent;
-  &.open, &:hover {
-    color: inherit;
+
+  &.open, &:hover, &:active, &:focus {
+    color: inherit !important;
+    background-color: transparent;
+    box-shadow: none;
   }
+
   .arrow {
     position: relative;
     top: -0.12em;
     left: 0.5em;
   }
+  
   &.clickable {
     &.active {
       font-weight: 600;


### PR DESCRIPTION
### Summary

Previously we had the wrong semantic element in the sidebar for link and because of that we weren't able to click on the item using only the keyboard.

![Untitled](https://user-images.githubusercontent.com/16152347/137487832-65ae234f-3dfb-4d1f-8ef4-d18b2479ddc4.png)



Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>