### PR TITLE
fix(kubernetes-annotations): kuma.io/mesh is an annotation not a label

### DIFF
--- a/docs/docs/1.4.x/documentation/kubernetes-annotations.md
+++ b/docs/docs/1.4.x/documentation/kubernetes-annotations.md
@@ -54,7 +54,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
  name: default
- labels:
+ annotations:
    kuma.io/mesh: default
 [...]
 ```

--- a/docs/docs/dev/documentation/kubernetes-annotations.md
+++ b/docs/docs/dev/documentation/kubernetes-annotations.md
@@ -54,7 +54,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
  name: default
- labels:
+ annotations:
    kuma.io/mesh: default
 [...]
 ```


### PR DESCRIPTION
## Summary

`kuma.io/mesh` only works as an annotation, bug from https://github.com/kumahq/kuma-website/pull/678
