### PR TITLE
Install was always default to latest

### DIFF
--- a/docs/.vuepress/_snippets/install_kumactl.md
+++ b/docs/.vuepress/_snippets/install_kumactl.md
@@ -5,7 +5,9 @@ To run Kuma on Kubernetes, you need to download the Kuma cli (`kumactl`) on your
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-`curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} bash -`
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 You can omit the `VERSION` variable to install the latest version. 
 :::

--- a/docs/.vuepress/_snippets/install_os.md
+++ b/docs/.vuepress/_snippets/install_os.md
@@ -11,9 +11,10 @@ Finally, you can follow the [Quickstart](#quickstart) to take it from here and c
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | bash -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
+
 or you can <a :href="'https://download.konghq.com/mesh-alpine/kuma-' + $page.latestVersion + '-' + $frontmatter.os + '-' + $frontmatter.arch + '.tar.gz'">download</a> the distribution manually.
 
 Then extract the archive with: `tar xvzf kuma-{{ $page.latestVersion }}`.

--- a/docs/docs/1.1.x/installation/amazonlinux.md
+++ b/docs/docs/1.1.x/installation/amazonlinux.md
@@ -16,10 +16,10 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-yum install -y tar gzip
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>yum install -y tar gzip
+curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.1.6-centos-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.1.x/installation/centos.md
+++ b/docs/docs/1.1.x/installation/centos.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.1.6-centos-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.1.x/installation/debian.md
+++ b/docs/docs/1.1.x/installation/debian.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.1.6-debian-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.1.x/installation/docker.md
+++ b/docs/docs/1.1.x/installation/docker.md
@@ -102,9 +102,9 @@ mtls:
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can download the distribution manually:
 

--- a/docs/docs/1.1.x/installation/eks.md
+++ b/docs/docs/1.1.x/installation/eks.md
@@ -22,9 +22,9 @@ To run Kuma on AWS EKS, you need to download a compatible version of Kuma for th
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.1.x/installation/kubernetes.md
+++ b/docs/docs/1.1.x/installation/kubernetes.md
@@ -22,9 +22,9 @@ To run Kuma on Kubernetes, you need to download a compatible version of Kuma for
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.1.x/installation/macos.md
+++ b/docs/docs/1.1.x/installation/macos.md
@@ -17,9 +17,9 @@ To run Kuma on macOS you can choose among different installation methods:
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.1.x/installation/openshift.md
+++ b/docs/docs/1.1.x/installation/openshift.md
@@ -17,9 +17,9 @@ To run Kuma on OpenShift, you need to download a compatible version of Kuma for 
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.1.x/installation/redhat.md
+++ b/docs/docs/1.1.x/installation/redhat.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.1.6-rhel-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.1.x/installation/ubuntu.md
+++ b/docs/docs/1.1.x/installation/ubuntu.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.1.6-ubuntu-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.2.x/installation/amazonlinux.md
+++ b/docs/docs/1.2.x/installation/amazonlinux.md
@@ -16,10 +16,10 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-yum install -y tar gzip
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>yum install -y tar gzip
+curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.2.3-centos-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.2.x/installation/centos.md
+++ b/docs/docs/1.2.x/installation/centos.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.2.3-centos-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.2.x/installation/debian.md
+++ b/docs/docs/1.2.x/installation/debian.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.2.3-debian-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.2.x/installation/docker.md
+++ b/docs/docs/1.2.x/installation/docker.md
@@ -102,9 +102,9 @@ mtls:
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can download the distribution manually:
 

--- a/docs/docs/1.2.x/installation/eks.md
+++ b/docs/docs/1.2.x/installation/eks.md
@@ -22,9 +22,9 @@ To run Kuma on AWS EKS, you need to download a compatible version of Kuma for th
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.2.x/installation/kubernetes.md
+++ b/docs/docs/1.2.x/installation/kubernetes.md
@@ -22,9 +22,9 @@ To run Kuma on Kubernetes, you need to download a compatible version of Kuma for
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.2.x/installation/macos.md
+++ b/docs/docs/1.2.x/installation/macos.md
@@ -17,9 +17,9 @@ To run Kuma on macOS you can choose among different installation methods:
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.2.x/installation/openshift.md
+++ b/docs/docs/1.2.x/installation/openshift.md
@@ -17,9 +17,9 @@ To run Kuma on OpenShift, you need to download a compatible version of Kuma for 
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.2.x/installation/redhat.md
+++ b/docs/docs/1.2.x/installation/redhat.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.2.3-rhel-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.2.x/installation/ubuntu.md
+++ b/docs/docs/1.2.x/installation/ubuntu.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.2.3-ubuntu-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.3.x/installation/amazonlinux.md
+++ b/docs/docs/1.3.x/installation/amazonlinux.md
@@ -16,10 +16,10 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-yum install -y tar gzip
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>yum install -y tar gzip
+curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.3.1-centos-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.3.x/installation/centos.md
+++ b/docs/docs/1.3.x/installation/centos.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.3.1-centos-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.3.x/installation/debian.md
+++ b/docs/docs/1.3.x/installation/debian.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.3.1-debian-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.3.x/installation/docker.md
+++ b/docs/docs/1.3.x/installation/docker.md
@@ -102,9 +102,9 @@ mtls:
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can download the distribution manually:
 

--- a/docs/docs/1.3.x/installation/eks.md
+++ b/docs/docs/1.3.x/installation/eks.md
@@ -22,9 +22,9 @@ To run Kuma on AWS EKS, you need to download a compatible version of Kuma for th
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.3.x/installation/kubernetes.md
+++ b/docs/docs/1.3.x/installation/kubernetes.md
@@ -22,9 +22,9 @@ To run Kuma on Kubernetes, you need to download a compatible version of Kuma for
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.3.x/installation/macos.md
+++ b/docs/docs/1.3.x/installation/macos.md
@@ -17,9 +17,9 @@ To run Kuma on macOS you can choose among different installation methods:
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.3.x/installation/openshift.md
+++ b/docs/docs/1.3.x/installation/openshift.md
@@ -17,9 +17,9 @@ To run Kuma on OpenShift, you need to download a compatible version of Kuma for 
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.3.x/installation/redhat.md
+++ b/docs/docs/1.3.x/installation/redhat.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.3.1-rhel-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.3.x/installation/ubuntu.md
+++ b/docs/docs/1.3.x/installation/ubuntu.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.3.1-ubuntu-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.4.x/installation/amazonlinux.md
+++ b/docs/docs/1.4.x/installation/amazonlinux.md
@@ -16,10 +16,10 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-yum install -y tar gzip
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>yum install -y tar gzip
+curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.4.1-centos-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.4.x/installation/centos.md
+++ b/docs/docs/1.4.x/installation/centos.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.4.1-centos-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.4.x/installation/debian.md
+++ b/docs/docs/1.4.x/installation/debian.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.4.1-debian-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.4.x/installation/docker.md
+++ b/docs/docs/1.4.x/installation/docker.md
@@ -102,9 +102,9 @@ mtls:
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can download the distribution manually:
 

--- a/docs/docs/1.4.x/installation/eks.md
+++ b/docs/docs/1.4.x/installation/eks.md
@@ -22,9 +22,9 @@ To run Kuma on AWS EKS, you need to download a compatible version of Kuma for th
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.4.x/installation/kubernetes.md
+++ b/docs/docs/1.4.x/installation/kubernetes.md
@@ -22,9 +22,9 @@ To run Kuma on Kubernetes, you need to download a compatible version of Kuma for
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.4.x/installation/macos.md
+++ b/docs/docs/1.4.x/installation/macos.md
@@ -17,9 +17,9 @@ To run Kuma on macOS you can choose among different installation methods:
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.4.x/installation/openshift.md
+++ b/docs/docs/1.4.x/installation/openshift.md
@@ -17,9 +17,9 @@ To run Kuma on OpenShift, you need to download a compatible version of Kuma for 
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.4.x/installation/redhat.md
+++ b/docs/docs/1.4.x/installation/redhat.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.4.1-rhel-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.4.x/installation/ubuntu.md
+++ b/docs/docs/1.4.x/installation/ubuntu.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.4.1-ubuntu-amd64.tar.gz) the distribution manually.
 

--- a/docs/docs/1.5.x/installation/amazonlinux.md
+++ b/docs/docs/1.5.x/installation/amazonlinux.md
@@ -16,10 +16,11 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-yum install -y tar gzip
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>yum install -y tar gzip
+curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
+
 or you can <a :href="'https://download.konghq.com/mesh-alpine/kuma-' + $page.latestVersion + '-centos-amd64.tar.gz'">download</a> the distribution manually.
 
 Then extract the archive with:

--- a/docs/docs/1.5.x/installation/centos.md
+++ b/docs/docs/1.5.x/installation/centos.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can <a :href="'https://download.konghq.com/mesh-alpine/kuma-' + $page.latestVersion + '-centos-amd64.tar.gz'">download</a> the distribution manually.
 

--- a/docs/docs/1.5.x/installation/debian.md
+++ b/docs/docs/1.5.x/installation/debian.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can <a :href="'https://download.konghq.com/mesh-alpine/kuma-' + $page.latestVersion + '-debian-amd64.tar.gz'">download</a> the distribution manually.
 

--- a/docs/docs/1.5.x/installation/docker.md
+++ b/docs/docs/1.5.x/installation/docker.md
@@ -96,9 +96,9 @@ mtls:
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can download the distribution manually:
 

--- a/docs/docs/1.5.x/installation/eks.md
+++ b/docs/docs/1.5.x/installation/eks.md
@@ -22,9 +22,9 @@ To run Kuma on AWS EKS, you need to download a compatible version of Kuma for th
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.5.x/installation/kubernetes.md
+++ b/docs/docs/1.5.x/installation/kubernetes.md
@@ -22,9 +22,9 @@ To run Kuma on Kubernetes, you need to download a compatible version of Kuma for
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.5.x/installation/macos.md
+++ b/docs/docs/1.5.x/installation/macos.md
@@ -17,9 +17,9 @@ To run Kuma on macOS you can choose among different installation methods:
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.5.x/installation/openshift.md
+++ b/docs/docs/1.5.x/installation/openshift.md
@@ -17,9 +17,9 @@ To run Kuma on OpenShift, you need to download a compatible version of Kuma for 
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 :::
 ::: tab "Direct Link"

--- a/docs/docs/1.5.x/installation/redhat.md
+++ b/docs/docs/1.5.x/installation/redhat.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can <a :href="'https://download.konghq.com/mesh-alpine/kuma-' + $page.latestVersion + '-rhel-amd64.tar.gz'">download</a> the distribution manually.
 

--- a/docs/docs/1.5.x/installation/ubuntu.md
+++ b/docs/docs/1.5.x/installation/ubuntu.md
@@ -12,9 +12,9 @@ Finally you can follow the [Quickstart](#_4-quickstart) to take it from here and
 
 Run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can <a :href="'https://download.konghq.com/mesh-alpine/kuma-' + $page.latestVersion + '-ubuntu-amd64.tar.gz'">download</a> the distribution manually.
 

--- a/docs/docs/1.6.x/installation/docker.md
+++ b/docs/docs/1.6.x/installation/docker.md
@@ -79,9 +79,9 @@ mtls:
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can download the distribution manually:
 

--- a/docs/docs/1.7.x/installation/docker.md
+++ b/docs/docs/1.7.x/installation/docker.md
@@ -79,9 +79,9 @@ mtls:
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can download the distribution manually:
 

--- a/docs/docs/1.8.x/installation/docker.md
+++ b/docs/docs/1.8.x/installation/docker.md
@@ -79,9 +79,9 @@ mtls:
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
-```sh
-curl -L https://kuma.io/installer.sh | sh -
-```
+<div class="language-sh">
+<pre><code>curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -</code></pre>
+</div>
 
 or you can download the distribution manually:
 


### PR DESCRIPTION
Signed-off-by: MustkimKhatik <83959074+MustkimKhatik@users.noreply.github.com>

Install was always pointing to the latest version because of  ```curl -L https://kuma.io/installer.sh | bash - ``` that what was the ```install_os``` having, so its changed to ```curl -L https://kuma.io/installer.sh | VERSION={{ $page.latestVersion }} sh -``` 

This change is done inside the ```div``` class because the normal fenced code was preventing the interpolation of ```{{$page.latestVersion }}``` in the documents.


