### PR TITLE
docs(*) update api reference for aggregate stats

### DIFF
--- a/docs/docs/4.4.4/documentation/http-api.md
+++ b/docs/docs/4.4.4/documentation/http-api.md
@@ -583,23 +583,28 @@ curl http://localhost:5681/mesh-insights/default
     "online": 1,
     "partiallyDegraded": 1
    }
-  },
-  "mTLS": {
-    "issuedBackends": {
-      "ca-1": {
-        "total": 1,
-        "online": 1,
-        "partiallyDegraded": 1
-      }
-    },
-    "supportedBackends": {
-      "ca-1": {
-        "total": 1,
-        "online": 1,
-        "partiallyDegraded": 1
-      }
-    }
   }
+ },
+ "mTLS": {
+   "issuedBackends": {
+     "ca-1": {
+       "total": 1,
+       "online": 1,
+       "partiallyDegraded": 1
+     }
+   },
+   "supportedBackends": {
+     "ca-1": {
+       "total": 1,
+       "online": 1,
+       "partiallyDegraded": 1
+     }
+   }
+ },
+ "services": {
+  "total": 3,
+  "internal": 2,
+  "external": 1
  }
 }
 ```
@@ -680,23 +685,28 @@ curl http://localhost:5681/mesh-insights
       "online": 1,
       "partiallyDegraded": 1
      }
-    },
-    "mTLS": {
-      "issuedBackends": {
-        "ca-1": {
-          "total": 1,
-          "online": 1,
-          "partiallyDegraded": 1
-        }
-      },
-      "supportedBackends": {
-        "ca-1": {
-          "total": 1,
-          "online": 1,
-          "partiallyDegraded": 1
-        }
-      }
     }
+   },
+   "mTLS": {
+     "issuedBackends": {
+       "ca-1": {
+         "total": 1,
+         "online": 1,
+         "partiallyDegraded": 1
+       }
+     },
+     "supportedBackends": {
+       "ca-1": {
+         "total": 1,
+         "online": 1,
+         "partiallyDegraded": 1
+       }
+     }
+   }, 
+   "services": {
+    "total": 3,
+    "internal": 2,
+    "external": 1
    }
   },
   {
@@ -762,23 +772,28 @@ curl http://localhost:5681/mesh-insights
       "online": 1,
       "partiallyDegraded": 1
      }
-    },
-    "mTLS": {
-      "issuedBackends": {
-        "ca-1": {
-          "total": 1,
-          "online": 1,
-          "partiallyDegraded": 1
-        }
-      },
-      "supportedBackends": {
-        "ca-1": {
-          "total": 1,
-          "online": 1,
-          "partiallyDegraded": 1
-        }
-      }
     }
+   },
+   "mTLS": {
+     "issuedBackends": {
+       "ca-1": {
+         "total": 1,
+         "online": 1,
+         "partiallyDegraded": 1
+       }
+     },
+     "supportedBackends": {
+       "ca-1": {
+         "total": 1,
+         "online": 1,
+         "partiallyDegraded": 1
+       }
+     }
+   },
+   "services": {
+    "total": 3,
+    "internal": 2,
+    "external": 1
    }
   }
  ],

--- a/docs/docs/4.4.4/documentation/http-api.md
+++ b/docs/docs/4.4.4/documentation/http-api.md
@@ -527,9 +527,21 @@ curl http://localhost:5681/mesh-insights/default
  "modificationTime": "2020-11-17T19:21:39.912878Z",
  "lastSync": "2020-11-17T12:21:39.912877Z",
  "dataplanes": {
-  "total": 1,
-  "offline": 1,
-  "partiallyDegraded": 1
+  "total": 4,
+  "offline": 2,
+  "partiallyDegraded": 2
+ },
+ "dataplanesByType": {
+  "standard": {
+   "total": 2,
+   "offline": 1,
+   "partiallyDegraded": 1
+  },
+  "gateway": {
+   "total": 2,
+   "offline": 1,
+   "partiallyDegraded": 1
+  }
  },
  "policies": {
   "Secret": {
@@ -612,9 +624,21 @@ curl http://localhost:5681/mesh-insights
    "modificationTime": "0001-01-01T00:00:00Z",
    "lastSync": "2020-11-17T12:24:11.905350Z",
    "dataplanes": {
-    "total": 1,
-    "offline": 1,
-    "partiallyDegraded": 1
+    "total": 4,
+    "offline": 2,
+    "partiallyDegraded": 2
+   },
+   "dataplanesByType": {
+    "standard": {
+     "total": 2,
+     "offline": 1,
+     "partiallyDegraded": 1
+    },
+    "gateway": {
+     "total": 2,
+     "offline": 1,
+     "partiallyDegraded": 1
+    }
    },
    "policies": {
     "Secret": {
@@ -682,9 +706,21 @@ curl http://localhost:5681/mesh-insights
    "modificationTime": "0001-01-01T00:00:00Z",
    "lastSync": "2020-11-17T12:24:11.941534Z",
    "dataplanes": {
-    "total": 1,
-    "offline": 1,
-    "partiallyDegraded": 1
+    "total": 4,
+    "offline": 2,
+    "partiallyDegraded": 2
+   },
+   "dataplanesByType": {
+    "standard": {
+     "total": 2,
+     "offline": 1,
+     "partiallyDegraded": 1
+    },
+    "gateway": {
+     "total": 2,
+     "offline": 1,
+     "partiallyDegraded": 1
+    }
    },
    "policies": {
     "Secret": {

--- a/docs/docs/4.4.4/other/compatibility.md
+++ b/docs/docs/4.4.4/other/compatibility.md
@@ -1,6 +1,6 @@
 # Compatibility
 
 We list here the minimum versions of dependencies that Kuma can have.
-Lower versions might work but we do not test against them.
+Lower versions might work, but we do not test against them.
 
-- Kubernetes >= 1.16
+- Kubernetes >= 1.17


### PR DESCRIPTION
As MeshInsights will contain `dataplanesByTypes` field which will
contain aggregated by type statistics for dataplanes

Also updated supported version of Kubernetes as we are now
supporting k8s 1.17+

Signed-off-by: Bart Smykla <bartek@smykla.com>