### PR TITLE
Use div for code block so vue interpolation works

### DIFF
--- a/docs/.vuepress/_snippets/install_os.md
+++ b/docs/.vuepress/_snippets/install_os.md
@@ -32,10 +32,9 @@ You can start the control-plane with: `kuma-{{ $page.latestVersion }}/bin/kuma-c
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](../introduction/deployments.md) like "multi-zone".
 
 We suggest adding the `kumactl` executable to your `PATH` so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
-
-```sh
-ln -s kuma-{{ $page.latestVersion }}/bin/kumactl /usr/local/bin/kumactl
-```
+<div class="language-sh">
+<pre><code> ln -s kuma-{{ $page.latestVersion }}/bin/kumactl /usr/local/bin/kumactl </code></pre>
+</div>
 
 ::: tip
 **Note**: By default this will run Kuma with a `memory` [store](../documentation/configuration.md), but for production you have to use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.


### PR DESCRIPTION
vuepress adds a `v:pre` tag to a fenced code block, which escapes any vue interpolation and shows the plain, unprocessed code. This interferes with instances where you need the vue interpolation for the example code to make sense. I updated an escaped code block to use the same style as a block earlier in the snippet so its interpolation could work.

see https://github.com/vuejs/vuepress/issues/413

Signed-off-by: zachmandeville <webmaster@coolguy.website>

