### PR TITLE
docs(tracing) added documentation for datadog service split

### DIFF
--- a/docs/docs/dev/explore/observability.md
+++ b/docs/docs/dev/explore/observability.md
@@ -297,7 +297,7 @@ spec:
       port: 8126
       targetPort: 8126
 ```
-Apply the configuration with `kubectl apply -f [..]`.
+Apply the configuration with `kubectl apply -f [..]`. Remember that in order for this to work you need to add label `app=datadog` to you agent pod.
 :::
 ::: tab "Universal"
 Checkout the [Datadog agent docs](https://docs.datadoghq.com/agent/basic_agent_usage)

--- a/docs/docs/dev/generated/resources/other_mesh.md
+++ b/docs/docs/dev/generated/resources/other_mesh.md
@@ -314,6 +314,10 @@
 - `port` (required)
 
     Port of datadog collector
+
+- `splitService` (optional)
+
+    Determines if datadog service name should be split based on traffic direction and destination. Default: false
 ## ZipkinTracingBackendConfig
 
 - `url` (required)

--- a/docs/docs/dev/policies/traffic-trace.md
+++ b/docs/docs/dev/policies/traffic-trace.md
@@ -130,7 +130,7 @@ Apply the configuration with `kumactl apply -f [..]` or with the [HTTP API](../r
 
 The `defaultBackend` property specifies the tracing backend to use if it's not explicitly specified in the `TrafficTrace` resource.
 
-The `splitService` property determines if Datadog service name should be split based on traffic direction and destination. For example, if you have a `backend` service that communicates with couple databases. When `splitService` is enabled instead of single service named `backend` you will get `backend_INBOUND`, `backend_OUTBOUND_db1`, `backend_OUTBOUND_db2` in Datadog. By default, this property is set to false.
+The `splitService` property determines if Datadog service names should be split based on traffic direction and destination. For example, with `splitService: true` and a `backend` service that communicates with a couple of databases, you would get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2` in Datadog. By default, this property is set to false.
 
 ## Add TrafficTrace resource
 

--- a/docs/docs/dev/policies/traffic-trace.md
+++ b/docs/docs/dev/policies/traffic-trace.md
@@ -98,7 +98,7 @@ spec:
       type: datadog
       sampling: 100.0
       conf:
-        address: trace-svc.datadog.svc.cluster.local
+        address: trace-svc.default.svc.cluster.local
         port: 8126
         splitService: true
 ```

--- a/docs/docs/dev/policies/traffic-trace.md
+++ b/docs/docs/dev/policies/traffic-trace.md
@@ -100,6 +100,7 @@ spec:
       conf:
         address: trace-svc.datadog.svc.cluster.local
         port: 8126
+        splitService: true
 ```
 
 where `trace-svc` is the name of the Kubernetes Service you specified when you configured the Datadog APM agent.
@@ -120,6 +121,7 @@ tracing:
     conf:
       address: 127.0.0.1
       port: 8126
+      splitService: true
 ```
 
 Apply the configuration with `kumactl apply -f [..]` or with the [HTTP API](../reference/http-api.md).
@@ -127,6 +129,8 @@ Apply the configuration with `kumactl apply -f [..]` or with the [HTTP API](../r
 ::::
 
 The `defaultBackend` property specifies the tracing backend to use if it's not explicitly specified in the `TrafficTrace` resource.
+
+The `splitService` property determines if Datadog service name should be split based on traffic direction and destination. For example, if you have a `backend` service that communicates with couple databases. When `splitService` is enabled instead of single service named `backend` you will get `backend_INBOUND`, `backend_OUTBOUND_db1`, `backend_OUTBOUND_db2` in Datadog. By default, this property is set to false.
 
 ## Add TrafficTrace resource
 


### PR DESCRIPTION
This is updated docs for Datadog tracing split service functionality
