### PR TITLE
feat(installer.sh) improve output when distribution isn't supported on Linux

### DIFF
--- a/docs/.vuepress/public/installer.sh
+++ b/docs/.vuepress/public/installer.sh
@@ -91,7 +91,7 @@ URL="https://download.konghq.com/mesh-alpine/$REPO_PREFIX-$VERSION-$DISTRO-$ARCH
 
 if ! curl -s --head "$URL" | head -n 1 | grep -E 'HTTP/1.1 [23]..|HTTP/2 [23]..' > /dev/null; then
   if [ "$OS" = "Linux" ]; then
-      printf "WARNING\tYou may be using an unsupported distribution!\n"
+      printf "WARNING\tYou appear to be running an unsupported Linux distribution.\n"
   fi
   printf "ERROR\tUnable to download $PRODUCT_NAME at the following URL: %s\n" "$URL"
   exit 1


### PR DESCRIPTION
As a small improvement to make the ERROR less confusing, until we can just install a statically linked `kumactl` in these cases.