### PR TITLE
fix(build): fix link to kuma 1.4.1

### DIFF
--- a/docs/_blog/2021-12-16-kuma-1-4-1.md
+++ b/docs/_blog/2021-12-16-kuma-1-4-1.md
@@ -4,7 +4,7 @@ description: Kuma 1.4.1 GA Released
 date: 2021-12-16
 tags:
   - Release
-canonicalUrl: 'https://docs.konghq.com/mesh/changelog/#151'
+canonicalUrl: 'https://github.com/kumahq/kuma/blob/master/CHANGELOG.md#141'
 ---
 
 We are happy to announce a new release of Kuma! Kuma 1.4.1 ships with new features, more performance improvements, and bug fixes. We strongly suggest to upgrade, in order to take advantage of the latest and greatest when it comes to service mesh.

--- a/docs/_blog/2021-12-16-kuma-1-4-1.md
+++ b/docs/_blog/2021-12-16-kuma-1-4-1.md
@@ -4,7 +4,6 @@ description: Kuma 1.4.1 GA Released
 date: 2021-12-16
 tags:
   - Release
-canonicalUrl: 'https://github.com/kumahq/kuma/blob/master/CHANGELOG.md#141'
 ---
 
 We are happy to announce a new release of Kuma! Kuma 1.4.1 ships with new features, more performance improvements, and bug fixes. We strongly suggest to upgrade, in order to take advantage of the latest and greatest when it comes to service mesh.

--- a/docs/_blog/2021-12-16-kuma-1-4-1.md
+++ b/docs/_blog/2021-12-16-kuma-1-4-1.md
@@ -4,7 +4,7 @@ description: Kuma 1.4.1 GA Released
 date: 2021-12-16
 tags:
   - Release
-canonicalUrl: 'https://konghq.com/blog/kuma-1-4-1'
+canonicalUrl: 'https://docs.konghq.com/mesh/changelog/#151'
 ---
 
 We are happy to announce a new release of Kuma! Kuma 1.4.1 ships with new features, more performance improvements, and bug fixes. We strongly suggest to upgrade, in order to take advantage of the latest and greatest when it comes to service mesh.


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

Kuma 1.4.1 blogpost was removed from konghq blog so this PR fixes the link checker by removing the link.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
 