### PR TITLE
fix(build): disable limit chunk count plugin in dev

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -511,12 +511,18 @@ Sitemap: https://kuma.io/sitemap.xml
   evergreen: false,
   configureWebpack: (config) => {
     return {
-      plugins: [
-        new webpack.EnvironmentPlugin({...process.env}),
-        new webpack.optimize.LimitChunkCountPlugin({
-          maxChunks: 20
-        })
-      ]
+      plugins: (function() {
+        const sharedPlugins = [
+          new webpack.EnvironmentPlugin({...process.env}),
+        ];
+        if (process.env.NODE_ENV.toLowerCase() === "production") {
+          return [...sharedPlugins, new webpack.optimize.LimitChunkCountPlugin({
+            maxChunks: 20
+          })]
+        } else {
+          return sharedPlugins;
+        }
+      })()
     }
   },
   shouldPrefetch: false,


### PR DESCRIPTION
Disable limit chunk count plugin in dev to speed up rebuild times.

First build still takes a lot of time but subsequent rebuilds are much faster now:

previously:
```
success [10:38:00] Build 878092 finished in 28634 ms! ( http://localhost:8080/ )
```

now:

```
success [10:53:50] Build 07ff8b finished in 1461 ms! ( http://localhost:8080/ )
```

I've figured it out by recording a flamegraph and seeing that we spend a lot of time there:

![image](https://user-images.githubusercontent.com/2753650/187639971-372dc46a-72b0-414d-a779-90257857f653.png)

If you want original flamegraph or instructions on how to do this let me know.

Signed-off-by: slonka <slonka@users.noreply.github.com>

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
