### PR TITLE
docs(*): add link to the YT playlist

### DIFF
--- a/docs/.vuepress/theme/components/custom/Community.vue
+++ b/docs/.vuepress/theme/components/custom/Community.vue
@@ -49,6 +49,18 @@
             <Content slot-key="card-3-title"/>
           </template>
           <Content slot-key="card-3-content"/>
+          <ul class="inline-list">
+            <li>
+              <a href="https://tny.sh/NXs6EVO" target="_blank">
+                <span class="icon">📝</span>  Agenda
+              </a>
+            </li>
+            <li>
+              <a href="https://www.youtube.com/playlist?list=PLg_AhYkg50viOMrea6Nm3t9JCempVyLcj" target="_blank">
+                <span class="icon">🎥</span> Past Recordings
+              </a>
+            </li>
+          </ul>
           <div class="community-form">
             <CommunityCallForm />
           </div>
@@ -96,5 +108,32 @@ export default {
   margin-top: 20px;
   padding-top: 20px;
   border-top: 1px solid #ccc;
+}
+
+.inline-list {
+  display: block;
+  overflow: hidden;
+  list-style: none;
+  margin: 10px 0 0 0 !important;
+  padding: 0;
+
+  li {
+    display: inline-block;
+
+  &:not(:last-of-type) {
+     border-right: 1px solid #ccc;
+     margin-right: 8px;
+     padding-right: 10px;
+   }
+  }
+
+  a {
+    display: block;
+  }
+
+  .icon {
+    display: inline-block;
+    margin: 0 5px 0 0;
+  }
 }
 </style>

--- a/docs/.vuepress/theme/global-components/CommunityCallForm.vue
+++ b/docs/.vuepress/theme/global-components/CommunityCallForm.vue
@@ -50,18 +50,8 @@
       </p>
       <ul class="inline-list">
         <li>
-          <a :href="agenda" target="_blank">
-            <span class="icon">📝</span>  Agenda
-          </a>
-        </li>
-        <li>
           <a :href="invite" target="_blank">
             <span class="icon">📅</span> Add to Your Calendar
-          </a>
-        </li>
-        <li>
-          <a href="https://www.youtube.com/playlist?list=PLg_AhYkg50viOMrea6Nm3t9JCempVyLcj" target="_blank">
-            <span class="icon">🎥</span> Past Recordings
           </a>
         </li>
       </ul>
@@ -128,7 +118,6 @@ export default {
   computed: {
     ...mapGetters({
       formEndpoint: 'getCommunityCallFormEndpoint',
-      agenda: 'getCommunityCallAgendaUrl',
       invite: 'getCommunityCallInvite'
     })
   },

--- a/docs/.vuepress/theme/store/index.js
+++ b/docs/.vuepress/theme/store/index.js
@@ -11,7 +11,6 @@ export default (releases, latestRelease, installMethods) => new Vuex.Store({
     installMethods: installMethods,
     requestADemoEndpoint:
       'https://script.google.com/macros/s/AKfycbwiFfaiSK6JqdNqZLAt5PRayPV43x7qw1ZAM_-sFSDg6IT44d4/exec' /** not currently in use */,
-    communityCallAgendaUrl: 'https://tny.sh/NXs6EVO',
     communityCallInvite:
       'https://calendar.google.com/calendar?cid=a29uZ2hxLmNvbV8xbWE5NnNzZGdnZmg5ZnJyY3M5N2VwdTM4b0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t'
   },
@@ -49,7 +48,6 @@ export default (releases, latestRelease, installMethods) => new Vuex.Store({
     },
 
     /** community call */
-    getCommunityCallAgendaUrl: (state) => state.communityCallAgendaUrl,
     getCommunityCallInvite: (state) => state.communityCallInvite,
 
     /** version releases as vue-router links */

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -50,6 +50,7 @@ can discuss and ask questions in real-time. If you have already joined, go direc
 ::: slot card-3-content
 Kuma hosts official monthly community calls where users and contributors can
 discuss topics and demonstrate use-cases. Interested? You can register below for the next Community Call.
+All recordings are available [Kuma Community Calls](https://www.youtube.com/playlist?list=PLg_AhYkg50viOMrea6Nm3t9JCempVyLcj).
 :::
 
 <!-- card 4 -->

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -50,7 +50,6 @@ can discuss and ask questions in real-time. If you have already joined, go direc
 ::: slot card-3-content
 Kuma hosts official monthly community calls where users and contributors can
 discuss topics and demonstrate use-cases. Interested? You can register below for the next Community Call.
-All recordings are available [Kuma Community Calls](https://www.youtube.com/playlist?list=PLg_AhYkg50viOMrea6Nm3t9JCempVyLcj).
 :::
 
 <!-- card 4 -->


### PR DESCRIPTION
We publish recordings of the Kuma Community Calls, but we don't have a link publicly available. This PR adds the link to the playlist on website:

![image](https://user-images.githubusercontent.com/12110261/153158255-824af524-270a-4673-8e4a-77ad6b29ba18.png)
