### PR TITLE
chore: add warning around transparent-proxy in universal

### DIFF
--- a/docs/docs/1.5.x/networking/transparent-proxying.md
+++ b/docs/docs/1.5.x/networking/transparent-proxying.md
@@ -76,7 +76,9 @@ The ports illustrated above are the default ones that `kumactl install transpare
 
 ### Invoking the Kuma data plane
 
+::: warning
 It is important that the `kuma-dp` process runs with the same system user that was passed to `kumactl install transparent-proxy --kuma-dp-user`.
+:::
 
 When systemd is used, this can be done with an entry `User=kuma-dp` in the `[Service]` section of the service file.
 

--- a/docs/docs/1.6.x/networking/transparent-proxying.md
+++ b/docs/docs/1.6.x/networking/transparent-proxying.md
@@ -76,7 +76,9 @@ The ports illustrated above are the default ones that `kumactl install transpare
 
 ### Invoking the Kuma data plane
 
+::: warning
 It is important that the `kuma-dp` process runs with the same system user that was passed to `kumactl install transparent-proxy --kuma-dp-user`.
+:::
 
 When systemd is used, this can be done with an entry `User=kuma-dp` in the `[Service]` section of the service file.
 

--- a/docs/docs/1.7.x/networking/transparent-proxying.md
+++ b/docs/docs/1.7.x/networking/transparent-proxying.md
@@ -76,7 +76,9 @@ The ports illustrated above are the default ones that `kumactl install transpare
 
 ### Invoking the Kuma data plane
 
+::: warning
 It is important that the `kuma-dp` process runs with the same system user that was passed to `kumactl install transparent-proxy --kuma-dp-user`.
+:::
 
 When systemd is used, this can be done with an entry `User=kuma-dp` in the `[Service]` section of the service file.
 

--- a/docs/docs/dev/networking/transparent-proxying.md
+++ b/docs/docs/dev/networking/transparent-proxying.md
@@ -76,7 +76,9 @@ The ports illustrated above are the default ones that `kumactl install transpare
 
 ### Invoking the Kuma data plane
 
+::: warning
 It is important that the `kuma-dp` process runs with the same system user that was passed to `kumactl install transparent-proxy --kuma-dp-user`.
+:::
 
 When systemd is used, this can be done with an entry `User=kuma-dp` in the `[Service]` section of the service file.
 


### PR DESCRIPTION
Make sure folks don't miss running the dp with kuma-dp user

Signed-off-by: Charly Molter <charly.molter@konghq.com>