### PR TITLE
Re-add the /latest_version endpoint

### DIFF
--- a/app/_headers
+++ b/app/_headers
@@ -1,0 +1,2 @@
+/latest_version
+  Content-Type: text/plain

--- a/app/_plugins/generators/alias.rb
+++ b/app/_plugins/generators/alias.rb
@@ -5,12 +5,19 @@ module Jekyll
     priority :lowest
 
     def generate(site)
-      content = File.read('app/_redirects')
+      static_files = [
+        "app/_redirects",
+        "app/_headers"
+      ]
 
-      page = PageWithoutAFile.new(site, __dir__, '', '_redirects')
-      page.content = content
-      page.data['layout'] = nil
-      site.pages << page
+      static_files.each do |path|
+        content = File.read(path)
+
+        page = PageWithoutAFile.new(site, __dir__, '', path.sub('app/',''))
+        page.content = content
+        page.data['layout'] = nil
+        site.pages << page
+      end
     end
   end
 end

--- a/app/_plugins/hooks/latest_version.rb
+++ b/app/_plugins/hooks/latest_version.rb
@@ -1,0 +1,4 @@
+Jekyll::Hooks.register :site, :post_write do |site|
+  latest = site.data['versions'].filter {|v| v['release'] != "dev"}.last
+  File.write "#{site.dest}/latest_version", latest['version']
+end 


### PR DESCRIPTION
Signed-off-by: Michael Heap <m@michaelheap.com>

Re-adds the missing `/latest_version` endpoint after the replatform to Jekyll. This file is used by the installer + GUI

Did you sign your commit? Yes

Have you read [Contributing guidelines] Yes
