### PR TITLE
docs(kumacp): change the default label of datadog 

### DIFF
--- a/docs/docs/1.2.x/policies/traffic-trace.md
+++ b/docs/docs/1.2.x/policies/traffic-trace.md
@@ -84,13 +84,16 @@ metadata:
   name: trace-svc
 spec:
   selector:
-    app: datadog
+    app.kubernetes.io/name: datadog-agent-deployment
   ports:
     - protocol: TCP
       port: 8126
       targetPort: 8126
 ```
 Apply the configuration with `kubectl apply -f [..]`.
+
+Check if the label of the datadog pod installed has not changed (`app.kubernetes.io/name: datadog-agent-deployment`),
+if it did adjust accordingly.
 :::
 ::::
 

--- a/docs/docs/1.3.x/policies/traffic-trace.md
+++ b/docs/docs/1.3.x/policies/traffic-trace.md
@@ -84,13 +84,16 @@ metadata:
   name: trace-svc
 spec:
   selector:
-    app: datadog
+    app.kubernetes.io/name: datadog-agent-deployment
   ports:
     - protocol: TCP
       port: 8126
       targetPort: 8126
 ```
 Apply the configuration with `kubectl apply -f [..]`.
+
+Check if the label of the datadog pod installed has not changed (`app.kubernetes.io/name: datadog-agent-deployment`),
+if it did adjust accordingly.
 :::
 ::::
 

--- a/docs/docs/1.4.x/policies/traffic-trace.md
+++ b/docs/docs/1.4.x/policies/traffic-trace.md
@@ -84,13 +84,16 @@ metadata:
   name: trace-svc
 spec:
   selector:
-    app: datadog
+    app.kubernetes.io/name: datadog-agent-deployment
   ports:
     - protocol: TCP
       port: 8126
       targetPort: 8126
 ```
 Apply the configuration with `kubectl apply -f [..]`.
+
+Check if the label of the datadog pod installed has not changed (`app.kubernetes.io/name: datadog-agent-deployment`),
+if it did adjust accordingly.
 :::
 ::::
 

--- a/docs/docs/1.5.x/policies/traffic-trace.md
+++ b/docs/docs/1.5.x/policies/traffic-trace.md
@@ -84,13 +84,16 @@ metadata:
   name: trace-svc
 spec:
   selector:
-    app: datadog
+    app.kubernetes.io/name: datadog-agent-deployment
   ports:
     - protocol: TCP
       port: 8126
       targetPort: 8126
 ```
 Apply the configuration with `kubectl apply -f [..]`.
+
+Check if the label of the datadog pod installed has not changed (`app.kubernetes.io/name: datadog-agent-deployment`),
+if it did adjust accordingly.
 :::
 ::::
 

--- a/docs/docs/1.6.x/policies/traffic-trace.md
+++ b/docs/docs/1.6.x/policies/traffic-trace.md
@@ -84,13 +84,16 @@ metadata:
   name: trace-svc
 spec:
   selector:
-    app: datadog
+    app.kubernetes.io/name: datadog-agent-deployment
   ports:
     - protocol: TCP
       port: 8126
       targetPort: 8126
 ```
 Apply the configuration with `kubectl apply -f [..]`.
+
+Check if the label of the datadog pod installed has not changed (`app.kubernetes.io/name: datadog-agent-deployment`),
+if it did adjust accordingly.
 :::
 ::::
 

--- a/docs/docs/1.7.x/explore/observability.md
+++ b/docs/docs/1.7.x/explore/observability.md
@@ -278,13 +278,16 @@ metadata:
   name: trace-svc
 spec:
   selector:
-    app: datadog
+    app.kubernetes.io/name: datadog-agent-deployment
   ports:
     - protocol: TCP
       port: 8126
       targetPort: 8126
 ```
 Apply the configuration with `kubectl apply -f [..]`.
+
+Check if the label of the datadog pod installed has not changed (`app.kubernetes.io/name: datadog-agent-deployment`),
+if it did adjust accordingly.
 :::
 ::: tab "Universal"
 Checkout the [Datadog agent docs](https://docs.datadoghq.com/agent/basic_agent_usage)

--- a/docs/docs/1.8.x/explore/observability.md
+++ b/docs/docs/1.8.x/explore/observability.md
@@ -314,13 +314,16 @@ metadata:
   name: trace-svc
 spec:
   selector:
-    app: datadog
+    app.kubernetes.io/name: datadog-agent-deployment
   ports:
     - protocol: TCP
       port: 8126
       targetPort: 8126
 ```
 Apply the configuration with `kubectl apply -f [..]`.
+
+Check if the label of the datadog pod installed has not changed (`app.kubernetes.io/name: datadog-agent-deployment`),
+if it did adjust accordingly.
 :::
 ::: tab "Universal"
 Checkout the [Datadog agent docs](https://docs.datadoghq.com/agent/basic_agent_usage)

--- a/docs/docs/dev/explore/observability.md
+++ b/docs/docs/dev/explore/observability.md
@@ -291,13 +291,18 @@ metadata:
   name: trace-svc
 spec:
   selector:
-    app: datadog
+    app.kubernetes.io/name: datadog-agent-deployment
   ports:
     - protocol: TCP
       port: 8126
       targetPort: 8126
 ```
-Apply the configuration with `kubectl apply -f [..]`. Remember that in order for this to work you need to add label `app=datadog` to you agent pod.
+
+Apply the configuration with `kubectl apply -f [..]`.
+
+Check if the label of the datadog pod installed has not changed (`app.kubernetes.io/name: datadog-agent-deployment`),
+if it did adjust accordingly.
+
 :::
 ::: tab "Universal"
 Checkout the [Datadog agent docs](https://docs.datadoghq.com/agent/basic_agent_usage)


### PR DESCRIPTION
change the default label of datadog to match the one that is present when installing the agent

Signed-off-by: slonka <slonka@users.noreply.github.com>

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
