### PR TITLE
Fix bad yaml in mTLS examples

### DIFF
--- a/docs/docs/1.1.0/policies/mutual-tls.md
+++ b/docs/docs/1.1.0/policies/mutual-tls.md
@@ -254,7 +254,7 @@ spec:
     backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:
@@ -275,7 +275,7 @@ mtls:
   backends:
   - name: ca-1
     type: provided
-    config:
+    conf:
       cert:
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
       key:

--- a/docs/docs/1.1.1/policies/mutual-tls.md
+++ b/docs/docs/1.1.1/policies/mutual-tls.md
@@ -254,7 +254,7 @@ spec:
     backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:
@@ -275,7 +275,7 @@ mtls:
   backends:
   - name: ca-1
     type: provided
-    config:
+    conf:
       cert:
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
       key:

--- a/docs/docs/1.1.2/policies/mutual-tls.md
+++ b/docs/docs/1.1.2/policies/mutual-tls.md
@@ -1,4 +1,5 @@
 # Mutual TLS
+# Mutual TLS
 
 This policy enables automatic encrypted mTLS traffic for all the services in a [`Mesh`](../mesh), as well as assigning an identity to every data plane proxy. Kuma supports different types of CA backends as well as automatic certificate rotation.
 
@@ -254,7 +255,7 @@ spec:
     backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:
@@ -275,7 +276,7 @@ mtls:
   backends:
   - name: ca-1
     type: provided
-    config:
+    conf:
       cert:
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
       key:

--- a/docs/docs/1.1.3/policies/mutual-tls.md
+++ b/docs/docs/1.1.3/policies/mutual-tls.md
@@ -254,7 +254,7 @@ spec:
     backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:
@@ -275,7 +275,7 @@ mtls:
   backends:
   - name: ca-1
     type: provided
-    config:
+    conf:
       cert:
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
       key:

--- a/docs/docs/1.1.4/policies/mutual-tls.md
+++ b/docs/docs/1.1.4/policies/mutual-tls.md
@@ -254,7 +254,7 @@ spec:
     backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:
@@ -275,7 +275,7 @@ mtls:
   backends:
   - name: ca-1
     type: provided
-    config:
+    conf:
       cert:
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
       key:

--- a/docs/docs/1.1.5/policies/mutual-tls.md
+++ b/docs/docs/1.1.5/policies/mutual-tls.md
@@ -254,7 +254,7 @@ spec:
     backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:
@@ -275,7 +275,7 @@ mtls:
   backends:
   - name: ca-1
     type: provided
-    config:
+    conf:
       cert:
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
       key:

--- a/docs/docs/1.1.6/policies/mutual-tls.md
+++ b/docs/docs/1.1.6/policies/mutual-tls.md
@@ -254,7 +254,7 @@ spec:
     backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:
@@ -275,7 +275,7 @@ mtls:
   backends:
   - name: ca-1
     type: provided
-    config:
+    conf:
       cert:
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
       key:

--- a/docs/docs/1.2.0/policies/mutual-tls.md
+++ b/docs/docs/1.2.0/policies/mutual-tls.md
@@ -254,7 +254,7 @@ spec:
     backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:
@@ -275,7 +275,7 @@ mtls:
   backends:
   - name: ca-1
     type: provided
-    config:
+    conf:
       cert:
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
       key:

--- a/docs/docs/1.2.1/policies/mutual-tls.md
+++ b/docs/docs/1.2.1/policies/mutual-tls.md
@@ -254,7 +254,7 @@ spec:
     backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:
@@ -275,7 +275,7 @@ mtls:
   backends:
   - name: ca-1
     type: provided
-    config:
+    conf:
       cert:
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
       key:

--- a/docs/docs/1.2.2/policies/mutual-tls.md
+++ b/docs/docs/1.2.2/policies/mutual-tls.md
@@ -254,7 +254,7 @@ spec:
     backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:
@@ -275,7 +275,7 @@ mtls:
   backends:
   - name: ca-1
     type: provided
-    config:
+    conf:
       cert:
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
       key:

--- a/docs/docs/1.2.3/policies/mutual-tls.md
+++ b/docs/docs/1.2.3/policies/mutual-tls.md
@@ -254,7 +254,7 @@ spec:
     backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:
@@ -275,7 +275,7 @@ mtls:
   backends:
   - name: ca-1
     type: provided
-    config:
+    conf:
       cert:
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
       key:

--- a/docs/docs/1.3.0/policies/mutual-tls.md
+++ b/docs/docs/1.3.0/policies/mutual-tls.md
@@ -305,7 +305,7 @@ spec:
     backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:
@@ -326,7 +326,7 @@ mtls:
   backends:
   - name: ca-1
     type: provided
-    config:
+    conf:
       cert:
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
       key:


### PR DESCRIPTION
we were using config instead of conf

Signed-off-by: Charly Molter <charly.molter@konghq.com>