### PR TITLE
Install was always default to latest

### DIFF
--- a/docs/.vuepress/_snippets/install_kumactl.md
+++ b/docs/.vuepress/_snippets/install_kumactl.md
@@ -5,7 +5,7 @@ To run Kuma on Kubernetes, you need to download the Kuma cli (`kumactl`) on your
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-`curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} bash -`
+'curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} bash -'
 
 You can omit the `VERSION` variable to install the latest version. 
 :::

--- a/docs/.vuepress/_snippets/install_os.md
+++ b/docs/.vuepress/_snippets/install_os.md
@@ -12,7 +12,7 @@ Finally, you can follow the [Quickstart](#quickstart) to take it from here and c
 Run the following script to automatically detect the operating system and download Kuma:
 
 ```sh
-curl -L https://kuma.io/installer.sh | bash -
+curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} bash -
 ```
 or you can <a :href="'https://download.konghq.com/mesh-alpine/kuma-' + $page.latestVersion + '-' + $frontmatter.os + '-' + $frontmatter.arch + '.tar.gz'">download</a> the distribution manually.
 


### PR DESCRIPTION
As guided, ENV_VAR was not at the right place so VERSION={{ $page.latestVersion }} curl -L https://kuma.io/installer.sh | bash - was always pointing to the latest by default in install_os.md and install_kumactl.md as well. So it's changed to 'curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} bash -' in both of the files

Signed-off-by: MustkimKhatik 