### PR TITLE
docs(observability)  Add information that in order to see dataplane metrics, you first need to create Traffic Metrics policy

### DIFF
--- a/app/docs/1.7.x/explore/observability.md
+++ b/app/docs/1.7.x/explore/observability.md
@@ -179,7 +179,7 @@ Kuma ships with default dashboards that are available to import from [the Grafan
 
 ##### Kuma Dataplane
 
-This dashboard lets you investigate the status of a single dataplane in the mesh.
+This dashboard lets you investigate the status of a single dataplane in the mesh. In order to see those metrics, you need to create [Traffic Metrics policy](/docs/{{ page.version }}/policies/traffic-metrics/) first. 
 
 <center>
 <img src="/assets/images/docs/0.4.0/kuma_dp1.jpeg" alt="Kuma Dataplane dashboard" style="width: 600px; padding-top: 20px; padding-bottom: 10px;"/>

--- a/app/docs/1.8.x/explore/observability.md
+++ b/app/docs/1.8.x/explore/observability.md
@@ -216,7 +216,7 @@ Kuma ships with default dashboards that are available to import from [the Grafan
 
 ##### Kuma Dataplane
 
-This dashboard lets you investigate the status of a single dataplane in the mesh.
+This dashboard lets you investigate the status of a single dataplane in the mesh. In order to see those metrics, you need to create [Traffic Metrics policy](/docs/{{ page.version }}/policies/traffic-metrics/) first. 
 
 <center>
 <img src="/assets/images/docs/0.4.0/kuma_dp1.jpeg" alt="Kuma Dataplane dashboard" style="width: 600px; padding-top: 20px; padding-bottom: 10px;"/>

--- a/app/docs/dev/explore/observability.md
+++ b/app/docs/dev/explore/observability.md
@@ -190,7 +190,7 @@ Kuma ships with default dashboards that are available to import from [the Grafan
 
 ##### Kuma Dataplane
 
-This dashboard lets you investigate the status of a single dataplane in the mesh.
+This dashboard lets you investigate the status of a single dataplane in the mesh. In order to see those metrics, you need to create [Traffic Metrics policy](/docs/{{ page.version }}/policies/traffic-metrics/) first. 
 
 <center>
 <img src="/assets/images/docs/0.4.0/kuma_dp1.jpeg" alt="Kuma Dataplane dashboard" style="width: 600px; padding-top: 20px; padding-bottom: 10px;"/>


### PR DESCRIPTION
 Add information that in order to see dataplane metrics, you first need to create Traffic Metrics policy.

Fixes: #1002 

Signed-off-by: Marcin Skalski <marcin.skalski@konghq.com>
