### PR TITLE
Add minimum Helm version to documentation

### DIFF
--- a/docs/docs/1.6.x/installation/helm.md
+++ b/docs/docs/1.6.x/installation/helm.md
@@ -8,6 +8,8 @@ To install and run Kuma on Kubernetes with Helm charts execute the following ste
 
 Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and continue your Kuma journey.
 
+Please note that at least version 3.8.0 of Helm is required to use the Kuma Helm charts. If you are using an older version of Helm, please upgrade to version 3.8.0 first.
+
 ::: tip
 Kuma also provides an alternative [Kubernetes distribution](../installation/kubernetes/) that we can use instead of Helm charts.
 :::

--- a/docs/docs/dev/installation/helm.md
+++ b/docs/docs/dev/installation/helm.md
@@ -8,6 +8,8 @@ To install and run Kuma on Kubernetes with Helm charts execute the following ste
 
 Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and continue your Kuma journey.
 
+Please note that at least version 3.8.0 of Helm is required to use the Kuma Helm charts. If you are using an older version of Helm, please upgrade to version 3.8.0 first.
+
 ::: tip
 Kuma also provides an alternative [Kubernetes distribution](../installation/kubernetes/) that we can use instead of Helm charts.
 :::


### PR DESCRIPTION
This PR modifies the Helm installation instructions to note that at least version 3.8.0 is required to use the Helm charts. This change was made only for the 1.6.x version of the documentation.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?

Yes
