### PR TITLE
fix: access control headers missing allowed method and headers

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -398,6 +398,8 @@ Sitemap: https://kuma.io/sitemap.xml
 /latest_version
     Content-Type: text/plain
     Access-Control-Allow-Origin: *
+    Access-Control-Allow-Method: GET
+    Access-Control-Allow-Headers: Content-Type
           `);
         }
 


### PR DESCRIPTION
Adds the `Access-Control-Allow-Method` and `Access-Control-Allow-Headers` headers to the `/latest_version` URL path so that preflight requests include them and CORS requests with a set `Content-Type` are allowed.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>