### PR TITLE
fix(search): update the search index when changing version

### DIFF
--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -3,7 +3,7 @@
     <aside class="sidebar">
       <VersionNav/>
       <AlgoliaSearchBox v-if="$site.themeConfig.algolia.indexName && $page.frontmatter.search === true"
-                        :options="algolia" class="nav-item"/>
+                        :options="algolia" class="nav-item" :key="key"/>
 
       <NavLinks/>
 
@@ -29,6 +29,16 @@ export default {
     VersionNav
   },
   props: ['items'],
+  data() {
+    return {algoliaOptions: {}, key: 0}
+  },
+  watch: {
+    '$route'() {
+      // Option3 from a blogpost. Couldn't find another way to refresh the search when the version selector changes
+      // https://medium.com/emblatech/ways-to-force-vue-to-re-render-a-component-df866fbacf47
+      this.key += 1;
+    },
+  },
 
   computed: {
     algolia() {

--- a/docs/.vuepress/theme/global-components/VersionNav.vue
+++ b/docs/.vuepress/theme/global-components/VersionNav.vue
@@ -41,20 +41,10 @@ export default {
     // this is used as the model for the version selector
     defaultSelectedInstallVersion: {
       get() {
-        const routePath = this.$route.path
-        const test = '/docs/'
-        
-        // first, check to see that we're on a docs page:
-        if (routePath.startsWith(test)) {
-          // 1. if we're on a docs page, check the router path and extract the version
-          // 2. set the version selector to the extracted version
-          return this.$route.path.split('/')[2]
+        if (this.$page.version) {
+         return this.$page.version
         }
-        else {
-          // if we're on a page outside of the docs, grab the latest release
-          // from our Vuex Store and set the version selector value to that instead
-          return this.getLatestRelease
-        }
+        return this.getLatestRelease
       },
       set(value) {
         this.redirectToSelectedDocVersion(value)


### PR DESCRIPTION
Before when we changed the version during the dropdown the search
would happen on the previous version.

This is done as a hack in Vue but couldn't find another way ;)

Fix #855

Signed-off-by: Charly Molter <charly.molter@konghq.com>