### PR TITLE
Changed traffic-permission to trafficpermission typo for kubectl

### DIFF
--- a/docs/docs/1.5.x/quickstart/kubernetes.md
+++ b/docs/docs/1.5.x/quickstart/kubernetes.md
@@ -168,7 +168,7 @@ By default, a very permissive traffic permission is created.
 For the sake of this demo we will delete it:
 
 ```sh
-kubectl delete traffic-permission allow-all-default
+kubectl delete trafficpermission allow-all-default
 ```
 
 You can try to make requests to the demo application at [`127.0.0.1:5000/`](http://127.0.0.1:5000/) and you will notice that they will **not** work.

--- a/docs/docs/dev/quickstart/kubernetes.md
+++ b/docs/docs/dev/quickstart/kubernetes.md
@@ -168,7 +168,7 @@ By default, a very permissive traffic permission is created.
 For the sake of this demo we will delete it:
 
 ```sh
-kubectl delete traffic-permission allow-all-default
+kubectl delete trafficpermission allow-all-default
 ```
 
 You can try to make requests to the demo application at [`127.0.0.1:5000/`](http://127.0.0.1:5000/) and you will notice that they will **not** work.


### PR DESCRIPTION
Based on the instruction, I wasn't able to remove `TrafficPermissions`on K8s because it had `-` in between the words. It works for `kumactl` but for `kubectl` it isn't the correct value. 

