### PR TITLE
Fix {% tip %} syntax after merge

### DIFF
--- a/app/docs/1.4.x/policies/fault-injection.md
+++ b/app/docs/1.4.x/policies/fault-injection.md
@@ -2,9 +2,9 @@
 title: Fault Injection
 ---
 
-:::tip
+{% tip %}
 Fault Injection is an inbound policy. Dataplanes whose configuration is modified are in the `destinations` matcher.
-:::
+{% endtip %}
 
 `FaultInjection` policy helps you to test your microservices against resiliency. Kuma provides 3 different types of failures that could be imitated in your environment. 
 These faults are [Delay](#delay), [Abort](#abort) and [ResponseBandwidth](#responsebandwidth-limit) limit.

--- a/app/docs/1.4.x/policies/health-check.md
+++ b/app/docs/1.4.x/policies/health-check.md
@@ -2,9 +2,9 @@
 title: Health Check
 ---
 
-:::tip
+{% tip %}
 Health Check is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
-:::
+{% endtip %}
 
 This policy enables Kuma to keep track of the health of every data plane proxy, with the goal of minimizing the number of failed requests in case a data plane proxy is temporarily unhealthy.
 

--- a/app/docs/1.4.x/policies/rate-limit.md
+++ b/app/docs/1.4.x/policies/rate-limit.md
@@ -2,9 +2,9 @@
 title: Rate Limit
 ---
 
-:::tip
+{% tip %}
 Rate Limit is an inbound policy. Dataplanes whose configuration is modified are in the `destinations` matcher.
-:::
+{% endtip %}
 
 The `RateLimit` policy leverages
 Envoy's [local rate limiting](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter)

--- a/app/docs/1.4.x/policies/traffic-route.md
+++ b/app/docs/1.4.x/policies/traffic-route.md
@@ -2,9 +2,9 @@
 title: Traffic Route
 ---
 
-:::tip
+{% tip %}
 Traffic Route is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
-:::
+{% endtip %}
 
 This policy lets you configure routing rules for the traffic in the mesh. It supports weighted routing and can be used to implement versioning across services or to support deployment strategies such as blue/green or canary.
 

--- a/app/docs/1.5.x/policies/circuit-breaker.md
+++ b/app/docs/1.5.x/policies/circuit-breaker.md
@@ -2,9 +2,9 @@
 title: Circuit Breaker
 ---
 
-:::tip
+{% tip %}
 Circuit Breaker is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
-:::
+{% endtip %}
 
 This policy will look for errors in the live traffic being exchanged between our data plane proxies and it will mark a data proxy as an unhealthy if certain conditions are met and - by doing so - making sure that no additional traffic can reach an unhealthy data plane proxy until it is healthy again.
 

--- a/app/docs/1.5.x/policies/fault-injection.md
+++ b/app/docs/1.5.x/policies/fault-injection.md
@@ -2,9 +2,9 @@
 title: Fault Injection
 ---
 
-:::tip
+{% tip %}
 Fault Injection is an inbound policy. Dataplanes whose configuration is modified are in the `destinations` matcher.
-:::
+{% endtip %}
 
 `FaultInjection` policy helps you to test your microservices against resiliency. Kuma provides 3 different types of failures that could be imitated in your environment. 
 These faults are [Delay](#delay), [Abort](#abort) and [ResponseBandwidth](#responsebandwidth-limit) limit.

--- a/app/docs/1.5.x/policies/health-check.md
+++ b/app/docs/1.5.x/policies/health-check.md
@@ -2,9 +2,9 @@
 title: Health Check
 ---
 
-:::tip
+{% tip %}
 Health Check is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
-:::
+{% endtip %}
 
 This policy enables Kuma to keep track of the health of every data plane proxy, with the goal of minimizing the number of failed requests in case a data plane proxy is temporarily unhealthy.
 

--- a/app/docs/1.5.x/policies/rate-limit.md
+++ b/app/docs/1.5.x/policies/rate-limit.md
@@ -2,9 +2,9 @@
 title: Rate Limit
 ---
 
-:::tip
+{% tip %}
 Rate Limit is an inbound policy. Dataplanes whose configuration is modified are in the `destinations` matcher.
-:::
+{% endtip %}
 
 The `RateLimit` policy leverages
 Envoy's [local rate limiting](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter)

--- a/app/docs/1.5.x/policies/traffic-route.md
+++ b/app/docs/1.5.x/policies/traffic-route.md
@@ -2,9 +2,9 @@
 title: Traffic Route
 ---
 
-:::tip
+{% tip %}
 Traffic Route is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
-:::
+{% endtip %}
 
 This policy lets you configure routing rules for the traffic in the mesh. It supports weighted routing and can be used to implement versioning across services or to support deployment strategies such as blue/green or canary.
 

--- a/app/docs/1.6.x/policies/circuit-breaker.md
+++ b/app/docs/1.6.x/policies/circuit-breaker.md
@@ -2,9 +2,9 @@
 title: Circuit Breaker
 ---
 
-:::tip
+{% tip %}
 Circuit Breaker is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
-:::
+{% endtip %}
 
 This policy will look for errors in the live traffic being exchanged between our data plane proxies and it will mark a data proxy as an unhealthy if certain conditions are met and - by doing so - making sure that no additional traffic can reach an unhealthy data plane proxy until it is healthy again.
 

--- a/app/docs/1.6.x/policies/fault-injection.md
+++ b/app/docs/1.6.x/policies/fault-injection.md
@@ -2,9 +2,9 @@
 title: Fault Injection
 ---
 
-:::tip
+{% tip %}
 Fault Injection is an inbound policy. Dataplanes whose configuration is modified are in the `destinations` matcher.
-:::
+{% endtip %}
 
 `FaultInjection` policy helps you to test your microservices against resiliency. Kuma provides 3 different types of failures that could be imitated in your environment. 
 These faults are [Delay](#delay), [Abort](#abort) and [ResponseBandwidth](#responsebandwidth-limit) limit.

--- a/app/docs/1.6.x/policies/health-check.md
+++ b/app/docs/1.6.x/policies/health-check.md
@@ -2,9 +2,9 @@
 title: Health Check
 ---
 
-:::tip
+{% tip %}
 Health Check is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
-:::
+{% endtip %}
 
 This policy enables Kuma to keep track of the health of every data plane proxy, with the goal of minimizing the number of failed requests in case a data plane proxy is temporarily unhealthy.
 

--- a/app/docs/1.6.x/policies/mesh-trace.md
+++ b/app/docs/1.6.x/policies/mesh-trace.md
@@ -302,9 +302,9 @@ By default, this property is set to false.
 
 ### Sampling
 
-:::tip
+{% tip %}
 Most of the time setting only `overall` is sufficient; `random` and `client` are for advanced use cases.
-:::
+{% endtip %}
 
 You can configure sampling settings equivalent to Envoy's:
 - [overall](https://www.envoyproxy.io/docs/envoy/v1.22.5/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto.html?highlight=overall_sampling#extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-tracing)

--- a/app/docs/1.6.x/policies/rate-limit.md
+++ b/app/docs/1.6.x/policies/rate-limit.md
@@ -2,9 +2,9 @@
 title: Rate Limit
 ---
 
-:::tip
+{% tip %}
 Rate Limit is an inbound policy. Dataplanes whose configuration is modified are in the `destinations` matcher.
-:::
+{% endtip %}
 
 The `RateLimit` policy leverages
 Envoy's [local rate limiting](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter)

--- a/app/docs/1.6.x/policies/retry.md
+++ b/app/docs/1.6.x/policies/retry.md
@@ -2,9 +2,9 @@
 title: Retry
 ---
 
-:::tip
+{% tip %}
 Retry is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
-:::
+{% endtip %}
 
 This policy enables Kuma to know how to behave if there is a failed scenario (i.e. HTTP request) which could be retried.
 

--- a/app/docs/1.6.x/policies/traffic-route.md
+++ b/app/docs/1.6.x/policies/traffic-route.md
@@ -2,9 +2,9 @@
 title: Traffic Route
 ---
 
-:::tip
+{% tip %}
 Traffic Route is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
-:::
+{% endtip %}
 
 This policy lets you configure routing rules for the traffic in the mesh. It supports weighted routing and can be used to implement versioning across services or to support deployment strategies such as blue/green or canary.
 

--- a/app/docs/1.7.x/policies/circuit-breaker.md
+++ b/app/docs/1.7.x/policies/circuit-breaker.md
@@ -6,10 +6,6 @@ title: Circuit Breaker
 Circuit Breaker is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
 {% endtip %}
 
-:::tip
-Circuit Breaker is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
-:::
-
 This policy will look for errors in the live traffic being exchanged between our data plane proxies and it will mark a data proxy as an unhealthy if certain conditions are met and - by doing so - making sure that no additional traffic can reach an unhealthy data plane proxy until it is healthy again.
 
 Circuit breakers - unlike active [Health Checks](/docs/{{ page.version }}/policies/health-check/) - do not send additional traffic to our data plane proxies but they rather inspect the existing service traffic. They are also commonly used to prevent cascading failures in our services.

--- a/app/docs/1.8.x/policies/retry.md
+++ b/app/docs/1.8.x/policies/retry.md
@@ -6,10 +6,6 @@ title: Retry
 Retry is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
 {% endtip %}
 
-:::tip
-Retry is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
-:::
-
 This policy enables Kuma to know how to behave if there is a failed scenario (i.e. HTTP request) which could be retried.
 
 ## Usage

--- a/app/docs/dev/policies/retry.md
+++ b/app/docs/dev/policies/retry.md
@@ -6,10 +6,6 @@ title: Retry
 Retry is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
 {% endtip %}
 
-:::tip
-Retry is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
-:::
-
 This policy enables Kuma to know how to behave if there is a failed scenario (i.e. HTTP request) which could be retried.
 
 ## Usage

--- a/app/docs/dev/policies/timeout.md
+++ b/app/docs/dev/policies/timeout.md
@@ -6,10 +6,6 @@ title: Timeout
 Timeout is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
 {% endtip %}
 
-:::tip
-Timeout is an outbound policy. Dataplanes whose configuration is modified are in the `sources` matcher.
-:::
-
 This policy enables Kuma to set timeouts on the outbound connections depending on the protocol.
 
 ## Usage


### PR DESCRIPTION
Signed-off-by: Fabian Rodriguez <fabian.rodriguez@konghq.com>

Fix the syntax for tooltips/warnings. After the merge of the move to Jekyll, some files kept the old syntax and some got duplicated tooltips
