### PR TITLE
feat(installer.sh): download kumactl if the Linux distribution doesn't have an archive

### DIFF
--- a/docs/.vuepress/public/installer.sh
+++ b/docs/.vuepress/public/installer.sh
@@ -24,9 +24,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 : "${ARCH:=amd64}"
 
 PRODUCT_NAME=Kuma
-CTL_NAME=kumactl
 LATEST_VERSION=https://kuma.io/latest_version
 REPO_PREFIX=kuma
+CTL_NAME=kumactl
 
 printf "\n"
 printf "INFO\tWelcome to the $PRODUCT_NAME automated download!\n"
@@ -91,10 +91,13 @@ fi
 URL="https://download.konghq.com/mesh-alpine/$REPO_PREFIX-$VERSION-$DISTRO-$ARCH.tar.gz"
 
 if ! curl -s --head "$URL" | head -n 1 | grep -E 'HTTP/1.1 [23]..|HTTP/2 [23]..' > /dev/null; then
-  if [ "$OS" = "Linux" ]; then
+  IFS=. read -r major minor patch <<< "${VERSION}"
+
+  # handle the kumactl archive
+  if [ "$OS" = "Linux" ] && [ "$major" -ge "1" ] && [ "$minor" -ge "7" ]; then
       printf "INFO\tWe don't compile the $PRODUCT_NAME executables for your Linux distribution.\n"
       printf "INFO\tFetching $CTL_NAME...\n"
-      URL="https://download.konghq.com/mesh-alpine/$REPO_PREFIX-$VERSION-linux-$ARCH.tar.gz"
+      URL="https://download.konghq.com/mesh-alpine/$REPO_PREFIX-$CTL_NAME-$VERSION-linux-$ARCH.tar.gz"
       if ! curl -s --head "$URL" | head -n 1 | grep -E 'HTTP/1.1 [23]..|HTTP/2 [23]..' > /dev/null; then
         printf "ERROR\tUnable to download $CTL_NAME at the following URL: %s\n" "$URL"
         exit 1

--- a/docs/.vuepress/public/installer.sh
+++ b/docs/.vuepress/public/installer.sh
@@ -24,6 +24,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 : "${ARCH:=amd64}"
 
 PRODUCT_NAME=Kuma
+CTL_NAME=kumactl
 LATEST_VERSION=https://kuma.io/latest_version
 REPO_PREFIX=kuma
 
@@ -91,7 +92,13 @@ URL="https://download.konghq.com/mesh-alpine/$REPO_PREFIX-$VERSION-$DISTRO-$ARCH
 
 if ! curl -s --head "$URL" | head -n 1 | grep -E 'HTTP/1.1 [23]..|HTTP/2 [23]..' > /dev/null; then
   if [ "$OS" = "Linux" ]; then
-      printf "WARNING\tYou appear to be running an unsupported Linux distribution.\n"
+      printf "INFO\tWe don't compile the $PRODUCT_NAME executables for your Linux distribution.\n"
+      printf "INFO\tFetching $CTL_NAME...\n"
+      URL="https://download.konghq.com/mesh-alpine/$REPO_PREFIX-$VERSION-linux-$ARCH.tar.gz"
+      if ! curl -s --head "$URL" | head -n 1 | grep -E 'HTTP/1.1 [23]..|HTTP/2 [23]..' > /dev/null; then
+        printf "ERROR\tUnable to download $CTL_NAME at the following URL: %s\n" "$URL"
+        exit 1
+      fi
   fi
   printf "ERROR\tUnable to download $PRODUCT_NAME at the following URL: %s\n" "$URL"
   exit 1

--- a/docs/.vuepress/public/installer.sh
+++ b/docs/.vuepress/public/installer.sh
@@ -94,13 +94,17 @@ if ! curl -s --head "$URL" | head -n 1 | grep -E 'HTTP/1.1 [23]..|HTTP/2 [23]..'
   IFS=. read -r major minor patch <<< "${VERSION}"
 
   # handle the kumactl archive
-  if [ "$OS" = "Linux" ] && [ "$major" -ge "1" ] && [ "$minor" -ge "7" ]; then
-      printf "INFO\tWe don't compile the $PRODUCT_NAME executables for your Linux distribution.\n"
-      printf "INFO\tFetching $CTL_NAME...\n"
-      URL="https://download.konghq.com/mesh-alpine/$REPO_PREFIX-$CTL_NAME-$VERSION-linux-$ARCH.tar.gz"
-      if ! curl -s --head "$URL" | head -n 1 | grep -E 'HTTP/1.1 [23]..|HTTP/2 [23]..' > /dev/null; then
-        printf "ERROR\tUnable to download $CTL_NAME at the following URL: %s\n" "$URL"
-        exit 1
+  if [ "$OS" = "Linux" ]; then
+      if  [ "$major" -ge "1" ] && [ "$minor" -ge "7" ]; then
+          printf "INFO\tWe don't compile the $PRODUCT_NAME executables for your Linux distribution.\n"
+          printf "INFO\tFetching $CTL_NAME...\n"
+          URL="https://download.konghq.com/mesh-alpine/$REPO_PREFIX-$CTL_NAME-$VERSION-linux-$ARCH.tar.gz"
+          if ! curl -s --head "$URL" | head -n 1 | grep -E 'HTTP/1.1 [23]..|HTTP/2 [23]..' > /dev/null; then
+            printf "ERROR\tUnable to download $CTL_NAME at the following URL: %s\n" "$URL"
+            exit 1
+          fi
+      else
+        printf "WARNING\tYou appear to be running an unsupported Linux distribution.\n"
       fi
   fi
   printf "ERROR\tUnable to download $PRODUCT_NAME at the following URL: %s\n" "$URL"


### PR DESCRIPTION
### Summary

See https://github.com/kumahq/kuma/issues/3814 and https://github.com/kumahq/kuma/pull/4167.

This will only attempt the download if the version is at least `1.7.0`, which is the first release when the above PRs will run.