### PR TITLE
fix: make symlink to kumactl absolute, otherwise it does not work

### DIFF
--- a/docs/_snippets/install_kumactl.md
+++ b/docs/_snippets/install_kumactl.md
@@ -34,5 +34,5 @@ So we enter the `bin` folder by executing: `cd kuma-{{ $page.latestVersion }}/bi
 We suggest adding the `kumactl` executable to your `PATH` (by executing: `PATH=$(pwd):$PATH`) so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```

--- a/docs/_snippets/install_os.md
+++ b/docs/_snippets/install_os.md
@@ -33,7 +33,7 @@ This example will run Kuma in `standalone` mode for a "flat" deployment, but the
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.1.x/installation/amazonlinux.md
+++ b/docs/docs/1.1.x/installation/amazonlinux.md
@@ -67,7 +67,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.1.6/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.1.x/installation/centos.md
+++ b/docs/docs/1.1.x/installation/centos.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.1.6/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.1.x/installation/debian.md
+++ b/docs/docs/1.1.x/installation/debian.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.1.6/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.1.x/installation/eks.md
+++ b/docs/docs/1.1.x/installation/eks.md
@@ -89,7 +89,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.1.6/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.1.x/installation/kubernetes.md
+++ b/docs/docs/1.1.x/installation/kubernetes.md
@@ -89,7 +89,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.1.6/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.1.x/installation/macos.md
+++ b/docs/docs/1.1.x/installation/macos.md
@@ -84,7 +84,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.1.6/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.1.x/installation/openshift.md
+++ b/docs/docs/1.1.x/installation/openshift.md
@@ -58,7 +58,7 @@ cd kuma-1.1.6/bin
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 Finally we can install and run Kuma in either **standalone** or **multi-zone** mode:

--- a/docs/docs/1.1.x/installation/redhat.md
+++ b/docs/docs/1.1.x/installation/redhat.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.1.6/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.1.x/installation/ubuntu.md
+++ b/docs/docs/1.1.x/installation/ubuntu.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.1.6/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.2.x/installation/amazonlinux.md
+++ b/docs/docs/1.2.x/installation/amazonlinux.md
@@ -67,7 +67,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.2.3/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.2.x/installation/centos.md
+++ b/docs/docs/1.2.x/installation/centos.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.2.3/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.2.x/installation/debian.md
+++ b/docs/docs/1.2.x/installation/debian.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.2.3/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.2.x/installation/eks.md
+++ b/docs/docs/1.2.x/installation/eks.md
@@ -89,7 +89,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.2.3/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.2.x/installation/kubernetes.md
+++ b/docs/docs/1.2.x/installation/kubernetes.md
@@ -89,7 +89,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.2.3/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 It may take a while for Kubernetes to start the Kuma resources. You can run:

--- a/docs/docs/1.2.x/installation/macos.md
+++ b/docs/docs/1.2.x/installation/macos.md
@@ -84,7 +84,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.2.3/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.2.x/installation/openshift.md
+++ b/docs/docs/1.2.x/installation/openshift.md
@@ -58,7 +58,7 @@ cd kuma-1.2.3/bin
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 Finally we can install and run Kuma in either **standalone** or **multi-zone** mode:

--- a/docs/docs/1.2.x/installation/redhat.md
+++ b/docs/docs/1.2.x/installation/redhat.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.2.3/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.2.x/installation/ubuntu.md
+++ b/docs/docs/1.2.x/installation/ubuntu.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.2.3/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.3.x/installation/amazonlinux.md
+++ b/docs/docs/1.3.x/installation/amazonlinux.md
@@ -67,7 +67,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.3.1/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.3.x/installation/centos.md
+++ b/docs/docs/1.3.x/installation/centos.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.3.1/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.3.x/installation/debian.md
+++ b/docs/docs/1.3.x/installation/debian.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.3.1/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.3.x/installation/eks.md
+++ b/docs/docs/1.3.x/installation/eks.md
@@ -89,7 +89,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.3.1/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.3.x/installation/kubernetes.md
+++ b/docs/docs/1.3.x/installation/kubernetes.md
@@ -89,7 +89,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.3.1/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.3.x/installation/macos.md
+++ b/docs/docs/1.3.x/installation/macos.md
@@ -84,7 +84,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.3.1/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.3.x/installation/openshift.md
+++ b/docs/docs/1.3.x/installation/openshift.md
@@ -58,7 +58,7 @@ cd kuma-1.3.1/bin
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 Finally we can install and run Kuma in either **standalone** or **multi-zone** mode:

--- a/docs/docs/1.3.x/installation/redhat.md
+++ b/docs/docs/1.3.x/installation/redhat.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.3.1/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.3.x/installation/ubuntu.md
+++ b/docs/docs/1.3.x/installation/ubuntu.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](/docs/1.3.1/docum
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.4.x/installation/amazonlinux.md
+++ b/docs/docs/1.4.x/installation/amazonlinux.md
@@ -67,7 +67,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.4.x/installation/centos.md
+++ b/docs/docs/1.4.x/installation/centos.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.4.x/installation/debian.md
+++ b/docs/docs/1.4.x/installation/debian.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.4.x/installation/eks.md
+++ b/docs/docs/1.4.x/installation/eks.md
@@ -89,7 +89,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.4.x/installation/kubernetes.md
+++ b/docs/docs/1.4.x/installation/kubernetes.md
@@ -89,7 +89,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.4.x/installation/macos.md
+++ b/docs/docs/1.4.x/installation/macos.md
@@ -84,7 +84,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.4.x/installation/openshift.md
+++ b/docs/docs/1.4.x/installation/openshift.md
@@ -58,7 +58,7 @@ cd kuma-1.4.1/bin
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 Finally we can install and run Kuma in either **standalone** or **multi-zone** mode:

--- a/docs/docs/1.4.x/installation/redhat.md
+++ b/docs/docs/1.4.x/installation/redhat.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.4.x/installation/ubuntu.md
+++ b/docs/docs/1.4.x/installation/ubuntu.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.5.x/installation/amazonlinux.md
+++ b/docs/docs/1.5.x/installation/amazonlinux.md
@@ -66,7 +66,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.5.x/installation/centos.md
+++ b/docs/docs/1.5.x/installation/centos.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.5.x/installation/debian.md
+++ b/docs/docs/1.5.x/installation/debian.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.5.x/installation/eks.md
+++ b/docs/docs/1.5.x/installation/eks.md
@@ -89,7 +89,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.5.x/installation/kubernetes.md
+++ b/docs/docs/1.5.x/installation/kubernetes.md
@@ -89,7 +89,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.5.x/installation/macos.md
+++ b/docs/docs/1.5.x/installation/macos.md
@@ -84,7 +84,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.5.x/installation/openshift.md
+++ b/docs/docs/1.5.x/installation/openshift.md
@@ -58,7 +58,7 @@ cd kuma-*/bin
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 Finally we can install and run Kuma in either **standalone** or **multi-zone** mode:

--- a/docs/docs/1.5.x/installation/redhat.md
+++ b/docs/docs/1.5.x/installation/redhat.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip

--- a/docs/docs/1.5.x/installation/ubuntu.md
+++ b/docs/docs/1.5.x/installation/ubuntu.md
@@ -62,7 +62,7 @@ To learn more, read the [multi-zone installation instructions](../documentation/
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s ./kumactl /usr/local/bin/kumactl
+ln -s $PWD/kumactl /usr/local/bin/kumactl
 ```
 
 ::: tip


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

Symlinks in the current form don't work, if they are `relative` they are relative in respect to the target, so we are symlinking `/usr/local/bin/kumactl` to `./kumactl` which evaluates to `/usr/local/bin/kumactl` and that's why we get a “loop” of symlinks:

```bash
bash: /usr/local/bin/kumactl: Too many levels of symbolic links
```

We can fix it by doing an absolute link.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
