### PR TITLE
fix(.github): use github app commit info

### DIFF
--- a/.github/workflows/sync-generated.yml
+++ b/.github/workflows/sync-generated.yml
@@ -33,8 +33,8 @@ jobs:
           token: ${{ steps.github-app-token.outputs.token }}
           path: kuma-website
           commit-message: "chore(ci): auto update auto generated docs"
-          committer: GitHub <noreply@github.com>
-          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          committer: kumahq[bot] <110050114+kumahq[bot]@users.noreply.github.com>
+          author: kumahq[bot] <110050114+kumahq[bot]@users.noreply.github.com>
           signoff: true
           branch: chore/auto-upgrade-kuma
           delete-branch: true


### PR DESCRIPTION
As discussed here:
https://github.com/orgs/community/discussions/24664#discussioncomment-3244950

The user id we can get from looking at the `user` for the PRs created by
this app.

For example:

```
$ gh api repos/kumahq/kuma-website/pulls/923
```