### PR TITLE
fix: improve doc gen to work with branches

### DIFF
--- a/.github/workflows/sync-generated.yml
+++ b/.github/workflows/sync-generated.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           repository: kumahq/kuma
           path: kuma
+          fetch-depth: '0' # Checkout all branches
       - name: "Clone docs"
         uses: actions/checkout@v2
         with:

--- a/sync_generated.sh
+++ b/sync_generated.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 for i in docs/docs/*; do
   if [[ ! -d $i ]]; then continue; fi
 


### PR DESCRIPTION
We were not doing a deep checkout of Kuma which resulted in the job
not checking out new branches

Signed-off-by: Charly Molter <charly.molter@konghq.com>