### PR TITLE
fix: vertical scrollbars on code blocks

### DIFF
--- a/docs/.vuepress/theme/styles/custom/base/_type-and-content.scss
+++ b/docs/.vuepress/theme/styles/custom/base/_type-and-content.scss
@@ -38,18 +38,6 @@ h6 {
 
 a {
   color: $color-5;
-
-  &:hover {
-  }
-
-  &:active {
-  }
-
-  &:focus {
-  }
-
-  &:visited {
-  }
 }
 
 // Images
@@ -120,19 +108,30 @@ div[class~='language-yaml']:before {
   content: 'yaml';
 }
 
-// As originally the plugin increase height of code-snippet
-// and there is no reason to do so
-pre div.code-copy {
-  height: 0;
-  .hover {
-    // Used important as it has to override the inline style from vuepress-plugin-code-copy
-    bottom: 0 !important;
+.code-copy {
+  // Positions the copy button container out of the document flow so that it doesn’t add extra height to the code block.
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  // Ensures the doesn’t occlude the scrollbar or content of the code block.
+  pointer-events: all;
+}
 
-    // Used to fix the overlap of the scroll bar as due to the
-    // above property and hence we set it manually below
-    margin-bottom: 25px;
-    margin-right: 15px;
-  }
+.code-copy .hover {
+  // Resets pointer events as they have been disabled on the `.code-copy` element.
+  pointer-events: all;
+
+  // Used important as it has to override the inline style from vuepress-plugin-code-copy
+  bottom: 0 !important;
+
+  // Used to fix the overlap of the scroll bar as due to the
+  // above property and hence we set it manually below
+  margin-bottom: 25px;
+  margin-right: 15px;
+}
+
+.code-copy-added {
+  position: static !important;
 }
 
 div[class~='language-sh'], 
@@ -145,9 +144,4 @@ div[class~='language-bash'] {
     font-size: 0.9rem;
     color: #333;
   }
-}
-
-//  Overrides the position: absolute on the code-block for the copy icon
-.code-copy-added{
-  position: static !important;
 }


### PR DESCRIPTION
Fixes an issue with vertical scrollbars appearing on code blocks.

**After**:

![Screenshot from 2022-08-24 13-42-27](https://user-images.githubusercontent.com/5774638/186409945-17e2d221-01e6-4836-b0fb-8f2353b3cbc6.png)

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>