### PR TITLE
fix: add redirect for deployments docs that returned 404 in gui

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -348,6 +348,7 @@ Sitemap: https://kuma.io/sitemap.xml
             `/docs/:version/other/ /docs/:version/other/enterprise 301`,
             `/docs/:version/installation/ /docs/:version/installation/kubernetes 301`,
             `/docs/:version/api/ /docs/:version/documentation/http-api 301`,
+            `/docs/:version/documentation/deployments/ /docs/:version/introduction/deployments 301`,
             `/latest_version.html /latest_version 301`,
           ];
           // Add redirects for x.y.{0..5} to x.y.x


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

Link defined [here](https://github.com/kumahq/kuma-gui/blob/084e76632d92c19b29507fa56da96ae70b53c80e/src/views/Entities/components/MultizoneInfo.vue#L18) results in a 404 because the page was moved. This fixes it.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
