### PR TITLE
Fix indentation filter

### DIFF
--- a/app/_plugins/filters/indent_filter.rb
+++ b/app/_plugins/filters/indent_filter.rb
@@ -2,13 +2,11 @@
 
 module IndentFilter
   def indent(input)
-    input.gsub(/\n/, "\n    ")
-    # Remove the trailing empty line
-    lines = input.split("\n")
-    if lines.last.strip == ""
-      lines.slice(0, lines.length - 2)
-    end
-    lines.join("\n")
+    input
+      .gsub("\n</code>", "</code>")
+      .split("\n")
+      .map { |l| l.prepend("   ") }
+      .join("\n")
   end
 end
 

--- a/app/docs/1.1.x/policies/retry.md
+++ b/app/docs/1.1.x/policies/retry.md
@@ -132,12 +132,15 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
   - 504
   ```
 
-  {% tip %}
-  Note that if you won't provide `retriableStatusCodes`, the default behaviour of the policy is to retry:
-  - when server responds with one of status codes: `502`, `503` or `504`,
-  - when server won't respond at all (disconnect/reset/read timeout),
-  - when server resets the stream with a `REFUSED_STREAM` error code.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+Note that if you won't provide `retriableStatusCodes`, the default behaviour of the policy is to retry:
+- when server responds with one of status codes: `502`, `503` or `504`,
+- when server won't respond at all (disconnect/reset/read timeout),
+- when server resets the stream with a `REFUSED_STREAM` error code.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ### GRPC
 
@@ -155,18 +158,21 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
   - `resource_exhausted`
   - `unavailable`
 
-  {% tip %}
-  Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
+{% capture tooltip %}
+{% tip %}
+Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
 
-  ```yaml
-  retryOn:
-  - cancelled
-  - deadline_exceeded
-  - internal
-  - resource_exhausted
-  - unavailable
-  ```
-  {% endtip %}
+```yaml
+retryOn:
+- cancelled
+- deadline_exceeded
+- internal
+- resource_exhausted
+- unavailable
+```
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ### TCP
 
@@ -174,9 +180,13 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
 
   A maximal amount of TCP connection attempts which will be made before giving up
 
-  {% tip %}
-  This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
-  {% endtip %}
+
+{% capture tooltip %}
+{% tip %}
+This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ## Matching
 

--- a/app/docs/1.2.x/policies/retry.md
+++ b/app/docs/1.2.x/policies/retry.md
@@ -131,13 +131,15 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
   - 503
   - 504
   ```
-
-  {% tip %}
-  Note that if you won't provide `retriableStatusCodes`, the default behaviour of the policy is to retry:
-  - when server responds with one of status codes: `502`, `503` or `504`,
-  - when server won't respond at all (disconnect/reset/read timeout),
-  - when server resets the stream with a `REFUSED_STREAM` error code.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+Note that if you won't provide `retriableStatusCodes`, the default behaviour of the policy is to retry:
+- when server responds with one of status codes: `502`, `503` or `504`,
+- when server won't respond at all (disconnect/reset/read timeout),
+- when server resets the stream with a `REFUSED_STREAM` error code.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ### GRPC
 
@@ -155,18 +157,21 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
   - `resource_exhausted`
   - `unavailable`
 
-  {% tip %}
-  Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
+{% capture tooltip %}
+{% tip %}
+Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
 
-  ```yaml
-  retryOn:
-  - cancelled
-  - deadline_exceeded
-  - internal
-  - resource_exhausted
-  - unavailable
-  ```
-  {% endtip %}
+```yaml
+retryOn:
+- cancelled
+- deadline_exceeded
+- internal
+- resource_exhausted
+- unavailable
+```
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ### TCP
 
@@ -174,9 +179,12 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
 
   A maximal amount of TCP connection attempts which will be made before giving up
 
-  {% tip %}
-  This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ## Matching
 

--- a/app/docs/1.3.x/policies/retry.md
+++ b/app/docs/1.3.x/policies/retry.md
@@ -132,12 +132,15 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
   - 504
   ```
 
-  {% tip %}
-  Note that if you won't provide `retriableStatusCodes`, the default behaviour of the policy is to retry:
-  - when server responds with one of status codes: `502`, `503` or `504`,
-  - when server won't respond at all (disconnect/reset/read timeout),
-  - when server resets the stream with a `REFUSED_STREAM` error code.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+Note that if you won't provide `retriableStatusCodes`, the default behaviour of the policy is to retry:
+- when server responds with one of status codes: `502`, `503` or `504`,
+- when server won't respond at all (disconnect/reset/read timeout),
+- when server resets the stream with a `REFUSED_STREAM` error code.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ### GRPC
 
@@ -155,18 +158,21 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
   - `resource_exhausted`
   - `unavailable`
 
-  {% tip %}
-  Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
+{% capture tooltip %}
+{% tip %}
+Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
 
-  ```yaml
-  retryOn:
-  - cancelled
-  - deadline_exceeded
-  - internal
-  - resource_exhausted
-  - unavailable
-  ```
-  {% endtip %}
+```yaml
+retryOn:
+- cancelled
+- deadline_exceeded
+- internal
+- resource_exhausted
+- unavailable
+```
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ### TCP
 
@@ -174,9 +180,12 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
 
   A maximal amount of TCP connection attempts which will be made before giving up
 
-  {% tip %}
-  This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ## Matching
 

--- a/app/docs/1.4.x/policies/retry.md
+++ b/app/docs/1.4.x/policies/retry.md
@@ -137,12 +137,16 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
   - 504
   ```
 
-  {% tip %}
-  Note that if you won't provide `retriableStatusCodes`, the default behaviour of the policy is to retry:
-  - when server responds with one of status codes: `502`, `503` or `504`,
-  - when server won't respond at all (disconnect/reset/read timeout),
-  - when server resets the stream with a `REFUSED_STREAM` error code.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+Note that if you won't provide `retriableStatusCodes`, the default behaviour of the policy is to retry:
+- when server responds with one of status codes: `502`, `503` or `504`,
+- when server won't respond at all (disconnect/reset/read timeout),
+- when server resets the stream with a `REFUSED_STREAM` error code.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
+
 - **`retriableMethods`** (optional)
 
   A list of HTTP methods in which a request's method must be contained before that request can be retried. The default behavior is that all methods are retriable.
@@ -164,18 +168,21 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
   - `resource_exhausted`
   - `unavailable`
 
-  {% tip %}
-  Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
+{% capture tooltip %}
+{% tip %}
+Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
 
-  ```yaml
-  retryOn:
-  - cancelled
-  - deadline_exceeded
-  - internal
-  - resource_exhausted
-  - unavailable
-  ```
-  {% endtip %}
+```yaml
+retryOn:
+- cancelled
+- deadline_exceeded
+- internal
+- resource_exhausted
+- unavailable
+```
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ### TCP
 
@@ -183,9 +190,12 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
 
   A maximal amount of TCP connection attempts which will be made before giving up
 
-  {% tip %}
-  This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ## Matching
 

--- a/app/docs/1.5.x/policies/retry.md
+++ b/app/docs/1.5.x/policies/retry.md
@@ -137,12 +137,16 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
   - 504
   ```
 
-  {% tip %}
-  Note that if you won't provide `retriableStatusCodes`, the default behaviour of the policy is to retry:
-  - when server responds with one of status codes: `502`, `503` or `504`,
-  - when server won't respond at all (disconnect/reset/read timeout),
-  - when server resets the stream with a `REFUSED_STREAM` error code.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+Note that if you won't provide `retriableStatusCodes`, the default behaviour of the policy is to retry:
+- when server responds with one of status codes: `502`, `503` or `504`,
+- when server won't respond at all (disconnect/reset/read timeout),
+- when server resets the stream with a `REFUSED_STREAM` error code.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
+
 - **`retriableMethods`** (optional)
 
   A list of HTTP methods in which a request's method must be contained before that request can be retried. The default behavior is that all methods are retriable.
@@ -164,18 +168,21 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
   - `resource_exhausted`
   - `unavailable`
 
-  {% tip %}
-  Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
+{% capture tooltip %}
+{% tip %}
+Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
 
-  ```yaml
-  retryOn:
-  - cancelled
-  - deadline_exceeded
-  - internal
-  - resource_exhausted
-  - unavailable
-  ```
-  {% endtip %}
+```yaml
+retryOn:
+- cancelled
+- deadline_exceeded
+- internal
+- resource_exhausted
+- unavailable
+```
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ### TCP
 
@@ -183,9 +190,12 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
 
   A maximal amount of TCP connection attempts which will be made before giving up
 
-  {% tip %}
-  This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ## Matching
 

--- a/app/docs/1.6.x/policies/retry.md
+++ b/app/docs/1.6.x/policies/retry.md
@@ -141,12 +141,16 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
   - 504
   ```
 
-  {% tip %}
-  Note that if you won't provide `retriableStatusCodes`, the default behaviour of the policy is to retry:
-  - when server responds with one of status codes: `502`, `503` or `504`,
-  - when server won't respond at all (disconnect/reset/read timeout),
-  - when server resets the stream with a `REFUSED_STREAM` error code.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+Note that if you won't provide `retriableStatusCodes`, the default behaviour of the policy is to retry:
+- when server responds with one of status codes: `502`, `503` or `504`,
+- when server won't respond at all (disconnect/reset/read timeout),
+- when server resets the stream with a `REFUSED_STREAM` error code.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
+
 - **`retriableMethods`** (optional)
 
   A list of HTTP methods in which a request's method must be contained before that request can be retried. The default behavior is that all methods are retriable.
@@ -168,18 +172,21 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
   - `resource_exhausted`
   - `unavailable`
 
-  {% tip %}
-  Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
+{% capture tooltip %}
+{% tip %}
+Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
 
-  ```yaml
-  retryOn:
-  - cancelled
-  - deadline_exceeded
-  - internal
-  - resource_exhausted
-  - unavailable
-  ```
-  {% endtip %}
+```yaml
+retryOn:
+- cancelled
+- deadline_exceeded
+- internal
+- resource_exhausted
+- unavailable
+```
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ### TCP
 
@@ -187,9 +194,12 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
 
   A maximal amount of TCP connection attempts which will be made before giving up
 
-  {% tip %}
-  This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ## Matching
 

--- a/app/docs/1.7.x/policies/retry.md
+++ b/app/docs/1.7.x/policies/retry.md
@@ -141,12 +141,16 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
   - 504
   ```
 
-  {% tip %}
-  Note that if you won't provide `retriableStatusCodes`, the default behaviour of the policy is to retry:
-  - when server responds with one of status codes: `502`, `503` or `504`,
-  - when server won't respond at all (disconnect/reset/read timeout),
-  - when server resets the stream with a `REFUSED_STREAM` error code.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+Note that if you won't provide `retriableStatusCodes`, the default behaviour of the policy is to retry:
+- when server responds with one of status codes: `502`, `503` or `504`,
+- when server won't respond at all (disconnect/reset/read timeout),
+- when server resets the stream with a `REFUSED_STREAM` error code.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
+
 - **`retriableMethods`** (optional)
 
   A list of HTTP methods in which a request's method must be contained before that request can be retried. The default behavior is that all methods are retriable.
@@ -168,18 +172,21 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
   - `resource_exhausted`
   - `unavailable`
 
-  {% tip %}
-  Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
+{% capture tooltip %}
+{% tip %}
+Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
 
-  ```yaml
-  retryOn:
-  - cancelled
-  - deadline_exceeded
-  - internal
-  - resource_exhausted
-  - unavailable
-  ```
-  {% endtip %}
+```yaml
+retryOn:
+- cancelled
+- deadline_exceeded
+- internal
+- resource_exhausted
+- unavailable
+```
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ### TCP
 
@@ -187,9 +194,12 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
 
   A maximal amount of TCP connection attempts which will be made before giving up
 
-  {% tip %}
-  This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ## Matching
 

--- a/app/docs/1.8.x/policies/retry.md
+++ b/app/docs/1.8.x/policies/retry.md
@@ -141,9 +141,12 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
   - 504
   ```
 
-  {% tip %}
+{% capture tooltip %}
+{% tip %}
   If both `retriableStatusCodes` is provided in addition to `retryOn` (below), but the latter doesn't contain `retriable_status_codes` as a condition, it will be automatically added.
-  {% endtip %}
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 - **`retryOn`** (optional)
 
@@ -162,21 +165,24 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
   - `retriable_headers`
   - `http3_post_connect_failure`
 
-  {% tip %}
-  Note that if `retryOn` is not defined or if it's empty, the policy will default to the equivalent of:
+{% capture tooltips %}
+{% tip %}
+Note that if `retryOn` is not defined or if it's empty, the policy will default to the equivalent of:
 
-  ```yaml
-  retryOn:
-  - gateway_error
-  - connect_failure
-  - refused_stream
-  ```
-  {% endtip %}
+```yaml
+retryOn:
+- gateway_error
+- connect_failure
+- refused_stream
+```
 
-  {% warning %}
-  Providing `retriable_status_codes` without also providing 
-  `retriableStatusCodes` (above) will fail policy validation.
-  {% endwarning %}
+{% endtip %}
+{% warning %}
+Providing `retriable_status_codes` without also providing 
+`retriableStatusCodes` (above) will fail policy validation.
+{% endwarning %}
+{% endcapture %}
+{{ tooltips | indent }}
 
 - **`retriableMethods`** (optional)
 
@@ -199,8 +205,10 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
   - `resource_exhausted`
   - `unavailable`
 
-  {% tip %}
-  Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
+
+{% capture tooltip %}
+{% tip %}
+Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
 
   ```yaml
   retryOn:
@@ -210,7 +218,10 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
   - resource_exhausted
   - unavailable
   ```
-  {% endtip %}
+
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ### TCP
 
@@ -218,9 +229,12 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
 
   A maximal amount of TCP connection attempts which will be made before giving up
 
-  {% tip %}
-  This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ## Matching
 

--- a/app/docs/dev/policies/retry.md
+++ b/app/docs/dev/policies/retry.md
@@ -141,9 +141,12 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
   - 504
   ```
 
-  {% tip %}
-  If both `retriableStatusCodes` is provided in addition to `retryOn` (below), but the latter doesn't contain `retriable_status_codes` as a condition, it will be automatically added.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+If both `retriableStatusCodes` is provided in addition to `retryOn` (below), but the latter doesn't contain `retriable_status_codes` as a condition, it will be automatically added.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 - **`retryOn`** (optional)
 
@@ -162,21 +165,24 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
   - `retriable_headers`
   - `http3_post_connect_failure`
 
-  {% tip %}
-  Note that if `retryOn` is not defined or if it's empty, the policy will default to the equivalent of:
+{% capture tooltips %}
+{% tip %}
+Note that if `retryOn` is not defined or if it's empty, the policy will default to the equivalent of:
 
-  ```yaml
-  retryOn:
-  - gateway_error
-  - connect_failure
-  - refused_stream
-  ```
-  {% endtip %}
+```yaml
+retryOn:
+- gateway_error
+- connect_failure
+- refused_stream
+```
+{% endtip %}
 
-  {% warning %}
-  Providing `retriable_status_codes` without also providing 
-  `retriableStatusCodes` (above) will fail policy validation.
-  {% endwarning %}
+{% warning %}
+Providing `retriable_status_codes` without also providing 
+`retriableStatusCodes` (above) will fail policy validation.
+{% endwarning %}
+{% endcapture %}
+{{ tooltips | indent }}
 
 - **`retriableMethods`** (optional)
 
@@ -199,18 +205,21 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
   - `resource_exhausted`
   - `unavailable`
 
-  {% tip %}
-  Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
+{% capture tooltip %}
+{% tip %}
+Note that if `retryOn` is not defined or if it's empty, the policy will default to all values and is equivalent to:
 
-  ```yaml
-  retryOn:
-  - cancelled
-  - deadline_exceeded
-  - internal
-  - resource_exhausted
-  - unavailable
-  ```
-  {% endtip %}
+```yaml
+retryOn:
+- cancelled
+- deadline_exceeded
+- internal
+- resource_exhausted
+- unavailable
+```
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ### TCP
 
@@ -218,9 +227,12 @@ You can configure your GRPC Retry policy in similar fashion as the HTTP one with
 
   A maximal amount of TCP connection attempts which will be made before giving up
 
-  {% tip %}
-  This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
-  {% endtip %}
+{% capture tooltip %}
+{% tip %}
+This policy will make attempt to retry the TCP connection which fail to be established and will be applied in the scenario when both, the dataplane, and the TCP service matched as a destination will be down.
+{% endtip %}
+{% endcapture %}
+{{ tooltip | indent }}
 
 ## Matching
 


### PR DESCRIPTION
It prepends 4 spaces to every line

It also fixes an edge case regarding code snippets being part of the
content to be indented. Previously, it was adding an extra newline to
the code snippet.

Fixes https://github.com/kumahq/kuma-website/issues/1102

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? Yes
