### PR TITLE
fix: installer script on debian

### DIFF
--- a/docs/.vuepress/public/installer.sh
+++ b/docs/.vuepress/public/installer.sh
@@ -18,7 +18,7 @@
 # download by setting the VERSION environment variable, and you can change
 # the default 64bit architecture by setting the ARCH variable.
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 
 : "${VERSION:=}"
 : "${ARCH:=amd64}"
@@ -91,7 +91,9 @@ fi
 URL="https://download.konghq.com/mesh-alpine/$REPO_PREFIX-$VERSION-$DISTRO-$ARCH.tar.gz"
 
 if ! curl -s --head "$URL" | head -n 1 | grep -E 'HTTP/1.1 [23]..|HTTP/2 [23]..' > /dev/null; then
-  IFS=. read -r major minor patch <<< "${VERSION}"
+  IFS=. read -r major minor patch <<EOF
+${VERSION}
+EOF
 
   # handle the kumactl archive
   if [ "$OS" = "Linux" ]; then

--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -33,7 +33,7 @@
           data-icon="octicon-star"
           data-size="small"
           data-show-count="false"
-          aria-label="Star Konvoy on GitHub"
+          aria-label="Star Kuma on GitHub"
         >
           {{
             getSiteData.themeConfig.repoButtonLabel 

--- a/docs/.vuepress/theme/global-components/Footer.vue
+++ b/docs/.vuepress/theme/global-components/Footer.vue
@@ -39,7 +39,7 @@
                 data-icon="octicon-star"
                 data-size="small"
                 data-show-count="false"
-                aria-label="Star Konvoy on GitHub"
+                aria-label="Star Kuma on GitHub"
               >
                 {{
                   getSiteData.themeConfig.repoButtonLabel

--- a/docs/docs/1.6.x/installation/redhat.md
+++ b/docs/docs/1.6.x/installation/redhat.md
@@ -3,6 +3,6 @@ os: rhel
 arch: amd64
 ---
 
-# Debian
+# Redhat
 
 !!!include(install_os.md)!!!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuma-website",
-  "description": "The website and docs for Konvoy.",
+  "description": "The website and docs for Kuma.",
   "author": "Kong Inc.",
   "scripts": {
     "docs:dev": "node ./node_modules/vuepress/cli.js dev docs --open",

--- a/tests/test-installer.sh
+++ b/tests/test-installer.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+TEXT_RESET='\033[0m'
+TEXT_RED='\033[0;31m'
+TEXT_GREEN='\033[0;32m'
+distros=( amazonlinux:2022 debian:bookworm centos:7 redhat/ubi8:8.6 ubuntu:22.10 )
+
+for distro in "${distros[@]}"; do
+  echo "running test for $distro"
+  docker run --rm -v $PWD/docs/.vuepress/public/installer.sh:/tmp/installer.sh $distro /bin/sh -c "apt-get update; apt-get install curl -y; yum install tar gzip -y; cd /tmp && sh ./installer.sh" &>/dev/null && echo -e "$distro ${TEXT_GREEN}passed${TEXT_RESET}" || echo -e "$distro ${TEXT_RED}failed${TEXT_RESET}" &
+done
+
+FAIL=0
+for job in $(jobs -p); do
+  wait "$job" || (( "FAIL+=1" ))
+done
+
+if [ "$FAIL" == "0" ]; then
+  echo -e "${TEXT_GREEN}All distros succeeded${TEXT_RESET}"
+  exit 0
+else
+  echo -e "${TEXT_RED}Distros failed: $FAIL${TEXT_RESET}"
+  exit 1
+fi


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

Installer on debian fails with:
```
sh: 21 Bad substitution
sh: 94: Syntax error: redirection unexpected
```

because it uses `bash` specific things when the shell is defined as `sh`. This PR fixes it and also adds a short test file to check if the installer succeeds on the distributions we list in "install" section in the sidebar. 

I also found that:
- in the sidebar "Redhat" was wrongly named "Debian" so I fixed that as well.
- we use an old name for this project in some places - and now that "[konvoy](https://d2iq.com/products/konvoy)" is actually a product we should not use that name 

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
