### PR TITLE
chore: fixes broken URL to k8s docs

### DIFF
--- a/docs/docs/1.8.x/explore/gateway-api.md
+++ b/docs/docs/1.8.x/explore/gateway-api.md
@@ -12,7 +12,7 @@ Gateway API is not supported in multi-zone. To use the builtin Gateway, you need
 
 1. Install the Gateway API CRDs.
 
-   The Gateway API CRDs aren't available in Kubernetes by default yet. You must first [install the _experimental release_ that includes those CRDs as well as the admission webhook](https://gateway-api.sigs.k8s.io/guides/getting-started/#install-experimental-channel).
+   The Gateway API CRDs aren't available in Kubernetes by default yet. You must first [install the _experimental release_ that includes those CRDs as well as the admission webhook](https://gateway-api.sigs.k8s.io/guides/#install-experimental-channel).
 
 2. Enable Gateway API support.
 

--- a/docs/docs/dev/explore/gateway-api.md
+++ b/docs/docs/dev/explore/gateway-api.md
@@ -12,7 +12,7 @@ Gateway API is not supported in multi-zone. To use the builtin Gateway, you need
 
 1. Install the Gateway API CRDs.
 
-   The Gateway API CRDs aren't available in Kubernetes by default yet. You must first [install the _experimental release_ that includes those CRDs as well as the admission webhook](https://gateway-api.sigs.k8s.io/guides/getting-started/#install-experimental-channel).
+   The Gateway API CRDs aren't available in Kubernetes by default yet. You must first [install the _experimental release_ that includes those CRDs as well as the admission webhook](https://gateway-api.sigs.k8s.io/guides/#install-experimental-channel).
 
 2. Enable Gateway API support.
 


### PR DESCRIPTION
Fixes a broken URL to the k8s docs which breaks the link checker because their redirection is implemented on the client side via JavaScript.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>