### PR TITLE
fix: kubectl being misspelled as kubactl in a few places

### DIFF
--- a/docs/docs/1.3.x/documentation/configuration.md
+++ b/docs/docs/1.3.x/documentation/configuration.md
@@ -18,7 +18,7 @@ If you install the control plane with `kumactl`, you can override the configurat
 ```sh
 kumactl install control-plane \
   --env-var KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
-  --env-var KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s | kubactl apply -f -
+  --env-var KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s | kubectl apply -f -
 ```
 :::
 ::: tab "Kubernetes (HELM)"
@@ -32,7 +32,7 @@ helm install --version 0.7.1 \
 
 Or you can edit the `Values.yaml` file:
 ```yaml
-cat Values.yaml 
+cat Values.yaml
 controlPlane:
   envVars:
     KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL: 5s
@@ -96,7 +96,7 @@ Configuration of `kuma-dp` is logged when `kuma-dp` runs.
 
 ## kumactl
 
-The configuration is stored in `$HOME/.kumactl/config`, which is created when you run `kumactl` for the first time. 
+The configuration is stored in `$HOME/.kumactl/config`, which is created when you run `kumactl` for the first time.
 When you add a new control plane with `kumactl config control-planes add`, the config file is updated.
 To change the path of the config file, run `kumactl` with `--config-file /new-path/config`.
 

--- a/docs/docs/1.4.x/documentation/configuration.md
+++ b/docs/docs/1.4.x/documentation/configuration.md
@@ -18,7 +18,7 @@ If you install the control plane with `kumactl`, you can override the configurat
 ```sh
 kumactl install control-plane \
   --env-var KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
-  --env-var KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s | kubactl apply -f -
+  --env-var KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s | kubectl apply -f -
 ```
 :::
 ::: tab "Kubernetes (HELM)"
@@ -103,7 +103,7 @@ Configuration of `kuma-dp` is logged when `kuma-dp` runs.
 
 ## kumactl
 
-The configuration is stored in `$HOME/.kumactl/config`, which is created when you run `kumactl` for the first time. 
+The configuration is stored in `$HOME/.kumactl/config`, which is created when you run `kumactl` for the first time.
 When you add a new control plane with `kumactl config control-planes add`, the config file is updated.
 To change the path of the config file, run `kumactl` with `--config-file /new-path/config`.
 

--- a/docs/docs/1.5.x/documentation/configuration.md
+++ b/docs/docs/1.5.x/documentation/configuration.md
@@ -18,7 +18,7 @@ If you install the control plane with `kumactl`, you can override the configurat
 ```sh
 kumactl install control-plane \
   --env-var KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
-  --env-var KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s | kubactl apply -f -
+  --env-var KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s | kubectl apply -f -
 ```
 :::
 ::: tab "Kubernetes (HELM)"
@@ -103,7 +103,7 @@ Configuration of `kuma-dp` is logged when `kuma-dp` runs.
 
 ## kumactl
 
-The configuration is stored in `$HOME/.kumactl/config`, which is created when you run `kumactl` for the first time. 
+The configuration is stored in `$HOME/.kumactl/config`, which is created when you run `kumactl` for the first time.
 When you add a new control plane with `kumactl config control-planes add`, the config file is updated.
 To change the path of the config file, run `kumactl` with `--config-file /new-path/config`.
 

--- a/docs/docs/1.6.x/documentation/configuration.md
+++ b/docs/docs/1.6.x/documentation/configuration.md
@@ -18,7 +18,7 @@ When using `kumactl`, you can override the configuration with the `--env-var` fl
 ```sh
 kumactl install control-plane \
   --env-var KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
-  --env-var KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s | kubactl apply -f -
+  --env-var KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s | kubectl apply -f -
 ```
 :::
 ::: tab "Kubernetes (HELM)"
@@ -103,7 +103,7 @@ Configuration of `kuma-dp` is logged when `kuma-dp` runs.
 
 ## kumactl
 
-The configuration is stored in `$HOME/.kumactl/config`, which is created when you run `kumactl` for the first time. 
+The configuration is stored in `$HOME/.kumactl/config`, which is created when you run `kumactl` for the first time.
 When you add a new control plane with `kumactl config control-planes add`, the config file is updated.
 To change the path of the config file, run `kumactl` with `--config-file /new-path/config`.
 

--- a/docs/docs/1.7.x/documentation/configuration.md
+++ b/docs/docs/1.7.x/documentation/configuration.md
@@ -18,7 +18,7 @@ When using `kumactl`, you can override the configuration with the `--env-var` fl
 ```sh
 kumactl install control-plane \
   --env-var KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
-  --env-var KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s | kubactl apply -f -
+  --env-var KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s | kubectl apply -f -
 ```
 :::
 ::: tab "Kubernetes (HELM)"
@@ -103,7 +103,7 @@ Configuration of `kuma-dp` is logged when `kuma-dp` runs.
 
 ## kumactl
 
-The configuration is stored in `$HOME/.kumactl/config`, which is created when you run `kumactl` for the first time. 
+The configuration is stored in `$HOME/.kumactl/config`, which is created when you run `kumactl` for the first time.
 When you add a new control plane with `kumactl config control-planes add`, the config file is updated.
 To change the path of the config file, run `kumactl` with `--config-file /new-path/config`.
 

--- a/docs/docs/1.8.x/documentation/configuration.md
+++ b/docs/docs/1.8.x/documentation/configuration.md
@@ -22,7 +22,7 @@ When using `kumactl`, override the configuration with the `--env-var` flag. For 
 ```sh
 kumactl install control plane \
   --env-var KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
-  --env-var KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s | kubactl apply -f -
+  --env-var KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s | kubectl apply -f -
 ```
 :::
 ::: tab "Kubernetes (HELM)"

--- a/docs/docs/dev/documentation/configuration.md
+++ b/docs/docs/dev/documentation/configuration.md
@@ -22,7 +22,7 @@ When using `kumactl`, override the configuration with the `--env-var` flag. For 
 ```sh
 kumactl install control plane \
   --env-var KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
-  --env-var KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s | kubactl apply -f -
+  --env-var KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s | kubectl apply -f -
 ```
 :::
 ::: tab "Kubernetes (HELM)"


### PR DESCRIPTION
Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>