### PR TITLE
fix: use `maxInterval` instead of `maxDuration` in Retry

### DIFF
--- a/docs/docs/1.1.x/policies/retry.md
+++ b/docs/docs/1.1.x/policies/retry.md
@@ -113,7 +113,7 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
 
     Base amount of time which should be taken between retries (i.e. `30ms`, `0.03s`, `0.0005m`)
 
-  - **`maxDuration`** (optional)
+  - **`maxInterval`** (optional)
 
     A maximal amount of time which will be taken between retries  (i.e. `1s`, `0.5m`)
 

--- a/docs/docs/1.2.x/policies/retry.md
+++ b/docs/docs/1.2.x/policies/retry.md
@@ -113,7 +113,7 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
 
     Base amount of time which should be taken between retries (i.e. `30ms`, `0.03s`, `0.0005m`)
 
-  - **`maxDuration`** (optional)
+  - **`maxInterval`** (optional)
 
     A maximal amount of time which will be taken between retries  (i.e. `1s`, `0.5m`)
 

--- a/docs/docs/1.3.x/policies/retry.md
+++ b/docs/docs/1.3.x/policies/retry.md
@@ -113,7 +113,7 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
 
     Base amount of time which should be taken between retries (i.e. `30ms`, `0.03s`, `0.0005m`)
 
-  - **`maxDuration`** (optional)
+  - **`maxInterval`** (optional)
 
     A maximal amount of time which will be taken between retries  (i.e. `1s`, `0.5m`)
 

--- a/docs/docs/1.4.x/policies/retry.md
+++ b/docs/docs/1.4.x/policies/retry.md
@@ -118,7 +118,7 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
 
     Base amount of time which should be taken between retries (i.e. `30ms`, `0.03s`, `0.0005m`)
 
-  - **`maxDuration`** (optional)
+  - **`maxInterval`** (optional)
 
     A maximal amount of time which will be taken between retries  (i.e. `1s`, `0.5m`)
 

--- a/docs/docs/1.5.x/policies/retry.md
+++ b/docs/docs/1.5.x/policies/retry.md
@@ -118,7 +118,7 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
 
     Base amount of time which should be taken between retries (i.e. `30ms`, `0.03s`, `0.0005m`)
 
-  - **`maxDuration`** (optional)
+  - **`maxInterval`** (optional)
 
     A maximal amount of time which will be taken between retries  (i.e. `1s`, `0.5m`)
 

--- a/docs/docs/1.6.x/policies/retry.md
+++ b/docs/docs/1.6.x/policies/retry.md
@@ -118,7 +118,7 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
 
     Base amount of time which should be taken between retries (i.e. `30ms`, `0.03s`, `0.0005m`)
 
-  - **`maxDuration`** (optional)
+  - **`maxInterval`** (optional)
 
     A maximal amount of time which will be taken between retries  (i.e. `1s`, `0.5m`)
 

--- a/docs/docs/1.7.x/policies/retry.md
+++ b/docs/docs/1.7.x/policies/retry.md
@@ -118,7 +118,7 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
 
     Base amount of time which should be taken between retries (i.e. `30ms`, `0.03s`, `0.0005m`)
 
-  - **`maxDuration`** (optional)
+  - **`maxInterval`** (optional)
 
     A maximal amount of time which will be taken between retries  (i.e. `1s`, `0.5m`)
 

--- a/docs/docs/dev/policies/retry.md
+++ b/docs/docs/dev/policies/retry.md
@@ -118,7 +118,7 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
 
     Base amount of time which should be taken between retries (i.e. `30ms`, `0.03s`, `0.0005m`)
 
-  - **`maxDuration`** (optional)
+  - **`maxInterval`** (optional)
 
     A maximal amount of time which will be taken between retries  (i.e. `1s`, `0.5m`)
 


### PR DESCRIPTION
Fix #851

Signed-off-by: Charly Molter <charly.molter@konghq.com>