### PR TITLE
docs(kuma-cp): update tokens HTTP API endpoint

### DIFF
--- a/docs/docs/dev/documentation/http-api.md
+++ b/docs/docs/dev/documentation/http-api.md
@@ -54,7 +54,9 @@ By default the API Server is listening on port `5681` (HTTP) and on `5682` (HTTP
 * `/meshes/{mesh}/secrets`
 * `/meshes/{mesh}/secrets/{name}`
 * `/status/zones`
-* `/tokens`
+* `/tokens/dataplane`
+* `/tokens/zone-ingress`
+* `/tokens/zone`
 * `/zones`
 * `/zones/{name}`
 * `/zones+insights`
@@ -3233,7 +3235,7 @@ For details, see [data plane proxy authentication](../security/certificates/#dat
 
 ### Generate dataplane proxy token
 
-Request: `PUT /tokens` with the following body:
+Request: `PUT /tokens/dataplane` with the following body:
 ```json
 {
   "name": "dp-echo-1",

--- a/docs/docs/dev/documentation/http-api.md
+++ b/docs/docs/dev/documentation/http-api.md
@@ -56,7 +56,6 @@ By default the API Server is listening on port `5681` (HTTP) and on `5682` (HTTP
 * `/status/zones`
 * `/tokens/dataplane`
 * `/tokens/zone-ingress`
-* `/tokens/zone`
 * `/zones`
 * `/zones/{name}`
 * `/zones+insights`

--- a/docs/docs/dev/documentation/http-api.md
+++ b/docs/docs/dev/documentation/http-api.md
@@ -3253,7 +3253,7 @@ Example:
 curl -XPOST \ 
   -H "Content-Type: application/json" \
   --data '{"name": "dp-echo-1", "mesh": "default", "tags": {"kuma.io/service": ["backend", "backend-admin"]}}' \
-  http://localhost:5681/tokens
+  http://localhost:5681/tokens/dataplane
 ```
 
 ## Global Insights

--- a/docs/docs/dev/documentation/http-api.md
+++ b/docs/docs/dev/documentation/http-api.md
@@ -3255,6 +3255,26 @@ curl -XPOST \
   http://localhost:5681/tokens/dataplane
 ```
 
+## Zone Ingress Tokens
+
+Generate token which zone ingress can use to authenticate itself.
+
+::: warning
+Requires [authentication to the control plane by the user](../security/certificates/#authentication).
+:::
+
+For details, see [zone ingress authentication](../security/zone-ingress-auth/#zone-ingress-token).
+
+### Generate Zone Ingress Token
+
+Example:
+```bash
+curl -XPOST \
+  -H "Content-Type: application/json" \
+  --data '{"zone": "us-east", "validFor": "720h"}' \
+  http://localhost:5681/tokens/zone-ingress
+```
+
 ## Global Insights
 
 ### Get Global Insights


### PR DESCRIPTION
Signed-off-by: Paul Parkanzky <paul.parkanzky@konghq.com>

Updated HTTP API reference with new `/tokens/dataplane` endpoint. In the code, it calls the same backend as the older `/tokens` endpoint, so I believe that ref is good.

Under `/tokens` path there is also `/zone` and `/zone-ingress`. I added them to the top level list, but they don't have an existing paragraph later in the doc. May need to collect more info on how those are used.