### PR TITLE
fix(generated): fix generated docs script

### DIFF
--- a/app/_data/docs_nav_kuma_1.6.x.yml
+++ b/app/_data/docs_nav_kuma_1.6.x.yml
@@ -696,3 +696,6 @@ items:
             url: /generated/cmd/kuma-prometheus-sd/kuma-prometheus-sd/
           - text: kumactl
             url: /generated/cmd/kumactl/kumactl/
+      - # Auto-generated
+        text: Kuma-cp configuration reference
+        url: /generated/kuma-cp

--- a/app/_data/docs_nav_kuma_1.7.x.yml
+++ b/app/_data/docs_nav_kuma_1.7.x.yml
@@ -725,3 +725,6 @@ items:
             url: /generated/cmd/kuma-prometheus-sd/kuma-prometheus-sd/
           - text: kumactl
             url: /generated/cmd/kumactl/kumactl/
+      - # Auto-generated
+        text: Kuma-cp configuration reference
+        url: /generated/kuma-cp

--- a/app/_data/docs_nav_kuma_1.8.x.yml
+++ b/app/_data/docs_nav_kuma_1.8.x.yml
@@ -744,6 +744,9 @@ items:
             url: /generated/cmd/kuma-prometheus-sd/kuma-prometheus-sd/
           - text: kumactl
             url: /generated/cmd/kumactl/kumactl/
+      - # Auto-generated
+        text: Kuma-cp configuration reference
+        url: /generated/kuma-cp
   - title: Contribute
     group: true
     items:

--- a/app/_data/docs_nav_kuma_dev.yml
+++ b/app/_data/docs_nav_kuma_dev.yml
@@ -749,6 +749,9 @@ items:
             url: /generated/cmd/kuma-dp/kuma-dp/
           - text: kumactl
             url: /generated/cmd/kumactl/kumactl/
+      - # Auto-generated
+        text: Kuma-cp configuration reference
+        url: /generated/kuma-cp
   - title: Contribute
     group: true
     items:

--- a/app/docs/dev/generated/cmd/kumactl/kumactl_generate_zone-ingress-token.md
+++ b/app/docs/dev/generated/cmd/kumactl/kumactl_generate_zone-ingress-token.md
@@ -8,6 +8,9 @@ Generate Zone Ingress Token
 
 Generate Zone Ingress Token that is used to prove Zone Ingress identity.
 
+DEPRECATED: Use kumactl generate zone-token --scope=ingress instead.
+
+
 ```
 kumactl generate zone-ingress-token [flags]
 ```

--- a/app/docs/dev/generated/cmd/kumactl/kumactl_get.md
+++ b/app/docs/dev/generated/cmd/kumactl/kumactl_get.md
@@ -77,3 +77,4 @@ Show Kuma resources.
 * [kumactl get zoneegress](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_get_zoneegress)	 - Show a single ZoneEgress resource
 * [kumactl get zoneegresses](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_get_zoneegresses)	 - Show ZoneEgress
 * [kumactl get zones](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_get_zones)	 - Show Zone
+

--- a/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshaccesslog.md
+++ b/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshaccesslog.md
@@ -31,4 +31,5 @@ kumactl get meshaccesslog NAME [flags]
 
 ### SEE ALSO
 
-- [kumactl get](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_get) - Show Kuma resources
+* [kumactl get](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_get)	 - Show Kuma resources
+

--- a/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshaccesslogs.md
+++ b/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshaccesslogs.md
@@ -33,4 +33,5 @@ kumactl get meshaccesslogs [flags]
 
 ### SEE ALSO
 
-- [kumactl get](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_get) - Show Kuma resources
+* [kumactl get](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_get)	 - Show Kuma resources
+

--- a/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshtrace.md
+++ b/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshtrace.md
@@ -31,5 +31,5 @@ kumactl get meshtrace NAME [flags]
 
 ### SEE ALSO
 
-* [kumactl get](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_get/)	 - Show Kuma resources
+* [kumactl get](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_get)	 - Show Kuma resources
 

--- a/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshtraces.md
+++ b/app/docs/dev/generated/cmd/kumactl/kumactl_get_meshtraces.md
@@ -33,4 +33,5 @@ kumactl get meshtraces [flags]
 
 ### SEE ALSO
 
-- [kumactl get](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_get) - Show Kuma resources
+* [kumactl get](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_get)	 - Show Kuma resources
+

--- a/app/docs/dev/generated/cmd/kumactl/kumactl_inspect.md
+++ b/app/docs/dev/generated/cmd/kumactl/kumactl_inspect.md
@@ -51,3 +51,4 @@ Inspect Kuma resources.
 * [kumactl inspect zoneegresses](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_inspect_zoneegresses)	 - Inspect Zone Egresses
 * [kumactl inspect zoneingress](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_inspect_zoneingress)	 - Inspect ZoneIngress
 * [kumactl inspect zones](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_inspect_zones)	 - Inspect Zones
+

--- a/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_meshaccesslog.md
+++ b/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_meshaccesslog.md
@@ -30,4 +30,5 @@ kumactl inspect meshaccesslog NAME [flags]
 
 ### SEE ALSO
 
-- [kumactl inspect](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_inspect) - Inspect Kuma resources
+* [kumactl inspect](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_inspect)	 - Inspect Kuma resources
+

--- a/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_meshtrace.md
+++ b/app/docs/dev/generated/cmd/kumactl/kumactl_inspect_meshtrace.md
@@ -30,4 +30,5 @@ kumactl inspect meshtrace NAME [flags]
 
 ### SEE ALSO
 
-- [kumactl inspect](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_inspect) - Inspect Kuma resources
+* [kumactl inspect](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_inspect)	 - Inspect Kuma resources
+

--- a/app/docs/dev/generated/cmd/kumactl/kumactl_uninstall.md
+++ b/app/docs/dev/generated/cmd/kumactl/kumactl_uninstall.md
@@ -26,5 +26,6 @@ Uninstall various Kuma components.
 ### SEE ALSO
 
 * [kumactl](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl)	 - Management tool for Kuma
+* [kumactl uninstall ebpf](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_uninstall_ebpf)	 - Uninstall BPF files from the nodes
 * [kumactl uninstall transparent-proxy](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_uninstall_transparent-proxy)	 - Uninstall Transparent Proxy pre-requisites on the host
 

--- a/app/docs/dev/generated/cmd/kumactl/kumactl_uninstall_ebpf.md
+++ b/app/docs/dev/generated/cmd/kumactl/kumactl_uninstall_ebpf.md
@@ -37,4 +37,5 @@ kumactl uninstall ebpf [flags]
 
 ### SEE ALSO
 
-- [kumactl uninstall](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_uninstall) - Uninstall various Kuma components.
+* [kumactl uninstall](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_uninstall)	 - Uninstall various Kuma components.
+

--- a/app/docs/dev/generated/cmd/kumactl/kumactl_uninstall_transparent-proxy.md
+++ b/app/docs/dev/generated/cmd/kumactl/kumactl_uninstall_transparent-proxy.md
@@ -6,7 +6,7 @@ Uninstall Transparent Proxy pre-requisites on the host
 
 ### Synopsis
 
-Uninstall Transparent Proxy by restoring the hosts iptables and /etc/resolv.conf
+Uninstall Transparent Proxy by restoring the hosts iptables and /etc/resolv.conf or removing leftover ebpf objects
 
 ```
 kumactl uninstall transparent-proxy [flags]
@@ -15,9 +15,11 @@ kumactl uninstall transparent-proxy [flags]
 ### Options
 
 ```
-      --dry-run   dry run
-  -h, --help      help for transparent-proxy
-      --verbose   verbose
+      --dry-run                  dry run
+      --ebpf-bpffs-path string   the path of the BPF filesystem (default "/sys/fs/bpf")
+      --ebpf-enabled             uninstall transparent proxy with ebpf mode
+  -h, --help                     help for transparent-proxy
+      --verbose                  verbose
 ```
 
 ### Options inherited from parent commands

--- a/app/docs/dev/generated/resources/other_mesh.md
+++ b/app/docs/dev/generated/resources/other_mesh.md
@@ -316,6 +316,14 @@ title: Mesh
 - `port` (required)
 
     Port of datadog collector
+
+- `splitService` (optional)
+
+    Determines if datadog service name should be split based on traffic
+    direction and destination. For example, with `splitService: true` and a
+    `backend` service that communicates with a couple of databases, you would
+    get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
+    `backend_OUTBOUND_db2` in Datadog. Default: false
 ## ZipkinTracingBackendConfig
 
 - `url` (required)

--- a/app/docs/dev/generated/resources/policy_external-service.md
+++ b/app/docs/dev/generated/resources/policy_external-service.md
@@ -36,7 +36,15 @@ title: ExternalService
         - `serverName` (optional)
         
             ServerName overrides the default Server Name Indicator set by Kuma.
-            The default value is set to "address" specified in "networking".
+            The default value is set to "address" specified in "networking".    
+    
+    - `disableHostDNSEntry` (optional)
+    
+        If disableHostDNSEntry is set to true then a DNS entry for the external
+        service taken from 'networking.address' won't be generated.
+        You can still reach this external service using
+        external-service-name.mesh:80 where "external-service-name" is taken from
+        "kuma.io/service" tag.
 
 - `tags` (required)
 

--- a/app/docs/dev/generated/resources/proxy_dataplane.md
+++ b/app/docs/dev/generated/resources/proxy_dataplane.md
@@ -4,35 +4,49 @@ title: Dataplane
 
 - `networking` (optional)
 
-    Networking describes inbound and outbound interfaces of the dataplane.    
+    Networking describes inbound and outbound interfaces of the data plane
+    proxy.    
     
     - `address` (required)
     
-        Public IP on which the dataplane is accessible in the network.    
+        IP on which the data plane proxy is accessible to the control plane and
+        other data plane proxies in the same network. This can also be a
+        hostname, in which case the control plane will periodically resolve it.    
     
     - `advertisedAddress` (optional)
     
-        In some situation, dataplane resides in a private network and not
-        reachable via 'address'. advertisedAddress is configured with public
-        routable address for such dataplane so that other dataplanes in the mesh
-        can connect to it over advertisedAddress and not via address
-        Note: Envoy binds to the address not advertisedAddress    
+        In some situations, a data plane proxy resides in a private network (e.g.
+        Docker) and is not reachable via `address` to other data plane proxies.
+        `advertisedAddress` is configured with a routable address for such data
+        plane proxy so that other proxies in the mesh can connect to it over
+        `advertisedAddress` and not via address.
+        
+        Envoy still binds to the `address`, not `advertisedAddress`.    
     
     - `gateway` (optional)
     
-        Gateway describes configuration of gateway of the dataplane.    
+        Gateway describes a configuration of the gateway of the data plane proxy.    
         
         - `tags` (required)
         
-            Tags associated with a gateway (e.g., Kong, Contour, etc) this
-            dataplane is deployed next to, e.g. service=gateway, env=prod.
-            `service` tag is mandatory.    
+            Tags associated with a gateway of this data plane to, e.g.
+            `kuma.io/service=gateway`, `env=prod`. `kuma.io/service` tag is
+            mandatory.    
         
         - `type` (required, enum)
         
-            Type of gateway this dataplane manages. The default is a DELEGATED
-            gateway, which is an external proxy. The BUILTIN gateway type causes
-            the dataplane proxy itself to be configured as a gateway.
+            Type of gateway this data plane proxy manages.
+            There are two types: `DELEGATED` and `BUILTIN`. Defaults to
+            `DELEGATED`.
+            
+            A `DELEGATED` gateway is an independently deployed proxy (e.g., Kong,
+            Contour, etc) that receives inbound traffic that is not proxied by
+            Kuma, and it sends outbound traffic into the data plane proxy.
+            
+            The `BUILTIN` gateway type causes the data plane proxy itself to be
+            configured as a gateway.
+            
+            See https://kuma.io/docs/latest/explore/gateway/ for more information.
         
             - `DELEGATED`
         
@@ -40,46 +54,73 @@ title: Dataplane
     
     - `inbound` (optional, repeated)
     
-        Inbound describes a list of inbound interfaces of the dataplane.    
+        Inbound describes a list of inbound interfaces of the data plane proxy.
+        
+        Inbound describes a service implemented by the data plane proxy.
+        All incoming traffic to a data plane proxy is going through inbound
+        listeners. For every defined Inbound there is a corresponding Envoy
+        Listener.    
         
         - `port` (required)
         
             Port of the inbound interface that will forward requests to the
-            service.    
+            service.
+            
+            When transparent proxying is used, it is a port on which the service is
+            listening to. When transparent proxying is not used, Envoy will bind to
+            this port.    
         
         - `servicePort` (optional)
         
-            Port of the service that requests will be forwarded to.    
+            Port of the service that requests will be forwarded to.
+            Defaults to the same value as `port`.    
         
         - `serviceAddress` (optional)
         
             Address of the service that requests will be forwarded to.
-            Empty value defaults to '127.0.0.1', since Kuma DP should be deployed
-            next to service.    
+            Defaults to '127.0.0.1', since Kuma DP should be deployed next to the
+            service.    
         
         - `address` (optional)
         
-            Address on which inbound listener will be exposed. Defaults to
-            networking.address.    
+            Address on which inbound listener will be exposed.
+            Defaults to `networking.address`.    
         
         - `tags` (required)
         
-            Tags associated with an application this dataplane is deployed next to,
-            e.g. kuma.io/service=web, version=1.0.
+            Tags associated with an application this data plane proxy is deployed
+            next to, e.g. `kuma.io/service=web`, `version=1.0`. You can then
+            reference these tags in policies like MeshTrafficPermission.
             `kuma.io/service` tag is mandatory.    
         
         - `health` (optional)
         
-            Health is an optional field filled automatically by Kuma Control Plane
-            on Kubernetes if Pod has ReadinessProbe configured. If 'health' is
-            equal to nil we consider dataplane as healthy. Unhealthy dataplanes
-            will be excluded from Endpoints Discovery Service (EDS)    
+            Health describes the status of an inbound.
+            If 'health' is nil we consider data plane proxy as healthy.
+            Unhealthy data plane proxies are excluded from Endpoints Discovery
+            Service (EDS). On Kubernetes, it is filled automatically by the control
+            plane if Pod has readiness probe configured. On Universal, it can be
+            set by the external health checking system, but the most common way is
+            to use service probes.
             
-            - `ready` (optional)    
+            See https://kuma.io/docs/latest/documentation/health for more
+            information.    
+            
+            - `ready` (optional)
+            
+                Ready indicates if the data plane proxy is ready to serve the
+                traffic.    
         
         - `serviceProbe` (optional)
         
-            ServiceProbe defines parameters for probing service's port    
+            ServiceProbe defines parameters for probing the service next to
+            sidecar. When service probe is defined, Envoy will periodically health
+            check the application next to it and report the status to the control
+            plane. On Kubernetes, Kuma deployments rely on Kubernetes probes so
+            this is not used.
+            
+            See https://kuma.io/docs/latest/documentation/health for more
+            information.    
             
             - `interval` (optional)
             
@@ -105,29 +146,40 @@ title: Dataplane
     
     - `outbound` (optional, repeated)
     
-        Outbound describes a list of outbound interfaces of the dataplane.    
+        Outbound describes a list of services consumed by the data plane proxy.
+        For every defined Outbound, there is a corresponding Envoy Listener.    
         
         - `address` (optional)
         
-            Address on which the service will be available to this dataplane.
-            Defaults to 127.0.0.1    
+            IP on which the consumed service will be available to this data plane
+            proxy. On Kubernetes, it's usually ClusterIP of a Service or PodIP of a
+            Headless Service. Defaults to 127.0.0.1    
         
         - `port` (required)
         
-            Port on which the service will be available to this dataplane.    
+            Port on which the consumed service will be available to this data plane
+            proxy. When transparent proxying is not used, Envoy will bind to this
+            port.    
         
         - `service` (optional)
         
-            DEPRECATED: use networking.outbound[].tags
-            Service name.    
+            DEPRECATED: use `networking.outbound[].tags['kuma.io/service']`
+            Service name identified by the value of `kuma.io/service`.    
         
         - `tags` (optional)
         
-            Tags    
+            Tags of consumed data plane proxies.
+            `kuma.io/service` tag is required.
+            These tags can then be referenced in `destinations` section of policies
+            like TrafficRoute or in `to` section in policies like MeshAccessLog. It
+            is recommended to only use `kuma.io/service`. If you need to consume
+            specific data plane proxy of a service (for example: `version=v2`) the
+            better practice is to use TrafficRoute.    
     
     - `transparentProxying` (optional)
     
-        TransparentProxying describes configuration for transparent proxying.    
+        TransparentProxying describes the configuration for transparent proxying.
+        It is used by default on Kubernetes.    
         
         - `redirectPortInbound` (optional)
         
@@ -139,7 +191,10 @@ title: Dataplane
         
         - `directAccessServices` (optional, repeated)
         
-            List of services that will be access directly via IP:PORT    
+            List of services that will be accessed directly via IP:PORT
+            Use `*` to indicate direct access to every service in the Mesh.
+            Using `*` to directly access every service is a resource-intensive
+            operation, use it only if needed.    
         
         - `redirectPortInboundV6` (optional)
         
@@ -149,13 +204,19 @@ title: Dataplane
         - `reachableServices` (optional, repeated)
         
             List of reachable services (represented by the value of
-            kuma.io/service) via transparent proxying. Setting an explicit list can
-            dramatically improve the performance of the mesh. If not specified, all
-            services in the mesh are reachable.    
+            `kuma.io/service`) via transparent proxying. Setting an explicit list
+            can dramatically improve the performance of the mesh. If not specified,
+            all services in the mesh are reachable.    
     
     - `admin` (optional)
     
-        Admin contains configuration related to Envoy Admin API    
+        Admin describes configuration related to Envoy Admin API.
+        Due to security, all the Envoy Admin endpoints are exposed only on
+        localhost. Additionally, Envoy will expose `/ready` endpoint on
+        `networking.address` for health checking systems to be able to check the
+        state of Envoy. The rest of the endpoints exposed on `networking.address`
+        are always protected by mTLS and only meant to be consumed internally by
+        the control plane.    
         
         - `port` (optional)
         
@@ -164,7 +225,7 @@ title: Dataplane
 - `metrics` (optional)
 
     Configuration for metrics that should be collected and exposed by the
-    dataplane.
+    data plane proxy.
     
     Settings defined here will override their respective defaults
     defined at a Mesh level.    
@@ -183,16 +244,35 @@ title: Dataplane
 
 - `probes` (optional)
 
-    Probes describes list of endpoints which will redirect traffic from
-    insecure port to localhost path    
+    Probes describe a list of endpoints that will be exposed without mTLS.
+    This is useful to expose the health endpoints of the application so the
+    orchestration system (e.g. Kubernetes) can still health check the
+    application.
     
-    - `port` (required)    
+    See
+    https://kuma.io/docs/latest/policies/service-health-probes/#virtual-probes
+    for more information.    
     
-    - `endpoints` (required, repeated)    
+    - `port` (required)
+    
+        Port on which the probe endpoints will be exposed. This cannot overlap
+        with any other ports.    
+    
+    - `endpoints` (required, repeated)
+    
+        List of endpoints to expose without mTLS.    
         
-        - `inboundPort` (required)    
+        - `inboundPort` (required)
         
-        - `inboundPath` (required)    
+            Inbound port is a port of the application from which we expose the
+            endpoint.    
+        
+        - `inboundPath` (required)
+        
+            Inbound path is a path of the application from which we expose the
+            endpoint. It is recommended to be as specific as possible.    
         
         - `path` (required)
+        
+            Path is a path on which we expose inbound path on the probes port.
 


### PR DESCRIPTION
- Add back kuma-cp reference to the sidebar
- fix sync_generated.sh to transform markdown in jekyll compatible content

Signed-off-by: Charly Molter <charly.molter@konghq.com>
