### PR TITLE
Generate /releases.json

### DIFF
--- a/app/_plugins/hooks/releases_json.rb
+++ b/app/_plugins/hooks/releases_json.rb
@@ -1,0 +1,4 @@
+Jekyll::Hooks.register :site, :post_write do |site|
+  releases = site.data['versions'].filter {|v| v['release'] != "dev"}.map {|v| v['version']}.to_json
+  File.write "#{site.dest}/releases.json", releases
+end 


### PR DESCRIPTION
Signed-off-by: Michael Heap <m@michaelheap.com>

`/releases.json` was missing on the replatform. This commit re-adds the data

Did you sign your commit? Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? Yes
