### PR TITLE
Limit chunk count to prevent Netlify rate limiting

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -412,7 +412,10 @@ Sitemap: https://kuma.io/sitemap.xml
   configureWebpack: (config) => {
     return {
       plugins: [
-        new webpack.EnvironmentPlugin({...process.env})
+        new webpack.EnvironmentPlugin({...process.env}),
+        new webpack.optimize.LimitChunkCountPlugin({
+          maxChunks: 20
+        })
       ]
     }
   },


### PR DESCRIPTION
We're seeing 429 error from Netlify, likely due to the number of chunks. This PR limits the number of generated chunks using Webpack