### PR TITLE
Add Helm chart version to install instructions

### DIFF
--- a/docs/docs/1.1.0/deployments/multi-zone.md
+++ b/docs/docs/1.1.0/deployments/multi-zone.md
@@ -73,7 +73,7 @@ In this example it is `35.226.196.103:5685`. This will be used as `<global-kds-a
 Install the `global` control plane by setting the `controlPlane.mode` value to `global` when installing the chart. This can be done on the command line, or in a provided file:
 
 ```sh
-helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+helm install --version 0.5.0 kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
 ```
 :::
 ::: tab "Universal"
@@ -112,7 +112,7 @@ To install the Remote Control plane we need to provide the following parameters:
  * `controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>`:
 
 ```bash
-helm install kuma --namespace kuma-system --set controlPlane.mode=remote,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
+helm install --version 0.5.0 kuma --namespace kuma-system --set controlPlane.mode=remote,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
 kumactl install dns | kubectl apply -f -
 ```
 

--- a/docs/docs/1.1.0/installation/helm.md
+++ b/docs/docs/1.1.0/installation/helm.md
@@ -28,7 +28,7 @@ At this point we can install and run Kuma using the following commands. We could
 
 ```sh
 kubectl create namespace kuma-system
-helm install --namespace kuma-system kuma kuma/kuma
+helm install --version 0.5.0 --namespace kuma-system kuma kuma/kuma
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/1.1.0/documentation/deployments/) like "multi-zone".

--- a/docs/docs/1.1.0/networking/cni.md
+++ b/docs/docs/1.1.0/networking/cni.md
@@ -31,7 +31,7 @@ kumactl install control-plane \
 When using [Helm](/docs/1.1.0/installation/helm), we should use the values in the `cni` section to set the relevant parameters.
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.5.0 --namespace kuma-system \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.1.1/deployments/multi-zone.md
+++ b/docs/docs/1.1.1/deployments/multi-zone.md
@@ -73,7 +73,7 @@ In this example it is `35.226.196.103:5685`. This will be used as `<global-kds-a
 Install the `global` control plane by setting the `controlPlane.mode` value to `global` when installing the chart. This can be done on the command line, or in a provided file:
 
 ```sh
-helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+helm install --version 0.5.1 kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
 ```
 :::
 ::: tab "Universal"
@@ -112,7 +112,7 @@ To install the Remote Control plane we need to provide the following parameters:
  * `controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>`:
 
 ```bash
-helm install kuma --namespace kuma-system --set controlPlane.mode=remote,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
+helm install --version 0.5.1 kuma --namespace kuma-system --set controlPlane.mode=remote,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
 kumactl install dns | kubectl apply -f -
 ```
 

--- a/docs/docs/1.1.1/installation/helm.md
+++ b/docs/docs/1.1.1/installation/helm.md
@@ -28,7 +28,7 @@ At this point we can install and run Kuma using the following commands. We could
 
 ```sh
 kubectl create namespace kuma-system
-helm install --namespace kuma-system kuma kuma/kuma
+helm install --version 0.5.1 --namespace kuma-system kuma kuma/kuma
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/1.1.1/documentation/deployments/) like "multi-zone".

--- a/docs/docs/1.1.1/networking/cni.md
+++ b/docs/docs/1.1.1/networking/cni.md
@@ -31,7 +31,7 @@ kumactl install control-plane \
 When using [Helm](/docs/1.1.1/installation/helm), we should use the values in the `cni` section to set the relevant parameters.
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.5.1 --namespace kuma-system \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.1.2/deployments/multi-zone.md
+++ b/docs/docs/1.1.2/deployments/multi-zone.md
@@ -73,7 +73,7 @@ In this example it is `35.226.196.103:5685`. This will be used as `<global-kds-a
 Install the `global` control plane by setting the `controlPlane.mode` value to `global` when installing the chart. This can be done on the command line, or in a provided file:
 
 ```sh
-helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+helm install --version 0.5.3 kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
 ```
 :::
 ::: tab "Universal"
@@ -112,7 +112,7 @@ To install the Remote Control plane we need to provide the following parameters:
  * `controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>`:
 
 ```bash
-helm install kuma --namespace kuma-system --set controlPlane.mode=remote,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
+helm install --version 0.5.3 kuma --namespace kuma-system --set controlPlane.mode=remote,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
 kumactl install dns | kubectl apply -f -
 ```
 

--- a/docs/docs/1.1.2/installation/helm.md
+++ b/docs/docs/1.1.2/installation/helm.md
@@ -28,7 +28,7 @@ At this point we can install and run Kuma using the following commands. We could
 
 ```sh
 kubectl create namespace kuma-system
-helm install --namespace kuma-system kuma kuma/kuma
+helm install --version 0.5.3 --namespace kuma-system kuma kuma/kuma
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/1.1.2/documentation/deployments/) like "multi-zone".

--- a/docs/docs/1.1.2/networking/cni.md
+++ b/docs/docs/1.1.2/networking/cni.md
@@ -31,7 +31,7 @@ kumactl install control-plane \
 When using [Helm](/docs/1.1.2/installation/helm), we should use the values in the `cni` section to set the relevant parameters.
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.5.3 --namespace kuma-system \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.1.3/deployments/multi-zone.md
+++ b/docs/docs/1.1.3/deployments/multi-zone.md
@@ -73,7 +73,7 @@ In this example it is `35.226.196.103:5685`. This will be used as `<global-kds-a
 Install the `global` control plane by setting the `controlPlane.mode` value to `global` when installing the chart. This can be done on the command line, or in a provided file:
 
 ```sh
-helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+helm install --version 0.5.4 kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
 ```
 :::
 ::: tab "Universal"
@@ -112,7 +112,7 @@ To install the Remote Control plane we need to provide the following parameters:
  * `controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>`:
 
 ```bash
-helm install kuma --namespace kuma-system --set controlPlane.mode=remote,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
+helm install --version 0.5.4 kuma --namespace kuma-system --set controlPlane.mode=remote,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
 kumactl install dns | kubectl apply -f -
 ```
 

--- a/docs/docs/1.1.3/installation/helm.md
+++ b/docs/docs/1.1.3/installation/helm.md
@@ -28,7 +28,7 @@ At this point we can install and run Kuma using the following commands. We could
 
 ```sh
 kubectl create namespace kuma-system
-helm install --namespace kuma-system kuma kuma/kuma
+helm install --version 0.5.4 --namespace kuma-system kuma kuma/kuma
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/1.1.2/documentation/deployments/) like "multi-zone".

--- a/docs/docs/1.1.3/networking/cni.md
+++ b/docs/docs/1.1.3/networking/cni.md
@@ -31,7 +31,7 @@ kumactl install control-plane \
 When using [Helm](/docs/1.1.2/installation/helm), we should use the values in the `cni` section to set the relevant parameters.
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.5.4 --namespace kuma-system \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.1.3/networking/dns.md
+++ b/docs/docs/1.1.3/networking/dns.md
@@ -132,7 +132,7 @@ kumactl install control-plane \
 With [Helm](/docs/1.1.3/installation/helm), the command invocation looks like:
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.5.4 --namespace kuma-system \
   --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=true \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.1.4/deployments/multi-zone.md
+++ b/docs/docs/1.1.4/deployments/multi-zone.md
@@ -73,7 +73,7 @@ In this example it is `35.226.196.103:5685`. This will be used as `<global-kds-a
 Install the `global` control plane by setting the `controlPlane.mode` value to `global` when installing the chart. This can be done on the command line, or in a provided file:
 
 ```sh
-helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+helm install --version 0.5.5 kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
 ```
 :::
 ::: tab "Universal"
@@ -112,7 +112,7 @@ To install the Remote Control plane we need to provide the following parameters:
  * `controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>`:
 
 ```bash
-helm install kuma --namespace kuma-system --set controlPlane.mode=remote,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
+helm install --version 0.5.5 kuma --namespace kuma-system --set controlPlane.mode=remote,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
 kumactl install dns | kubectl apply -f -
 ```
 

--- a/docs/docs/1.1.4/installation/helm.md
+++ b/docs/docs/1.1.4/installation/helm.md
@@ -28,7 +28,7 @@ At this point we can install and run Kuma using the following commands. We could
 
 ```sh
 kubectl create namespace kuma-system
-helm install --namespace kuma-system kuma kuma/kuma
+helm install --version 0.5.5 --namespace kuma-system kuma kuma/kuma
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/1.1.2/documentation/deployments/) like "multi-zone".

--- a/docs/docs/1.1.4/networking/cni.md
+++ b/docs/docs/1.1.4/networking/cni.md
@@ -31,7 +31,7 @@ kumactl install control-plane \
 When using [Helm](/docs/1.1.2/installation/helm), we should use the values in the `cni` section to set the relevant parameters.
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.5.5 --namespace kuma-system \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.1.4/networking/dns.md
+++ b/docs/docs/1.1.4/networking/dns.md
@@ -132,7 +132,7 @@ kumactl install control-plane \
 With [Helm](/docs/1.1.3/installation/helm), the command invocation looks like:
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.5.5 --namespace kuma-system \
   --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=true \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.1.5/deployments/multi-zone.md
+++ b/docs/docs/1.1.5/deployments/multi-zone.md
@@ -73,7 +73,7 @@ In this example it is `35.226.196.103:5685`. This will be used as `<global-kds-a
 Install the `global` control plane by setting the `controlPlane.mode` value to `global` when installing the chart. This can be done on the command line, or in a provided file:
 
 ```sh
-helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+helm install --version 0.5.6 kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
 ```
 :::
 ::: tab "Universal"
@@ -112,7 +112,7 @@ To install the Remote Control plane we need to provide the following parameters:
  * `controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>`:
 
 ```bash
-helm install kuma --namespace kuma-system --set controlPlane.mode=remote,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
+helm install --version 0.5.6 kuma --namespace kuma-system --set controlPlane.mode=remote,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
 kumactl install dns | kubectl apply -f -
 ```
 

--- a/docs/docs/1.1.5/installation/helm.md
+++ b/docs/docs/1.1.5/installation/helm.md
@@ -28,7 +28,7 @@ At this point we can install and run Kuma using the following commands. We could
 
 ```sh
 kubectl create namespace kuma-system
-helm install --namespace kuma-system kuma kuma/kuma
+helm install --version 0.5.6 --namespace kuma-system kuma kuma/kuma
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/1.1.5/documentation/deployments/) like "multi-zone".

--- a/docs/docs/1.1.5/networking/cni.md
+++ b/docs/docs/1.1.5/networking/cni.md
@@ -31,7 +31,7 @@ kumactl install control-plane \
 When using [Helm](/docs/1.1.5/installation/helm), we should use the values in the `cni` section to set the relevant parameters.
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.5.6 --namespace kuma-system \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.1.5/networking/dns.md
+++ b/docs/docs/1.1.5/networking/dns.md
@@ -134,7 +134,7 @@ kumactl install control-plane \
 With [Helm](/docs/1.1.3/installation/helm), the command invocation looks like:
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.5.6 --namespace kuma-system \
   --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=true \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.1.6/deployments/multi-zone.md
+++ b/docs/docs/1.1.6/deployments/multi-zone.md
@@ -73,7 +73,7 @@ In this example it is `35.226.196.103:5685`. This will be used as `<global-kds-a
 Install the `global` control plane by setting the `controlPlane.mode` value to `global` when installing the chart. This can be done on the command line, or in a provided file:
 
 ```sh
-helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+helm install --version 0.5.7 kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
 ```
 :::
 ::: tab "Universal"
@@ -112,7 +112,7 @@ To install the Remote Control plane we need to provide the following parameters:
  * `controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>`:
 
 ```bash
-helm install kuma --namespace kuma-system --set controlPlane.mode=remote,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
+helm install --version 0.5.7 kuma --namespace kuma-system --set controlPlane.mode=remote,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
 kumactl install dns | kubectl apply -f -
 ```
 

--- a/docs/docs/1.1.6/installation/helm.md
+++ b/docs/docs/1.1.6/installation/helm.md
@@ -28,7 +28,7 @@ At this point we can install and run Kuma using the following commands. We could
 
 ```sh
 kubectl create namespace kuma-system
-helm install --namespace kuma-system kuma kuma/kuma
+helm install --version 0.5.7 --namespace kuma-system kuma kuma/kuma
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/1.1.6/documentation/deployments/) like "multi-zone".

--- a/docs/docs/1.1.6/networking/cni.md
+++ b/docs/docs/1.1.6/networking/cni.md
@@ -31,7 +31,7 @@ kumactl install control-plane \
 When using [Helm](/docs/1.1.6/installation/helm), we should use the values in the `cni` section to set the relevant parameters.
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.5.7 --namespace kuma-system \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.1.6/networking/dns.md
+++ b/docs/docs/1.1.6/networking/dns.md
@@ -134,7 +134,7 @@ kumactl install control-plane \
 With [Helm](/docs/1.1.3/installation/helm), the command invocation looks like:
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.5.7 --namespace kuma-system \
   --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=true \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.2.0/deployments/multi-zone.md
+++ b/docs/docs/1.2.0/deployments/multi-zone.md
@@ -73,7 +73,7 @@ In this example it is `35.226.196.103:5685`. This will be used as `<global-kds-a
 Install the `global` control plane by setting the `controlPlane.mode` value to `global` when installing the chart. This can be done on the command line, or in a provided file:
 
 ```sh
-helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+helm install --version 0.6.0 kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
 ```
 :::
 ::: tab "Universal"
@@ -111,7 +111,7 @@ To install the Zone Control plane we need to provide the following parameters:
  * `controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>`:
 
 ```bash
-helm install kuma --namespace kuma-system --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
+helm install --version 0.6.0 kuma --namespace kuma-system --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
 ```
 
 ::: tip

--- a/docs/docs/1.2.0/installation/helm.md
+++ b/docs/docs/1.2.0/installation/helm.md
@@ -28,7 +28,7 @@ At this point we can install and run Kuma using the following commands. We could
 
 ```sh
 kubectl create namespace kuma-system
-helm install --namespace kuma-system kuma kuma/kuma
+helm install --version 0.6.0 --namespace kuma-system kuma kuma/kuma
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/1.2.0/documentation/deployments/) like "multi-zone".

--- a/docs/docs/1.2.0/networking/cni.md
+++ b/docs/docs/1.2.0/networking/cni.md
@@ -31,7 +31,7 @@ kumactl install control-plane \
 When using [Helm](/docs/1.2.0/installation/helm), we should use the values in the `cni` section to set the relevant parameters.
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.6.0 --namespace kuma-system \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.2.0/networking/dns.md
+++ b/docs/docs/1.2.0/networking/dns.md
@@ -74,7 +74,7 @@ kumactl install control-plane \
 Set the environment variable:
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.6.0 --namespace kuma-system \
   --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=false \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.2.1/deployments/multi-zone.md
+++ b/docs/docs/1.2.1/deployments/multi-zone.md
@@ -73,7 +73,7 @@ In this example it is `35.226.196.103:5685`. This will be used as `<global-kds-a
 Install the `global` control plane by setting the `controlPlane.mode` value to `global` when installing the chart. This can be done on the command line, or in a provided file:
 
 ```sh
-helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+helm install --version 0.6.1 kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
 ```
 :::
 ::: tab "Universal"
@@ -111,7 +111,7 @@ To install the Zone Control plane we need to provide the following parameters:
  * `controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>`:
 
 ```bash
-helm install kuma --namespace kuma-system --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
+helm install --version 0.6.1 kuma --namespace kuma-system --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
 ```
 
 ::: tip

--- a/docs/docs/1.2.1/installation/helm.md
+++ b/docs/docs/1.2.1/installation/helm.md
@@ -28,7 +28,7 @@ At this point we can install and run Kuma using the following commands. We could
 
 ```sh
 kubectl create namespace kuma-system
-helm install --namespace kuma-system kuma kuma/kuma
+helm install --version 0.6.1 --namespace kuma-system kuma kuma/kuma
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/1.2.1/documentation/deployments/) like "multi-zone".

--- a/docs/docs/1.2.1/networking/cni.md
+++ b/docs/docs/1.2.1/networking/cni.md
@@ -31,7 +31,7 @@ kumactl install control-plane \
 When using [Helm](/docs/1.2.1/installation/helm), we should use the values in the `cni` section to set the relevant parameters.
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.6.1 --namespace kuma-system \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.2.1/networking/dns.md
+++ b/docs/docs/1.2.1/networking/dns.md
@@ -74,7 +74,7 @@ kumactl install control-plane \
 Set the environment variable:
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.6.1 --namespace kuma-system \
   --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=false \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.2.2/deployments/multi-zone.md
+++ b/docs/docs/1.2.2/deployments/multi-zone.md
@@ -73,7 +73,7 @@ In this example it is `35.226.196.103:5685`. This will be used as `<global-kds-a
 Install the `global` control plane by setting the `controlPlane.mode` value to `global` when installing the chart. This can be done on the command line, or in a provided file:
 
 ```sh
-helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+helm install --version 0.6.2 kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
 ```
 :::
 ::: tab "Universal"
@@ -111,7 +111,7 @@ To install the Zone Control plane we need to provide the following parameters:
  * `controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>`:
 
 ```bash
-helm install kuma --namespace kuma-system --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
+helm install --version 0.6.2 kuma --namespace kuma-system --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
 ```
 
 ::: tip

--- a/docs/docs/1.2.2/installation/helm.md
+++ b/docs/docs/1.2.2/installation/helm.md
@@ -28,7 +28,7 @@ At this point we can install and run Kuma using the following commands. We could
 
 ```sh
 kubectl create namespace kuma-system
-helm install --namespace kuma-system kuma kuma/kuma
+helm install --version 0.6.2 --namespace kuma-system kuma kuma/kuma
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/1.2.2/documentation/deployments/) like "multi-zone".

--- a/docs/docs/1.2.2/networking/cni.md
+++ b/docs/docs/1.2.2/networking/cni.md
@@ -31,7 +31,7 @@ kumactl install control-plane \
 When using [Helm](/docs/1.2.2/installation/helm), we should use the values in the `cni` section to set the relevant parameters.
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.6.2 --namespace kuma-system \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.2.2/networking/dns.md
+++ b/docs/docs/1.2.2/networking/dns.md
@@ -74,7 +74,7 @@ kumactl install control-plane \
 Set the environment variable:
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.6.2 --namespace kuma-system \
   --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=false \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.2.3/deployments/multi-zone.md
+++ b/docs/docs/1.2.3/deployments/multi-zone.md
@@ -73,7 +73,7 @@ In this example it is `35.226.196.103:5685`. This will be used as `<global-kds-a
 Install the `global` control plane by setting the `controlPlane.mode` value to `global` when installing the chart. This can be done on the command line, or in a provided file:
 
 ```sh
-helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+helm install --version 0.6.3 kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
 ```
 :::
 ::: tab "Universal"
@@ -111,7 +111,7 @@ To install the Zone Control plane we need to provide the following parameters:
  * `controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>`:
 
 ```bash
-helm install kuma --namespace kuma-system --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
+helm install --version 0.6.3 kuma --namespace kuma-system --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
 ```
 
 ::: tip

--- a/docs/docs/1.2.3/installation/helm.md
+++ b/docs/docs/1.2.3/installation/helm.md
@@ -27,7 +27,7 @@ Once the repo is added, all following updates can be fetched with `helm repo upd
 At this point we can install and run Kuma using the following commands. We could use any Kubernetes namespace to install Kuma, by default we suggest using `kuma-system`:
 
 ```sh
-helm install --create-namespace --namespace kuma-system kuma kuma/kuma
+helm install --verison 0.6.3 --create-namespace --namespace kuma-system kuma kuma/kuma
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/1.2.3/documentation/deployments/) like "multi-zone".

--- a/docs/docs/1.2.3/networking/cni.md
+++ b/docs/docs/1.2.3/networking/cni.md
@@ -31,7 +31,7 @@ kumactl install control-plane \
 When using [Helm](/docs/1.2.3/installation/helm), we should use the values in the `cni` section to set the relevant parameters.
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.6.3 --namespace kuma-system \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.2.3/networking/dns.md
+++ b/docs/docs/1.2.3/networking/dns.md
@@ -74,7 +74,7 @@ kumactl install control-plane \
 Set the environment variable:
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.6.3 --namespace kuma-system \
   --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=false \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.3.0/deployments/multi-zone.md
+++ b/docs/docs/1.3.0/deployments/multi-zone.md
@@ -73,7 +73,7 @@ In this example it is `35.226.196.103:5685`. This will be used as `<global-kds-a
 Install the `global` control plane by setting the `controlPlane.mode` value to `global` when installing the chart. This can be done on the command line, or in a provided file:
 
 ```sh
-helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+helm install --version 0.7.0 kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
 ```
 :::
 ::: tab "Universal"
@@ -111,7 +111,7 @@ To install the Zone Control plane we need to provide the following parameters:
  * `controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>`:
 
 ```bash
-helm install kuma --namespace kuma-system --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
+helm install --version 0.7.0 kuma --namespace kuma-system --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
 ```
 
 ::: tip

--- a/docs/docs/1.3.0/installation/helm.md
+++ b/docs/docs/1.3.0/installation/helm.md
@@ -27,7 +27,7 @@ Once the repo is added, all following updates can be fetched with `helm repo upd
 At this point we can install and run Kuma using the following commands. We could use any Kubernetes namespace to install Kuma, by default we suggest using `kuma-system`:
 
 ```sh
-helm install --create-namespace --namespace kuma-system kuma kuma/kuma
+helm install --version 0.7.0 --create-namespace --namespace kuma-system kuma kuma/kuma
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/1.3.0/documentation/deployments/) like "multi-zone".

--- a/docs/docs/1.3.0/networking/cni.md
+++ b/docs/docs/1.3.0/networking/cni.md
@@ -31,7 +31,7 @@ kumactl install control-plane \
 When using [Helm](/docs/1.3.0/installation/helm), we should use the values in the `cni` section to set the relevant parameters.
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.7.0 --namespace kuma-system \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.3.0/networking/dns.md
+++ b/docs/docs/1.3.0/networking/dns.md
@@ -92,7 +92,7 @@ kumactl install control-plane \
 Set the environment variable:
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.7.0 --namespace kuma-system \
   --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=false \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.3.1/deployments/multi-zone.md
+++ b/docs/docs/1.3.1/deployments/multi-zone.md
@@ -73,7 +73,7 @@ In this example it is `35.226.196.103:5685`. This will be used as `<global-kds-a
 Install the `global` control plane by setting the `controlPlane.mode` value to `global` when installing the chart. This can be done on the command line, or in a provided file:
 
 ```sh
-helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+helm install --version 0.7.1 kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
 ```
 :::
 ::: tab "Universal"
@@ -111,7 +111,7 @@ To install the Zone Control plane we need to provide the following parameters:
  * `controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>`:
 
 ```bash
-helm install kuma --namespace kuma-system --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
+helm install --version 0.7.1 kuma --namespace kuma-system --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
 ```
 
 ::: tip

--- a/docs/docs/1.3.1/documentation/configuration.md
+++ b/docs/docs/1.3.1/documentation/configuration.md
@@ -24,7 +24,7 @@ $ kumactl install control-plane \
 ::: tab "Kubernetes (HELM)"
 If you install the control plane with HELM, you can override the configuration with the `envVars` field. For example, to configure the refresh interval for configuration with the data plane proxy, specify:
 ```sh
-$ helm install \
+$ helm install --version 0.7.1 \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s \
   kuma kuma/kuma
@@ -37,7 +37,7 @@ controlPlane:
   envVars:
     KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL: 5s
     KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL: 5s
-$ helm install -f Values.yaml kuma kuma/kuma
+$ helm install --version 0.7.1 -f Values.yaml kuma kuma/kuma
 ```
 :::
 ::: tab "Universal"

--- a/docs/docs/1.3.1/installation/helm.md
+++ b/docs/docs/1.3.1/installation/helm.md
@@ -27,7 +27,7 @@ Once the repo is added, all following updates can be fetched with `helm repo upd
 At this point we can install and run Kuma using the following commands. We could use any Kubernetes namespace to install Kuma, by default we suggest using `kuma-system`:
 
 ```sh
-helm install --create-namespace --namespace kuma-system kuma kuma/kuma
+helm install --version 0.7.1 --create-namespace --namespace kuma-system kuma kuma/kuma
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/1.3.1/documentation/deployments/) like "multi-zone".

--- a/docs/docs/1.3.1/networking/cni.md
+++ b/docs/docs/1.3.1/networking/cni.md
@@ -31,7 +31,7 @@ kumactl install control-plane \
 When using [Helm](/docs/1.3.1/installation/helm), we should use the values in the `cni` section to set the relevant parameters.
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.7.1 --namespace kuma-system \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
    kuma kuma/kuma
 ```

--- a/docs/docs/1.3.1/networking/dns.md
+++ b/docs/docs/1.3.1/networking/dns.md
@@ -92,7 +92,7 @@ kumactl install control-plane \
 Set the environment variable:
 
 ```shell
-helm install --namespace kuma-system \
+helm install --version 0.7.1 --namespace kuma-system \
   --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=false \
    kuma kuma/kuma
 ```


### PR DESCRIPTION
Before this change, users would install the latest
version of the Helm chart (and Kuma) no matter what
the desired outcome was. By specifying a chart
version to helm install, users will get the exact
version of Kuma they desire based on the version
of docs they are reading. Chart versions are based
on versions available using:
`helm search repo kuma -l`

Reference: https://helm.sh/docs/helm/helm_install
fixes #522