### PR TITLE
fix(theme): fix display of sub items with sub items

### DIFF
--- a/docs/.vuepress/theme/styles/vuepress-core/sidebar-group.scss
+++ b/docs/.vuepress/theme/styles/vuepress-core/sidebar-group.scss
@@ -11,13 +11,10 @@
   &.is-sub-group {
     padding-left: 0;
     & > .sidebar-heading {
-      font-size: 0.95em;
+      font-size: 1em;
       line-height: 1.4;
       font-weight: normal;
       padding-left: 2rem;
-      &:not(.clickable) {
-        opacity: 0.5;
-      }
     }
     & > .sidebar-group-items {
       padding-left: 1rem;


### PR DESCRIPTION
Fixes height, font size and opacity:

Before:

![before](https://user-images.githubusercontent.com/2266568/181590656-5e93a67b-a9dd-44fe-b65c-49371676f30e.png)


After:

![after](https://user-images.githubusercontent.com/2266568/181590637-179e86b0-80a1-4ae2-84ae-67890f3fef10.png)
