### PR TITLE
fix(refDoc): ensure both namespace of pod options are documented

### DIFF
--- a/docs/docs/1.4.x/documentation/dps-and-data-model.md
+++ b/docs/docs/1.4.x/documentation/dps-and-data-model.md
@@ -238,7 +238,7 @@ spec:
   template:
     metadata:
       ...
-      annotations:
+      labels:
         # indicate to Kuma that this Pod doesn't need a sidecar
         kuma.io/sidecar-injection: disabled
     spec:
@@ -248,8 +248,10 @@ spec:
 
 On Kubernetes the [`Dataplane`](#dataplane-entity) entity is also automatically created for you, and because transparent proxying is being used to communicate between the service and the sidecar proxy, no code changes are required in your applications.
 
+::: warning
 While you can still use annotations instead of labels, we strongly recommend using labels.
-It's the only way to guarantee that application can only be started with sidecar.
+It's the only way to guarantee that applications can only be started with sidecar.
+:::
 
 ::: tip
 NOTE: During the creation of the [`Dataplane`](#dataplane-entity) entity, the Kuma control plane will generate a dataplane tag `kuma.io/service: <name>_<namespace>_svc_<port>` fetching `<name>`, `<namespace>` and `<port>` from the Kubernetes service that is associated with the particular pod.

--- a/docs/docs/1.4.x/documentation/fine-tuning.md
+++ b/docs/docs/1.4.x/documentation/fine-tuning.md
@@ -32,7 +32,7 @@ The main task of the control plane is to provide config for dataplanes. When a d
 This goroutine runs the reconciliation process with given interval (1s by default). During this process, all dataplanes and policies are fetched for matching.
 When matching is done, the Envoy config (including policies and available endpoints of services) for given dataplane is generated and sent only if there is an actual change.
 
-* `KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL` : interval for re-genarting configuration for Dataplanes connected to the Control Plane (default: 1s)
+* `KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL` : interval for re-generating configuration for Dataplanes connected to the Control Plane (default: 1s)
 
 This process can be CPU intensive with high number of dataplanes therefore you can control the interval time for a single dataplane.
 You can lower the interval scarifying the latency of the new config propagation to avoid overloading the CP. For example,

--- a/docs/docs/1.4.x/documentation/kubernetes-annotations.md
+++ b/docs/docs/1.4.x/documentation/kubernetes-annotations.md
@@ -6,9 +6,11 @@ This page provide a complete list of all the annotations you can specify when yo
 
 ### `kuma.io/sidecar-injection`
 
-Lets you enable or disable sidecar injection.
+Enable or disable sidecar injection.
 
 **Example**
+
+Used on the namespace it will inject the sidecar in all pods created in the namespace:
 
 ```yaml
 apiVersion: v1
@@ -20,14 +22,44 @@ metadata:
 [...]
 ```
 
+Used on a deployment using pod template it will inject the sidecar in all pods managed by this deployment:
+
+```yaml
+apiVersion: v1
+king: Deployment
+metadata:
+  name: my-deployment
+spec:
+  template:
+    metadata:
+      labels:
+        kuma.io/sidecar-injection: enabled
+[...]
+```
+
+Labeling pods or deployments will take precedence on the namespace annotation.
+
 ## Annotations
 
 ### `kuma.io/mesh`
 
-Associates a given Pod with a particular Mesh. Annotation value must be the name of a Mesh resource.
+Associate Pods with a particular Mesh. Annotation value must be the name of a Mesh resource.
 
 **Example**
 
+It can be used on an entire namespace:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+ name: default
+ labels:
+   kuma.io/mesh: default
+[...]
+```
+
+It can be used on a pod:
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -38,9 +70,11 @@ metadata:
 [...]
 ```
 
+Annotating pods or deployments will take precedence on the namespace annotation.
+
 ### `kuma.io/sidecar-injection`
 
-Lets you enable or disable sidecar injection.
+Similar to the prefered [label](#kuma-io-sidecar-injection).
 
 **Example**
 
@@ -54,8 +88,10 @@ metadata:
 [...]
 ```
 
-While you can still use annotation to inject sidecar, we strongly recommend using labels.
+:::warning
+While you can still use annotations to inject sidecar, we strongly recommend using labels.
 It's the only way to guarantee that application can only be started with sidecar.
+:::
 
 ### `kuma.io/gateway`
 

--- a/docs/docs/dev/documentation/dps-and-data-model.md
+++ b/docs/docs/dev/documentation/dps-and-data-model.md
@@ -238,7 +238,7 @@ spec:
   template:
     metadata:
       ...
-      annotations:
+      labels:
         # indicate to Kuma that this Pod doesn't need a sidecar
         kuma.io/sidecar-injection: disabled
     spec:
@@ -248,8 +248,10 @@ spec:
 
 On Kubernetes the [`Dataplane`](#dataplane-entity) entity is also automatically created for you, and because transparent proxying is being used to communicate between the service and the sidecar proxy, no code changes are required in your applications.
 
+::: warning
 While you can still use annotations instead of labels, we strongly recommend using labels.
-It's the only way to guarantee that application can only be started with sidecar.
+It's the only way to guarantee that applications can only be started with sidecar.
+:::
 
 ::: tip
 NOTE: During the creation of the [`Dataplane`](#dataplane-entity) entity, the Kuma control plane will generate a dataplane tag `kuma.io/service: <name>_<namespace>_svc_<port>` fetching `<name>`, `<namespace>` and `<port>` from the Kubernetes service that is associated with the particular pod.

--- a/docs/docs/dev/documentation/fine-tuning.md
+++ b/docs/docs/dev/documentation/fine-tuning.md
@@ -32,7 +32,7 @@ The main task of the control plane is to provide config for dataplanes. When a d
 This goroutine runs the reconciliation process with given interval (1s by default). During this process, all dataplanes and policies are fetched for matching.
 When matching is done, the Envoy config (including policies and available endpoints of services) for given dataplane is generated and sent only if there is an actual change.
 
-* `KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL` : interval for re-genarting configuration for Dataplanes connected to the Control Plane (default: 1s)
+* `KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL` : interval for re-generating configuration for Dataplanes connected to the Control Plane (default: 1s)
 
 This process can be CPU intensive with high number of dataplanes therefore you can control the interval time for a single dataplane.
 You can lower the interval scarifying the latency of the new config propagation to avoid overloading the CP. For example,

--- a/docs/docs/dev/documentation/kubernetes-annotations.md
+++ b/docs/docs/dev/documentation/kubernetes-annotations.md
@@ -6,9 +6,11 @@ This page provide a complete list of all the annotations you can specify when yo
 
 ### `kuma.io/sidecar-injection`
 
-Lets you enable or disable sidecar injection.
+Enable or disable sidecar injection.
 
 **Example**
+
+Used on the namespace it will inject the sidecar in all pods created in the namespace:
 
 ```yaml
 apiVersion: v1
@@ -20,14 +22,44 @@ metadata:
 [...]
 ```
 
+Used on a deployment using pod template it will inject the sidecar in all pods managed by this deployment:
+
+```yaml
+apiVersion: v1
+king: Deployment
+metadata:
+  name: my-deployment
+spec:
+  template:
+    metadata:
+      labels:
+        kuma.io/sidecar-injection: enabled
+[...]
+```
+
+Labeling pods or deployments will take precedence on the namespace annotation.
+
 ## Annotations
 
 ### `kuma.io/mesh`
 
-Associates a given Pod with a particular Mesh. Annotation value must be the name of a Mesh resource.
+Associate Pods with a particular Mesh. Annotation value must be the name of a Mesh resource.
 
 **Example**
 
+It can be used on an entire namespace:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+ name: default
+ labels:
+   kuma.io/mesh: default
+[...]
+```
+
+It can be used on a pod:
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -38,9 +70,11 @@ metadata:
 [...]
 ```
 
+Annotating pods or deployments will take precedence on the namespace annotation.
+
 ### `kuma.io/sidecar-injection`
 
-Lets you enable or disable sidecar injection.
+Similar to the prefered [label](#kuma-io-sidecar-injection).
 
 **Example**
 
@@ -54,8 +88,10 @@ metadata:
 [...]
 ```
 
-While you can still use annotation to inject sidecar, we strongly recommend using labels.
+:::warning
+While you can still use annotations to inject sidecar, we strongly recommend using labels.
 It's the only way to guarantee that application can only be started with sidecar.
+:::
 
 ### `kuma.io/gateway`
 


### PR DESCRIPTION
Some labels/annotations can work either on namespace or pods.
This should be documented

Also correct 2 minor typos

Signed-off-by: Charly Molter <charly.molter@konghq.com>