### PR TITLE
docs(gateway): fix absolute path

### DIFF
--- a/docs/docs/dev/quickstart/kubernetes.md
+++ b/docs/docs/dev/quickstart/kubernetes.md
@@ -209,7 +209,7 @@ The resources for creating a builtin gateway is included with
   traffic
 
 Learn more about builtin gateways in [the dedicated gateway
-docs.](https://kuma.io/docs/1.7.x/explore/gateway/#builtin)
+docs.](/explore/gateway/#builtin)
 
 ## Explore Observability features
 

--- a/docs/docs/dev/quickstart/kubernetes.md
+++ b/docs/docs/dev/quickstart/kubernetes.md
@@ -209,7 +209,7 @@ The resources for creating a builtin gateway is included with
   traffic
 
 Learn more about builtin gateways in [the dedicated gateway
-docs.](/explore/gateway/#builtin)
+docs.](../explore/gateway/#builtin)
 
 ## Explore Observability features
 


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

fix absolute path that would lead to new versions linking to old versions of the docs

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
