### PR TITLE
Re-add the latest: true flag in versions.yml

### DIFF
--- a/app/_data/versions.yml
+++ b/app/_data/versions.yml
@@ -22,6 +22,7 @@
 - edition: "kuma"
   version: "1.8.1"
   release: "1.8.x"
+  latest: true
 - edition: "kuma"
   version: "2.0.0"
   release: "dev"

--- a/app/_plugins/generators/redirects.rb
+++ b/app/_plugins/generators/redirects.rb
@@ -9,7 +9,7 @@ module Jekyll
       active_versions = site.data['versions'].filter {|v| v['release'] != "dev"}
 
       # Generate redirects for the latest version
-      latest_release = active_versions.last['release']
+      latest_release = site.data['latest_version']['release']
       redirects = [
         "# Generated redirects",
         "/docs /docs/#{latest_release} 301",

--- a/app/_plugins/generators/sitemap.rb
+++ b/app/_plugins/generators/sitemap.rb
@@ -4,13 +4,14 @@ module Sitemap
 
     def generate(site)
       # What's our latest version?
-      latest = site.data['versions'].reject { |v| v['release'] == 'dev' }.last
+      latest = site.data['latest_version']
 
       # Grab all pages that contain that version
       all_pages = []
       # Build a map of the latest available version of every URL
       site.pages.each do |page|
-        next if is_versioned(page['url']) and !is_latest(page['url'], latest)
+        # Skip if it's not the latest version of a page
+        next if is_versioned_url(page['url']) and !is_version(page['url'], latest)
         all_pages << page
       end
 
@@ -49,7 +50,7 @@ module Sitemap
       end
     end
 
-    def is_versioned(url)
+    def is_versioned_url(url)
       versioned = [
         "/install/",
         "/docs/",
@@ -60,7 +61,7 @@ module Sitemap
       false
     end
 
-    def is_latest(url, latest)
+    def is_version(url, latest)
       url.include?(latest['release'])
     end
   end

--- a/app/_plugins/generators/versions.rb
+++ b/app/_plugins/generators/versions.rb
@@ -5,8 +5,11 @@ module Jekyll
     priority :high
 
     def generate(site)
-      latest_version = site.data['versions'].reject { |v| v['release'] == 'dev' }.last
-      site.data['latest_version'] = latest_version
+      latest_versions = site.data['versions'].select {|v| v['latest']}
+      if latest_versions.size != 1
+        raise "Exactly one entry in app/_data/versions.yml must be marked as 'latest: true' (#{latest_versions.size} found)"
+      end
+      site.data['latest_version'] = latest_versions.first
 
       # Add a `version` property to every versioned page
       # TODO: Also create aliases under /latest/ for all x.x.x doc pages

--- a/app/_plugins/hooks/latest_version.rb
+++ b/app/_plugins/hooks/latest_version.rb
@@ -1,4 +1,4 @@
 Jekyll::Hooks.register :site, :post_write do |site|
-  latest = site.data['versions'].filter {|v| v['release'] != "dev"}.last
+  latest = site.data['latest_version']
   File.write "#{site.dest}/latest_version", latest['version']
 end 


### PR DESCRIPTION
Signed-off-by: Michael Heap <m@michaelheap.com>

The `latest: true` flag was used to soft launch new versions without triggering docs reindexing/GUI updates. This was removed in the replatform, and is now re-added.

Did you sign your commit? Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? Yes
