### PR TITLE
fix(*): remove default arch to detect correct one

### DIFF
--- a/docs/.vuepress/public/installer.sh
+++ b/docs/.vuepress/public/installer.sh
@@ -21,7 +21,7 @@
 DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 
 : "${VERSION:=}"
-: "${ARCH:=amd64}"
+: "${ARCH:=}"
 : "${PRODUCT_NAME:=Kuma}"
 : "${LATEST_VERSION:=https://kuma.io/latest_version}"
 : "${REPO_PREFIX:=kuma}"


### PR DESCRIPTION
When the default `ARCH` is set script cannot detect the architecure of the processor. 