### PR TITLE
Fix container-patches typo in annotation documentation

### DIFF
--- a/docs/docs/1.7.x/reference/kubernetes-annotations.md
+++ b/docs/docs/1.7.x/reference/kubernetes-annotations.md
@@ -229,7 +229,7 @@ metadata:
     kuma.io/sidecar-env-vars: TEST1=1;TEST2=2 
 ```
 
-### `kuma.io/containes-patches`
+### `kuma.io/container-patches`
 
 Specifies the list of names of `ContainerPatch` resources to be applied on
 `kuma-init` and `kuma-sidecar` containers.

--- a/docs/docs/dev/reference/kubernetes-annotations.md
+++ b/docs/docs/dev/reference/kubernetes-annotations.md
@@ -229,7 +229,7 @@ metadata:
     kuma.io/sidecar-env-vars: TEST1=1;TEST2=2 
 ```
 
-### `kuma.io/containes-patches`
+### `kuma.io/container-patches`
 
 Specifies the list of names of `ContainerPatch` resources to be applied on
 `kuma-init` and `kuma-sidecar` containers.


### PR DESCRIPTION
There's a typo in the documentation that says the annotation is containes-patches, instead of container-patches.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)
✅ 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
✅ 