### PR TITLE
fix: add the required valid for parameter to kumactl command

### DIFF
--- a/docs/docs/1.5.x/deployments/multi-zone.md
+++ b/docs/docs/1.5.x/deployments/multi-zone.md
@@ -254,7 +254,7 @@ You need the following values to pass to each zone control plane setup:
    a zone token first with appropriate scope first:
 
     ```sh
-    kumactl generate zone-token --zone=<zone-name> --scope egress > /tmp/zoneegress-token
+    kumactl generate zone-token --zone=<zone-name> --valid-for=24h --scope egress > /tmp/zoneegress-token
     ```
 
    You can also generate the token [with the REST API](../security/zoneegress-auth.md).

--- a/docs/docs/1.5.x/documentation/zoneegress.md
+++ b/docs/docs/1.5.x/documentation/zoneegress.md
@@ -67,7 +67,7 @@ kumactl install control-plane \
 In Universal mode, the token is required to authenticate `ZoneEgress` instance. Create the token by using `kumactl` binary:
 
 ```bash
-kumactl generate zone-token --valid-for --scope egress > /path/to/token
+kumactl generate zone-token --valid-for 24h --scope egress > /path/to/token
 ```
 
 Create a `ZoneEgress` data plane proxy configuration to allow `kuma-cp` services to be configured to proxy traffic to other zones or external services through zone egress:

--- a/docs/docs/1.6.x/deployments/multi-zone.md
+++ b/docs/docs/1.6.x/deployments/multi-zone.md
@@ -254,7 +254,7 @@ You need the following values to pass to each zone control plane setup:
    a zone token first with appropriate scope first:
 
     ```sh
-    kumactl generate zone-token --zone=<zone-name> --scope egress > /tmp/zoneegress-token
+    kumactl generate zone-token --zone=<zone-name> --valid-for=24h --scope egress > /tmp/zoneegress-token
     ```
 
    You can also generate the token [with the REST API](../security/zoneegress-auth.md).

--- a/docs/docs/1.6.x/explore/zoneegress.md
+++ b/docs/docs/1.6.x/explore/zoneegress.md
@@ -67,7 +67,7 @@ kumactl install control-plane \
 In Universal mode, the token is required to authenticate `ZoneEgress` instance. Create the token by using `kumactl` binary:
 
 ```bash
-kumactl generate zone-token --valid-for --scope egress > /path/to/token
+kumactl generate zone-token --valid-for 24h --scope egress > /path/to/token
 ```
 
 Create a `ZoneEgress` data plane proxy configuration to allow `kuma-cp` services to be configured to proxy traffic to other zones or external services through zone egress:

--- a/docs/docs/dev/deployments/multi-zone.md
+++ b/docs/docs/dev/deployments/multi-zone.md
@@ -254,7 +254,7 @@ You need the following values to pass to each zone control plane setup:
    a zone token first with appropriate scope first:
 
     ```sh
-    kumactl generate zone-token --zone=<zone-name> --scope egress > /tmp/zoneegress-token
+    kumactl generate zone-token --zone=<zone-name> --valid-for=24h --scope egress > /tmp/zoneegress-token
     ```
 
    You can also generate the token [with the REST API](../security/zoneegress-auth.md).

--- a/docs/docs/dev/explore/zoneegress.md
+++ b/docs/docs/dev/explore/zoneegress.md
@@ -67,7 +67,7 @@ kumactl install control-plane \
 In Universal mode, the token is required to authenticate `ZoneEgress` instance. Create the token by using `kumactl` binary:
 
 ```bash
-kumactl generate zone-token --valid-for --scope egress > /path/to/token
+kumactl generate zone-token --valid-for 24h --scope egress > /path/to/token
 ```
 
 Create a `ZoneEgress` data plane proxy configuration to allow `kuma-cp` services to be configured to proxy traffic to other zones or external services through zone egress:


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

During setting up of universal multizone I got an error when trying to generate egress token. The required "--valid-for" parameter was missing.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
