### PR TITLE
docs: data collection under reference docs section

### DIFF
--- a/docs/.vuepress/site-config/sidebar-nav.js
+++ b/docs/.vuepress/site-config/sidebar-nav.js
@@ -2050,7 +2050,6 @@ module.exports = {
         "overview/what-is-a-service-mesh",
         "overview/why-kuma",
         "documentation/deployments",
-        "community/data-collection",
         "other/enterprise",
         "other/license",
       ]
@@ -2193,7 +2192,8 @@ module.exports = {
             "generated/traffic-trace",
             "generated/virtual-outbound",
           ],
-        }
+        },
+        "community/data-collection",
       ]
     }
   ],

--- a/docs/docs/1.4.1/community/data-collection.md
+++ b/docs/docs/1.4.1/community/data-collection.md
@@ -1,8 +1,10 @@
 # Kuma data collection
 
-Kuma can collect some data about your deployment if enabled. Data collection (telemetry) is disabled by default. The collected data is sent to Kong servers for storage and aggregation. You can enable data collection when you install the control plane.
+Kuma can collect information about your deployment to continuously improve the product and gather anonymous feedback. The collected data is sent to Kong servers securely for storage and aggregation. 
 
-## Enable data collection on Kubernetes
+You can enable data collection when installing the control plane in Kubernetes, of before running `kuma-cp` in Universal mode.
+
+## Enabling data collection
 
 1.  Set the following environment variable:
 
@@ -10,7 +12,7 @@ Kuma can collect some data about your deployment if enabled. Data collection (te
     KUMA_REPORTS_ENABLED=true
     ```
 
-1.  Specify the environment variable when you install the control plane. See the [configuration docs](/docs/1.4.0/documentation/configuration/) for details.
+1.  Specify the environment variable when you install the control plane. See the [configuration docs](/docs/1.3.1/documentation/configuration/) for details.
 
 Or you can set the `reports.enabled` field to `true` in the config YAML file.
 

--- a/docs/docs/1.4.1/community/data-collection.md
+++ b/docs/docs/1.4.1/community/data-collection.md
@@ -12,7 +12,7 @@ You can enable data collection when installing the control plane in Kubernetes, 
     KUMA_REPORTS_ENABLED=true
     ```
 
-1.  Specify the environment variable when you install the control plane. See the [configuration docs](/docs/1.3.1/documentation/configuration/) for details.
+1.  Specify the environment variable when you install the control plane. See the [configuration docs](/docs/1.4.1/documentation/configuration/) for details.
 
 Or you can set the `reports.enabled` field to `true` in the config YAML file.
 


### PR DESCRIPTION
Moving the data collection section away from "Introduction" and into the reference docs section.