### PR TITLE
docs(networking) rewrite transparent proxy and dns

### DIFF
--- a/docs/docs/dev/networking/dns-cp.md
+++ b/docs/docs/dev/networking/dns-cp.md
@@ -1,0 +1,41 @@
+# DNS in the control plane
+
+::: warning
+This is deprecated way of handling Kuma DNS that will be removed in the future versions of Kuma. Consider using [DNS embedded in kuma-dp](../dns)
+:::
+
+In this mode, DNS traffic is not intercepted and resolved by Envoy, but the DNS resolver is explicitly configured with `kuma-cp` DNS server for defined domains (`.mesh` by default).
+
+## How Kuma DNS in the control plane works
+
+Kuma DNS in the control plane works in a similar way as Kuma DNS embedded in `kuma-dp`, but DNS server is run by `kuma-cp`.
+The DNS server in kuma-cp listens on port `5653`.
+
+## Installation
+
+The Kuma control plane exposes a DNS service which handles the name resolution in the `.mesh` DNS zone.
+
+Usually DNS configuration expects DNS server to be served on port `53` therefore we need to [configure](../documentation/configuration) the control plane with `KUMA_DNS_SERVER_PORT` set to `53`.
+
+:::: tabs
+::: tab "Kubernetes" :options="{ useUrlFragment: false }"
+1. When you install the control plane, [configure](../documentation/configuration) it with the following environment variable to disable the data plane proxy DNS:
+
+`KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=false`
+
+2. Plug Kuma DNS resolver into Kube DNS or Core DNS
+
+`kumactl install dns`
+:::
+::: tab "Universal"
+Follow the instruction in [transparent proxying](../transparent-proxying), but when `install transparent-proxy` is executed. Set the following arguments
+
+```shell
+kumactl install transparent-proxy \
+          --kuma-dp-user kuma-dp \
+          --kuma-cp-ip <KUMA_CP_IP_ADDRESS>
+```
+
+In addition to changing `iptables`, this command will also modify `/etc/resolv.conf`.
+:::
+::::

--- a/docs/docs/dev/networking/dns.md
+++ b/docs/docs/dev/networking/dns.md
@@ -1,45 +1,51 @@
 # DNS
 
-As of Kuma version 1.2.0, DNS on the data plane proxy is enabled by default on Kubernetes. You can also continue to deploy with [DNS on the control plane](#control-plane-dns).
+Kuma ships with DNS resolver to provide service naming - a mapping of hostname to Virtual IPs (VIPs) of services registered in Kuma.
 
-## Data plane proxy DNS
+The usage of Kuma DNS is only relevant when [transparent proxying](../transparent-proxying) is used.
 
-In this mode, all name lookups are handled locally by the data plane proxy. This approach allows for more robust handling of name resolution.
+## How it works
 
-On Kubernetes, this is the default. You must enable it manually on universal deployments.
+Kuma DNS server responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAAA` records, for example ```redis.mesh. 60 IN A  240.0.0.100``` or ```redis.mesh. 60 IN AAAAA  fd00:fd00::100```.
 
-### Universal
+The virtual IPs are allocated by the control plane from the configured CIDR (by default `240.0.0.0/4`) , by constantly scanning the services available in all Kuma meshes.
+When a service is removed, its VIP is also freed, and Kuma DNS does not respond for it with `A` and `AAAA` DNS record.
+Virtual IPs are stable (replicated) between instances of the control plane and data plane proxies.
 
-In Universal mode, the `kumactl install transparent-proxy` and `kuma-dp` processes enable DNS resolution to .mesh addresses.
+Once a new VIP is allocated or an old VIP is freed, the control plane configures the data plane proxy with this change.
 
-Prerequisites:
+All name lookups are handled locally by the data plane proxy, not by the control plane.
+This approach allows for more robust handling of name resolution.
+For example, when the control plane is down, a data plane proxy can still resolve DNS.
 
-- `kuma-dp`, `envoy`, and `coredns` must run on the worker node -- that is, the node that runs your service mesh workload.
-- `core-dns` must be in the PATH so that `kuma-dp` can access it. 
-  - You can also set the location with the `--dns-coredns-path` flag. 
-- User created to run the `kuma-dp` process. You must run the `kuma-dp` process with a different user than the user you test with. Otherwise, name resolution might not work.
-  - On Ubuntu, for example, you can run: `useradd -U kuma-dp`.
+The data plane proxy DNS consists of:
 
-1.  Specify the flags `--skip-resolv-conf` and `--redirect-dns` in the [transparent proxy](transparent-proxying/) iptables rules:
+- an Envoy DNS filter provides responses from the mesh for DNS records
+- a CoreDNS instance launched by `kuma-dp` that sends requests between the Envoy DNS filter and the original host DNS
+- iptable rules that will redirect the original DNS traffic to the local CoreDNS instance
 
-    ```shell
-    kumactl install transparent-proxy \
-              --kuma-dp-user kuma-dp \
-              --kuma-cp-ip <kuma-cp IP> \
-              --skip-resolv-conf \
-              --redirect-dns
-    ```
+As the DNS requests are sent to the Envoy DNS filter first, any DNS name that exists inside the mesh will always resolve to the mesh address. 
+This in practice means that DNS name present in the mesh will "shadow" equivalent names that exist outside the mesh.
 
-1.  Start [the kuma-dp](../documentation/dps-and-data-model/#dataplane-entity)
+Kuma DNS is not a service discovery mechanism, it does not return real IP address of service instances.
+Instead, it always returns a single VIP that is assigned to the relevant service in the mesh. This makes for a unified view of all services within a single zone or across multiple zones.
 
-    ```shell
-    kuma-dp run \
-      --cp-address=https://127.0.0.1:5678 \
-      --dataplane-file=dp.yaml \
-      --dataplane-token-file=/tmp/kuma-dp-redis-1-token
-    ```
+The default TTL is 60 seconds, to ensure the client synchronizes with Kuma DNS and to account for any intervening changes.
 
-    The `kuma-dp` process also starts CoreDNS and allows resolution of .mesh addresses.
+## Installation
+
+:::: tabs :options="{ useUrlFragment: false }"
+::: tab "Kubernetes"
+
+Kuma DNS is enabled by default whenever kuma-dp sidecar proxy is injected. 
+
+:::
+::: tab "Universal"
+
+Follow the instruction in [transparent proxying](../transparent-proxying).
+
+:::
+::::
 
 ### Special considerations
 
@@ -48,138 +54,70 @@ This mode implements advanced networking techniques, so take special care for th
  * The mode can safely be used with the [Kuma CNI plugin](cni/).
  * In mixed IPv4 and IPv6 environments, it's recommended that you specify an [IPv6 virtual IP CIDR](ipv6/).
 
-### How it works
+### Overriding the CoreDNS configuration
 
-The data plane proxy DNS consists of:
+In some cases it might be useful for you to configure the default CoreDNS.
 
-- an Envoy DNS filter provides responses from the mesh for DNS records
-- a CoreDNS instance launched by `kuma-cp` that sends requests between the envoy filter and the host DNS 
-- iptable rules that will redirect the original DNS traffic to the local CoreDNS instance
-
-As the DNS requests are sent to the Envoy DNS filter first, any DNS name that exists inside the mesh will always resolve to the mesh address. 
-This in practice means that DNS name present in the mesh will "shadow" equivalent names that exist outside the mesh.
-
-### Overriding the coreDNS configuration
-
-In some cases it might be useful for you to configure the default coreDNS.
-To do so you can use `--dns-coredns-config-template-path` as an argument to `kuma-dp`.
-This file is a [coreDNS configuration](https://coredns.io/manual/toc/) that is processed as a go-template.
-If you edit this configuration you should base yourself on the default existing configuration.
-
-## Control Plane DNS
-
-The Kuma control plane deploys its DNS resolver on UDP port `5653`. It allows decoupling the service name resolution from the underlying infrastructure and thus makes Kuma more flexible. When Kuma is deployed as a distributed control plane, Kuma DNS enables cross-cluster service discovery.
-
-### Kubernetes
-
-When you install the control plane, set the following environment variable to disable the data plane proxy DNS:
-
-`KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=false`
-
-:::: tabs
-::: tab "kumactl"
-
-Pass the environment variable to the `--env-var` argument when you install:
-
-```shell
-kumactl install control-plane \
-  --env-var KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=false
-```
-
+:::: tabs :options="{ useUrlFragment: false }"
+::: tab "Kubernetes"
+At this moment, there is no builtin option to override CoreDNS configuration. 
 :::
-::: tab "Helm"
-
-Set the environment variable:
-
-```shell
-helm install --namespace kuma-system \
-  --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=false \
-   kuma kuma/kuma
-```
-
-:::
+::: tab "Universal"
+Use `--dns-coredns-config-template-path` as an argument to `kuma-dp`.
 ::::
 
-### Universal
+This file is a [CoreDNS configuration](https://coredns.io/manual/toc/) that is processed as a go-template.
+If you edit this configuration you should base yourself on the default existing configuration, which looks like the following
 
-1.  Configure [the transparent proxy](transparent-proxying/) iptables rules:
+```
+.:{{ .CoreDNSPort }} {
+    forward . 127.0.0.1:{{ .EnvoyDNSPort }}
+    # We want all requests to be sent to the Envoy DNS Filter, unsuccessful responses should be forwarded to the original DNS server.
+    # For example: requests other than A, AAAA and SRV will return NOTIMP when hitting the envoy filter and should be sent to the original DNS server.
+    # Codes from: https://github.com/miekg/dns/blob/master/msg.go#L138
+    alternate NOTIMP,FORMERR,NXDOMAIN,SERVFAIL,REFUSED . /etc/resolv.conf
+    prometheus localhost:{{ .PrometheusPort }}
+    errors
+}
 
-    ```shell
-    kumactl install transparent-proxy \
-              --kuma-dp-user kuma-dp \
-              --kuma-cp-ip <KUMA_CP_IP_ADDRESS>
-    ```
-
-1.  Start [the kuma-dp](../documentation/dps-and-data-model/#dataplane-entity) with flag `--dns-enabled` set to `false`:
-
-    ```shell
-    kuma-dp run \
-      --cp-address=https://127.0.0.1:5678 \
-      --dataplane-file=dp.yaml \
-      --dataplane-token-file=/tmp/<KUMA_DP_REDIS_1_TOKEN> \
-      --dns-enabled=false
-    ```
+.:{{ .CoreDNSEmptyPort }} {
+    template ANY ANY . {
+      rcode NXDOMAIN
+    }
+}
+```
 
 ## Configuration
 
-You can configure Kuma DNS with the config file, or with environment variables:
+You can configure Kuma DNS in `kuma-cp`:
 
 ```yaml
-# DNS Server configuration
 dnsServer:
-  # The domain that the server will resolve the services for
   domain: "mesh" # ENV: KUMA_DNS_SERVER_DOMAIN
-  # Port on which the server is exposed
-  port: 5653 # ENV: KUMA_DNS_SERVER_PORT
-  # The CIDR range used to allocate
   CIDR: "240.0.0.0/4" # ENV: KUMA_DNS_SERVER_CIDR
-  # Will create a service "<kuma.io/service>.mesh" dns entry for every service.
   serviceVipEnabled: true # ENV: KUMA_DNS_SERVER_SERVICE_VIP_ENABLED
 ```
 
-The `domain` field specifies the default `.mesh` DNS zone that Kuma DNS provides resolution for. If you change this value, make sure to change the zone value for `kumactl install dns` to match. These values must be the same for kube-dns or CoreDNS server to redirect relevant DNS requests.
-
-The `port` field specifies the port where Kuma DNS accepts requests. Make sure this value matches the port setting for the `kuma-control-plane` service. 
+The `domain` field specifies the default `.mesh` DNS zone that Kuma DNS provides resolution for. It's only relevant when `serviceVipEnabled` is set to `true`. 
 
 The `CIDR` field sets the IP range of virtual IPs. The default `240.0.0.0/4` is reserved for future IPv4 use IPv4 and is guaranteed to be non-routable. We strongly recommend to not change this value unless you have a specific need for a different IP range.
 
-The `serviceVipEnabled` field defines if there should be a vip generated for each `kuma.io/service`. This can be disabled for performance reason and [virtual-outbound](../policies/virtual-outbound.md) provides a more flexible way to do this.
-
-## How Kuma DNS works 
-
-Kuma DNS includes these components: 
-
-- The DNS server
-- The VIPs allocator
-- Cross-replica persistence
-
-The DNS server listens on port `5653`, responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAAA` records, for example ```<service>.mesh. 60 IN A  240.0.0.100``` or ```<service>.mesh. 60 IN AAAAA  fd00:fd00::100```. The default TTL is 60 seconds, to ensure the client synchronizes with Kuma DNS and to account for any intervening changes.
-
-The virtual IPs are allocated from the configured CIDR, by constantly scanning the services available in all Kuma meshes. When a service is removed, its VIP is also freed, and Kuma DNS does not respond for it with `A` DNS record.
-
-Kuma DNS is not a service discovery mechanism. Instead, it returns a single VIP that is assigned to the relevant service in the mesh. This makes for a unified view of all services within a single zone or across multiple zones.
+The `serviceVipEnabled` field defines if there should be a vip generated for each `kuma.io/service`. This can be disabled for performance reason and [virtual-outbound](../policies/virtual-outbound) provides a more flexible way to do this.
 
 ## Usage
 
-::: tip
-The following setup will only work when `serviceVipEnabled=true` which will default to false and then fully removed in future versions of Kuma.
+Consuming a service handled by Kuma DNS, whether from Kuma-enabled Pod on Kubernetes or VM with `kuma-dp`, is based on the automatically generated `kuma.io/service` tag. The resulting domain name has the format `{service tag}.mesh`. For example:
 
-The preferred way to define hostnames is using [virtual-outbounds](../policies/virtual-outbound.md).
-Virtual-outbounds also makes it possible to define dynamic hostnames using specific tags or to expose services on a different port.
-:::
-
-Consuming a service handled by Kuma DNS from inside a Kubernetes container is based on the automatically generated `kuma.io/service` tag. The resulting domain name has the format `{service tag}.mesh`. For example:
-
-```bash
-<kuma-enabled-pod>curl http://echo-server_echo-example_svc_1010.mesh:80
-<kuma-enabled-pod>curl http://echo-server_echo-example_svc_1010.mesh
+```
+<kuma-enabled-pod>$ curl http://echo-server_echo-example_svc_1010.mesh:80
+<kuma-enabled-pod>$ curl http://echo-server_echo-example_svc_1010.mesh
 ```
 
 A DNS standards compliant name is also available, where the underscores in the service name are replaced with dots. For example:
 
-```bash
-<kuma-enabled-pod>curl http://echo-server.echo-example.svc.1010.mesh:80
-<kuma-enabled-pod>curl http://echo-server.echo-example.svc.1010.mesh
+```
+<kuma-enabled-pod>$ curl http://echo-server.echo-example.svc.1010.mesh:80
+<kuma-enabled-pod>$ curl http://echo-server.echo-example.svc.1010.mesh
 ```
 
 The default listeners created on the VIP default to port `80`, so the port can be omitted with a standard HTTP client.
@@ -223,3 +161,10 @@ Kuma DNS allocates a VIP for every service within a mesh. Then, it creates an ou
      }
     },
 ```
+
+::: tip
+The following setup will work when `serviceVipEnabled=true` which is a default value.
+
+The preferred way to define hostnames is using [Virtual Outbounds](../policies/virtual-outbound).
+Virtual Outbounds also makes it possible to define dynamic hostnames using specific tags or to expose services on a different port.
+:::

--- a/docs/docs/dev/networking/dns.md
+++ b/docs/docs/dev/networking/dns.md
@@ -93,14 +93,14 @@ You can configure Kuma DNS in `kuma-cp`:
 
 ```yaml
 dnsServer:
-  domain: "mesh" # ENV: KUMA_DNS_SERVER_DOMAIN
   CIDR: "240.0.0.0/4" # ENV: KUMA_DNS_SERVER_CIDR
+  domain: "mesh" # ENV: KUMA_DNS_SERVER_DOMAIN
   serviceVipEnabled: true # ENV: KUMA_DNS_SERVER_SERVICE_VIP_ENABLED
 ```
 
-The `domain` field specifies the default `.mesh` DNS zone that Kuma DNS provides resolution for. It's only relevant when `serviceVipEnabled` is set to `true`. 
+The `CIDR` field sets the IP range of virtual IPs. The default `240.0.0.0/4` is reserved for future IPv4 use and is guaranteed to be non-routable. We strongly recommend to not change this value unless you have a specific need for a different IP range.
 
-The `CIDR` field sets the IP range of virtual IPs. The default `240.0.0.0/4` is reserved for future IPv4 use IPv4 and is guaranteed to be non-routable. We strongly recommend to not change this value unless you have a specific need for a different IP range.
+The `domain` field specifies the default `.mesh` DNS zone that Kuma DNS provides resolution for. It's only relevant when `serviceVipEnabled` is set to `true`.
 
 The `serviceVipEnabled` field defines if there should be a vip generated for each `kuma.io/service`. This can be disabled for performance reason and [virtual-outbound](../policies/virtual-outbound) provides a more flexible way to do this.
 

--- a/docs/docs/dev/networking/networking.md
+++ b/docs/docs/dev/networking/networking.md
@@ -20,7 +20,7 @@ This is the default, single zone mode, in which all of the following ports are e
     * `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when running in `universal` - that you can use to apply new policies. It also exposes the Kuma GUI at `/gui`
     * `5682`: HTTPS version of the services available under `5681`
 * UDP
-    * `5653`: the Kuma DNS server
+    * `5653`: [the Kuma DNS server](../dns-cp)
 
 ### Global Control Plane
 
@@ -46,7 +46,7 @@ When Kuma is run as a distributed service mesh, the Zone control plane exposes t
     * `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when running in `universal` - you can only manage the dataplane resources.
     * `5682`: HTTPS version of the services available under `5681`
 * UDP
-    * `5653`: the Kuma DNS server
+    * `5653`: [the Kuma DNS server](../dns-cp)
 
 ## kuma-dp ports
 

--- a/docs/docs/dev/networking/service-discovery.md
+++ b/docs/docs/dev/networking/service-discovery.md
@@ -19,7 +19,7 @@ While doing so, the data-planes also advertise the IP address of each service. T
 
 The IP address that's being advertised by every data-plane to the control-plane is also being used to route service traffic from one `kuma-dp` to another `kuma-dp`. This means that Kuma knows at any given time what are all the IP addresses associated to every replica of every service. Another use-case where the IP address of the data-planes is being used is for metrics scraping by Prometheus.
 
-Kuma already ships with its own [DNS service discovery](../networking/dns/) on both standalone and multi-zone modes. 
+Kuma already ships with its own [DNS](../networking/dns/) on both standalone and multi-zone modes. 
 
 Connectivity among the `kuma-dp` instances can happen in two ways:
 

--- a/docs/docs/dev/networking/transparent-proxying.md
+++ b/docs/docs/dev/networking/transparent-proxying.md
@@ -152,7 +152,7 @@ Execute `kumactl install transparent-proxy --help` to see available options.
 ### Reachable Services
 
 By default, every data plane proxy in the mesh follows every other data plane proxy.
-This may lead to a performance problems in larger deployments of the mesh.
+This may lead to performance problems in larger deployments of the mesh.
 It is highly recommended to define a list of services that your service connects to.
 
 :::: tabs :options="{ useUrlFragment: false }"

--- a/docs/docs/dev/networking/transparent-proxying.md
+++ b/docs/docs/dev/networking/transparent-proxying.md
@@ -1,70 +1,61 @@
 # Transparent Proxying
 
-In order to interecept traffic from and to a service through a `kuma-dp` data plane proxy instance, Kuma utilizes a variety of patterns.
+In order to automatically intercept traffic from and to a service through a `kuma-dp` data plane proxy instance, Kuma utilizes a transparent proxying using [`iptables`](https://linux.die.net/man/8/iptables).
 
-* On **Kubernetes** `kuma-dp` leverages transparent proxying automatically via `iptables` or CNI, for all incoming and outgoing traffic that is automatically intercepted by `kuma-dp` without having to change the application code.
-* On **Universal** `kuma-dp` leverages the [data plane proxy specification](../documentation/dps-and-data-model/) associated to it for receiving incoming requests on a pre-defined port, while it can leverage both transparent proxying and explicit `outbound` entries in the same data plane proxy specification for all outgoing traffic.
+Transparent proxying helps with a smoother rollout of a Service Mesh to a current deployment by preserving existing service naming and as the result - avoid changes to the application code.
+
+## Kubernetes
+
+On **Kubernetes** `kuma-dp` leverages transparent proxying automatically via `iptables` installed with `kuma-init` container or CNI.
+All incoming and outgoing traffic is automatically intercepted by `kuma-dp` without having to change the application code.
+
+Kuma integrates with a service naming provided by Kubernetes DNS as well as providing its own [Kuma DNS](../dns) for multizone service naming. 
+
+## Universal
+
+On **Universal** `kuma-dp` leverages the [data plane proxy specification](../documentation/dps-and-data-model/) associated to it for receiving incoming requests on a pre-defined port.
 
 There are several advantages for using transparent proxying in universal mode:
 
  * Simpler [Dataplane resource](../documentation/dps-and-data-model/#dataplane-specification), as the `outbound` section becomes obsolete and can be skipped.
- * Universal service naming with `.mesh` [DNS domain](../networking/dns/).
+ * Universal service naming with `.mesh` [DNS domain](../networking/dns/) instead of explicit outbound like `https://localhost:10001`.
+ * Support for hostnames of your choice using [VirtualOutbounds](../policies/virtual-outbound) that lets you preserve existing service naming.
  * Better service manageability (security, tracing).
-
-### Preparing the Kuma Control plane
-
-The Kuma control plane exposes a DNS service which handles the name resolution in the `.mesh` DNS zone. By default it listens on port `UDP/5653`. For this setup we need it to listen on port `UDP/53`, therefore make sure that this environment variable is set before running `kuma-cp`: `KUMA_DNS_SERVER_PORT=53`.
-
-:::tip
-The IP address of the host that runs Kuma Control plane will be used in the next section. Make sure to have it once, `kuma-cp` is started.
-:::
 
 ### Setting up the service host
 
-The host that will run the `kuma-dp` process in transparent proxying mode needs to be prepared with the following steps:
+Prerequisites:
+
+- `kuma-dp`, `envoy`, and `coredns` must run on the worker node -- that is, the node that runs your service mesh workload.
+- `coredns` must be in the PATH so that `kuma-dp` can access it.
+    - You can also set the location with the `--dns-coredns-path` flag to `kuma-dp`.
+
+Kuma comes with [`kumactl` executable](../documentation/cli/#kumactl) which can help us to prepare the host. Due to the wide variety of Linux setup options, these steps may vary and may need to be adjusted for the specifics of the particular deployment.
+The host that will run the `kuma-dp` process in transparent proxying mode needs to be prepared with the following steps executed as `root`:
 
  1. Create a new dedicated user on the machine.
- 2. Redirect all the relevant inbound and outbound traffic to the Kuma data plane proxy.
- 3. Point the DNS resolving for `.mesh` to the `kuma-cp` embedded DNS server.
-
-Kuma comes with [`kumactl` executable](../documentation/cli/#kumactl) which can help us preparing the host. Due to the wide variety of Linux setup options, these steps may vary and may need to be adjusted for the specifics of the particular deployment. However, the common steps would be to execute the following commands as `root`:
-
+ 
 ```sh
-# create a dedicated user called kuma-dp-user
 useradd -U kuma-dp
-
-# use kumactl
-kumactl install transparent-proxy \
-          --kuma-dp-user kuma-dp \
-          --kuma-cp-ip <kuma-cp IP>
 ```
 
-Where `kuma-dp-user` is the name of the dedicated user that will be used to run the `kuma-dp` process and `<kuma-cp IP>` is the IP address of the Kuma control plane (`kuma-cp`). 
+ 2. Redirect all the relevant inbound, outbound and DNS traffic to the Kuma data plane proxy.
+```sh
+kumactl install transparent-proxy \
+  --kuma-dp-user kuma-dp \
+  --skip-resolv-conf \
+  --redirect-dns
+```
 
 :::warning
-Please note that this command **will change** both the host `iptables` rules as well as modify `/etc/resolv.conf`, while keeping a backup copy of the original file.
+Please note that this command **will change** the host `iptables` rules.
 :::
 
-The command has several other options which allow to change the default inbound and outbound redirect ports, add ports for exclusion and also disable the iptables or `resolve.conf` modification steps. The command's help has enumerated and documented the available options.
-
-::: tip
-The default settings will exclude the SSH port `22` from the redirection, thus allowing the remote access to the host to be preserved. If the host is set up to use other remote management mechanisms, use `--exclude-inbound-ports` to provide a comma separated list of the TCP ports that will be excluded from the redirection.
-:::
-
-The changes will persist over restarts, so this command is needed only once. Reverting back to the original state of the host can be done by issuing `kumactl uninstall transparent-proxy`.
-
-### `firewalld` support
-
-If you run `firewalld` to manage firewalls and wrap iptables, add the `--store-firewalld` flag to `kumactl install transparent-proxy`. This persists the relevant rules across host restarts. The changes are stored in `/etc/firewalld/direct.xml`. There is no uninstall command for this feature.
-
-### Upgrades
-
-Before upgrading to the next version of Kuma, make sure to run `kumactl uninstall transparent-proxy` and only then replace the `kumactl` binary.
-This will ensure smooth upgrade and no leftovers from the previous installations.
+The changes will persist over restarts, so this command is needed only once. Reverting to the original state of the host can be done by issuing `kumactl uninstall transparent-proxy`.
 
 ### Data plane proxy resource
 
-In transparent proxying mode, the `Dataplane` resource that will be should ommit the `networking.outbound` section and use `networking.transparentProxying`section instead.
+In transparent proxying mode, the `Dataplane` resource should omit the `networking.outbound` section and use `networking.transparentProxying` section instead.
 
 ```yaml
 type: Dataplane
@@ -94,45 +85,33 @@ When starting `kuma-dp` with a script or some other automation instead, we can u
 ```sh
 runuser -u kuma-dp -- \
   /usr/bin/kuma-dp run \
-    --cp-address=https://172.19.0.2:5678 \
+    --cp-address=https://<IP or hostname of CP>:5678 \
     --dataplane-token-file=/kuma/token-demo \
     --dataplane-file=/kuma/dpyaml-demo \
     --dataplane-var name=dp-demo \
-    --dataplane-var address=172.19.0.4 \
-    --dataplane-var port=80  \
+    --dataplane-var address=<IP of VM> \
+    --dataplane-var port=<Port of the service>  \
     --binary-path /usr/local/bin/envoy
 ```
 
-## Transparent Proxying
+You can now reach the service on the same IP and port as before installing transparent proxy, but now the traffic goes through Envoy.
+At the same time, you can now connect to services using [Kuma DNS](../dns).
 
-There are two ways of how the service can interact with its sidecar to connect to other services.
+### firewalld support
 
-One is explicitly defining outbounds in the Dataplane:
+If you run `firewalld` to manage firewalls and wrap iptables, add the `--store-firewalld` flag to `kumactl install transparent-proxy`. This persists the relevant rules across host restarts. The changes are stored in `/etc/firewalld/direct.xml`. There is no uninstall command for this feature.
 
-```yaml
-type: Dataplane
-...
-networking:
-  ...
-  outbound:
-  - port: 10000
-    tags:
-      kuma.io/service: backend
-```
+### Upgrades
 
-This approach is simple, but it has the disadvantage that you need to reconfigure the service to use `http://localhost:10000` when it wants to connect with service `backend`.
-This strategy is used on Universal deployments.
+Before upgrading to the next version of Kuma, make sure to run `kumactl uninstall transparent-proxy` and only then replace the `kumactl` binary.
+This will ensure smooth upgrade and no leftovers from the previous installations.
 
-The alternative approach is Transparent Proxying. With Transparent Proxying before we start a service, we apply [`iptables`](https://linux.die.net/man/8/iptables) that intercept all the traffic on VM/Pod and redirect it to Envoy.
-The main advantage of this mode is when you integrate with the current hostname resolving mechanism, you can deploy Service Mesh _transparently_ on the platform without reconfiguring applications.
+## Configuration
 
-Kuma provides support for transparent proxying on both Universal and Kubernetes.
-
-### Configure intercepted traffic
+### Intercepted traffic
 
 :::: tabs :options="{ useUrlFragment: false }"
 ::: tab "Kubernetes"
-Kuma deploys `iptables` rules either with `kuma-init` Init Container or with `cni` when deployed with CNI mode.
 
 By default, all the traffic is intercepted by Envoy. You can exclude which ports are intercepted by Envoy with the following annotations placed on the Pod
 ```yaml
@@ -155,29 +134,65 @@ spec:
       containers:
         ...
 ```  
-:::
 
-You can also control this value on whole Kuma deployment with the following Kuma CP configuration
-```sh
+You can also control this value on whole Kuma deployment with the following Kuma CP [configuration](../documentation/configuration)
+```
 KUMA_RUNTIME_KUBERNETES_SIDECAR_TRAFFIC_EXCLUDE_INBOUND_PORTS=1234
 KUMA_RUNTIME_KUBERNETES_SIDECAR_TRAFFIC_EXCLUDE_OUTBOUND_PORTS=5678,8900
-``` 
-
-Global settings can be always overridden with annotations on the individual Pods. 
-
-::: tip
-When deploying Kuma with `kumactl install control-plane` you can set those settings with
-```sh
-kumactl install control-plane \
-  --env-var KUMA_RUNTIME_KUBERNETES_SIDECAR_TRAFFIC_EXCLUDE_INBOUND_PORTS=1234
-  --env-var KUMA_RUNTIME_KUBERNETES_SIDECAR_TRAFFIC_EXCLUDE_OUTBOUND_PORTS=5678,8900
 ```
 
-When deploying Kuma with HELM, use `controlPlane.envVar` value
+:::
+::: tab "Universal"
+The default settings will exclude the SSH port `22` from the redirection, thus allowing the remote access to the host to be preserved.
+If the host is set up to use other remote management mechanisms, use `--exclude-inbound-ports` to provide a comma separated list of the TCP ports that will be excluded from the redirection.
+
+Execute `kumactl install transparent-proxy --help` to see available options.
+::::
+
+### Reachable Services
+
+By default, every data plane proxy in the mesh follows every other data plane proxy.
+This may lead to a performance problems in larger deployments of the mesh.
+It is highly recommended to define a list of services that your service connects to.
+
+:::: tabs :options="{ useUrlFragment: false }"
+::: tab "Kubernetes"
 ```yaml
-envVar:
-  KUMA_RUNTIME_KUBERNETES_SIDECAR_TRAFFIC_EXCLUDE_INBOUND_PORTS: "1234"
-  KUMA_RUNTIME_KUBERNETES_SIDECAR_TRAFFIC_EXCLUDE_OUTBOUND_PORTS=5678,8900
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-app
+  namespace: kuma-example
+spec:
+  ...
+  template:
+    metadata:
+      ...
+      annotations:
+        # a comma separated list of kuma.io/service values
+        kuma.io/transparent-proxying-reachable-services: "redis_kuma-demo_svc_6379,elastic_kuma-demo_svc_9200"
+    spec:
+      containers:
+        ...
+```
+:::
+::: tab "Universal"
+```yaml
+type: Dataplane
+mesh: default
+name: {{ name }}
+networking:
+  address: {{ address }}
+  inbound:
+  - port: {{ port }}
+    tags:
+      kuma.io/service: demo-client
+  transparentProxying:
+    redirectPortInbound: 15006
+    redirectPortOutbound: 15001
+    reachableServices:
+      - redis_kuma-demo_svc_6379
+      - elastic_kuma-demo_svc_9200 
 ```
 :::
 ::::

--- a/docs/docs/dev/sidebar.json
+++ b/docs/docs/dev/sidebar.json
@@ -67,6 +67,7 @@
       "networking/networking",
       "networking/service-discovery",
       "networking/dns",
+      "networking/dns-cp",
       "networking/cni",
       "networking/transparent-proxying",
       "networking/ipv6"


### PR DESCRIPTION
* Assume across the networking docs that DNS in dp is the default
* Extract DNS in the CP to the separate doc with warning about deprecation
* Remove duplication of setup instructions between DNS and Transparent Proxying page
* Add reachable services