### PR TITLE
Fix variable interpolation in code snippet

### DIFF
--- a/app/_includes/snippets/install_kumactl.md
+++ b/app/_includes/snippets/install_kumactl.md
@@ -35,9 +35,7 @@ So we enter the `bin` folder by executing: `cd kuma-{{ page.latest_version }}/bi
 
 We suggest adding the `kumactl` executable to your `PATH` (by executing: `PATH=$(pwd):$PATH`) so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
-{% raw %}
 ```sh
 ln -s kuma-{{ page.latest_version }}/bin/kumactl /usr/local/bin/kumactl
 ```
-{% endraw %}
 


### PR DESCRIPTION
Remove {% raw %} block surrounding code snippet that prevented the page version from being rendered

Signed-off-by: Fabian Rodriguez <fabian.rodriguez@konghq.com>

Fixes https://github.com/kumahq/kuma-website/issues/1064 

See https://deploy-preview-1096--kuma.netlify.app/docs/1.8.x/installation/kubernetes/
