### PR TITLE
fix(kumacp): fix default retry on in retry policy

### DIFF
--- a/app/docs/1.8.x/policies/retry.md
+++ b/app/docs/1.8.x/policies/retry.md
@@ -171,9 +171,9 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
 
   ```yaml
   retryOn:
-  - gateway-error
-  - connect-failure
-  - refused-stream
+  - gateway_error
+  - connect_failure
+  - refused_stream
   ```
   {% endtip %}
 

--- a/app/docs/dev/policies/retry.md
+++ b/app/docs/dev/policies/retry.md
@@ -171,9 +171,9 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
 
   ```yaml
   retryOn:
-  - gateway-error
-  - connect-failure
-  - refused-stream
+  - gateway_error
+  - connect_failure
+  - refused_stream
   ```
   {% endtip %}
 


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

Closes https://github.com/kumahq/kuma-website/issues/1103

A client tried to apply `gateway-error` instead of `gateway_error` and that caused an error.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
