### PR TITLE
feat(kumacp): backport docker auth to older versions of doc

### DIFF
--- a/app/docs/1.1.x/installation/docker.md
+++ b/app/docs/1.1.x/installation/docker.md
@@ -56,6 +56,39 @@ To learn more, read the [multi-zone installation instructions](/docs/{{ page.ver
 **Note**: By default this will run Kuma with a `memory` [backend](/docs/{{ page.version }}/documentation/backends), but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 {% endtip %}
 
+#### 2.1 Authentication (optional)
+
+Running administrative tasks (like generating a dataplane token) requires [authentication by token](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) or a connection via localhost.
+
+##### 2.1.1 Localhost
+
+For `kuma-cp` to recognize requests issued to docker published port it needs to run the container in the host network.
+To do this, add `--network="host"` parameter to the `docker run` command from point 2.
+
+##### 2.1.2 Authenticating via token
+
+You can also configure `kumactl` to access `kuma-dp` from the container.
+Get the `kuma-cp` container id:
+
+```sh
+docker ps # copy kuma-cp container id
+
+export KUMA_CP_CONTAINER_ID='...'
+```
+
+Configure `kumactl`:
+
+```sh
+TOKEN=$(bash -c "docker exec -it $KUMA_CP_CONTAINER_ID wget -q -O - http://localhost:5681/global-secrets/admin-user-token" | jq -r .data | base64 -d)
+
+kumactl config control-planes add \
+ --name my-control-plane \
+ --address http://localhost:5681 \
+ --auth-type=tokens \
+ --auth-conf token=$TOKEN \
+ --skip-verify
+```
+
 ### 3. Use Kuma
 
 Kuma (`kuma-cp`) is now running! Now that Kuma has been installed you can access the control-plane via either the GUI, the HTTP API, or the CLI:

--- a/app/docs/1.2.x/installation/docker.md
+++ b/app/docs/1.2.x/installation/docker.md
@@ -56,6 +56,39 @@ To learn more, read the [multi-zone installation instructions](/docs/{{ page.ver
 **Note**: By default this will run Kuma with a `memory` [backend](/docs/{{ page.version }}/documentation/backends), but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 {% endtip %}
 
+#### 2.1 Authentication (optional)
+
+Running administrative tasks (like generating a dataplane token) requires [authentication by token](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) or a connection via localhost.
+
+##### 2.1.1 Localhost
+
+For `kuma-cp` to recognize requests issued to docker published port it needs to run the container in the host network.
+To do this, add `--network="host"` parameter to the `docker run` command from point 2.
+
+##### 2.1.2 Authenticating via token
+
+You can also configure `kumactl` to access `kuma-dp` from the container.
+Get the `kuma-cp` container id:
+
+```sh
+docker ps # copy kuma-cp container id
+
+export KUMA_CP_CONTAINER_ID='...'
+```
+
+Configure `kumactl`:
+
+```sh
+TOKEN=$(bash -c "docker exec -it $KUMA_CP_CONTAINER_ID wget -q -O - http://localhost:5681/global-secrets/admin-user-token" | jq -r .data | base64 -d)
+
+kumactl config control-planes add \
+ --name my-control-plane \
+ --address http://localhost:5681 \
+ --auth-type=tokens \
+ --auth-conf token=$TOKEN \
+ --skip-verify
+```
+
 ### 3. Use Kuma
 
 Kuma (`kuma-cp`) is now running! Now that Kuma has been installed you can access the control-plane via either the GUI, the HTTP API, or the CLI:

--- a/app/docs/1.2.x/quickstart/universal.md
+++ b/app/docs/1.2.x/quickstart/universal.md
@@ -50,6 +50,11 @@ kumactl generate dataplane-token --name=redis > kuma-token-redis
 kumactl generate dataplane-token --name=app > kuma-token-app
 ```
 
+{% warning %}
+This action requires [authentication](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) unless executed against a control-plane running on localhost.
+If `kuma-cp` is running inside docker container please see [docker authentication docs](/docs/{{ page.version }}//installation/docker#21-authentication-optional).
+{% endwarning %}
+
 ## Create a data plane proxy for each service
 
 For Redis:

--- a/app/docs/1.3.x/installation/docker.md
+++ b/app/docs/1.3.x/installation/docker.md
@@ -56,6 +56,39 @@ To learn more, read the [multi-zone installation instructions](/docs/{{ page.ver
 **Note**: By default this will run Kuma with a `memory` [backend](/docs/{{ page.version }}/documentation/backends), but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 {% endtip %}
 
+#### 2.1 Authentication (optional)
+
+Running administrative tasks (like generating a dataplane token) requires [authentication by token](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) or a connection via localhost.
+
+##### 2.1.1 Localhost
+
+For `kuma-cp` to recognize requests issued to docker published port it needs to run the container in the host network.
+To do this, add `--network="host"` parameter to the `docker run` command from point 2.
+
+##### 2.1.2 Authenticating via token
+
+You can also configure `kumactl` to access `kuma-dp` from the container.
+Get the `kuma-cp` container id:
+
+```sh
+docker ps # copy kuma-cp container id
+
+export KUMA_CP_CONTAINER_ID='...'
+```
+
+Configure `kumactl`:
+
+```sh
+TOKEN=$(bash -c "docker exec -it $KUMA_CP_CONTAINER_ID wget -q -O - http://localhost:5681/global-secrets/admin-user-token" | jq -r .data | base64 -d)
+
+kumactl config control-planes add \
+ --name my-control-plane \
+ --address http://localhost:5681 \
+ --auth-type=tokens \
+ --auth-conf token=$TOKEN \
+ --skip-verify
+```
+
 ### 3. Use Kuma
 
 Kuma (`kuma-cp`) is now running! Now that Kuma has been installed you can access the control-plane via either the GUI, the HTTP API, or the CLI:

--- a/app/docs/1.3.x/quickstart/universal.md
+++ b/app/docs/1.3.x/quickstart/universal.md
@@ -50,6 +50,11 @@ kumactl generate dataplane-token --name=redis > kuma-token-redis
 kumactl generate dataplane-token --name=app > kuma-token-app
 ```
 
+{% warning %}
+This action requires [authentication](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) unless executed against a control-plane running on localhost.
+If `kuma-cp` is running inside docker container please see [docker authentication docs](/docs/{{ page.version }}//installation/docker#21-authentication-optional).
+{% endwarning %}
+
 ## Create a data plane proxy for each service
 
 For Redis:

--- a/app/docs/1.4.x/installation/docker.md
+++ b/app/docs/1.4.x/installation/docker.md
@@ -56,6 +56,39 @@ To learn more, read the [multi-zone installation instructions](/docs/{{ page.ver
 **Note**: By default this will run Kuma with a `memory` [backend](/docs/{{ page.version }}/documentation/backends), but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 {% endtip %}
 
+#### 2.1 Authentication (optional)
+
+Running administrative tasks (like generating a dataplane token) requires [authentication by token](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) or a connection via localhost.
+
+##### 2.1.1 Localhost
+
+For `kuma-cp` to recognize requests issued to docker published port it needs to run the container in the host network.
+To do this, add `--network="host"` parameter to the `docker run` command from point 2.
+
+##### 2.1.2 Authenticating via token
+
+You can also configure `kumactl` to access `kuma-dp` from the container.
+Get the `kuma-cp` container id:
+
+```sh
+docker ps # copy kuma-cp container id
+
+export KUMA_CP_CONTAINER_ID='...'
+```
+
+Configure `kumactl`:
+
+```sh
+TOKEN=$(bash -c "docker exec -it $KUMA_CP_CONTAINER_ID wget -q -O - http://localhost:5681/global-secrets/admin-user-token" | jq -r .data | base64 -d)
+
+kumactl config control-planes add \
+ --name my-control-plane \
+ --address http://localhost:5681 \
+ --auth-type=tokens \
+ --auth-conf token=$TOKEN \
+ --skip-verify
+```
+
 ### 3. Use Kuma
 
 Kuma (`kuma-cp`) is now running! Now that Kuma has been installed you can access the control-plane via either the GUI, the HTTP API, or the CLI:

--- a/app/docs/1.4.x/quickstart/universal.md
+++ b/app/docs/1.4.x/quickstart/universal.md
@@ -50,6 +50,11 @@ kumactl generate dataplane-token --name=redis > kuma-token-redis
 kumactl generate dataplane-token --name=app > kuma-token-app
 ```
 
+{% warning %}
+This action requires [authentication](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) unless executed against a control-plane running on localhost.
+If `kuma-cp` is running inside docker container please see [docker authentication docs](/docs/{{ page.version }}//installation/docker#21-authentication-optional).
+{% endwarning %}
+
 ## Create a data plane proxy for each service
 
 For Redis:

--- a/app/docs/1.5.x/installation/docker.md
+++ b/app/docs/1.5.x/installation/docker.md
@@ -52,6 +52,39 @@ To learn more, read the [multi-zone installation instructions](/docs/{{ page.ver
 **Note**: By default this will run Kuma with a `memory` [backend](/docs/{{ page.version }}/documentation/backends), but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 {% endtip %}
 
+#### 2.1 Authentication (optional)
+
+Running administrative tasks (like generating a dataplane token) requires [authentication by token](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) or a connection via localhost.
+
+##### 2.1.1 Localhost
+
+For `kuma-cp` to recognize requests issued to docker published port it needs to run the container in the host network.
+To do this, add `--network="host"` parameter to the `docker run` command from point 2.
+
+##### 2.1.2 Authenticating via token
+
+You can also configure `kumactl` to access `kuma-dp` from the container.
+Get the `kuma-cp` container id:
+
+```sh
+docker ps # copy kuma-cp container id
+
+export KUMA_CP_CONTAINER_ID='...'
+```
+
+Configure `kumactl`:
+
+```sh
+TOKEN=$(bash -c "docker exec -it $KUMA_CP_CONTAINER_ID wget -q -O - http://localhost:5681/global-secrets/admin-user-token" | jq -r .data | base64 -d)
+
+kumactl config control-planes add \
+ --name my-control-plane \
+ --address http://localhost:5681 \
+ --auth-type=tokens \
+ --auth-conf token=$TOKEN \
+ --skip-verify
+```
+
 ### 3. Use Kuma
 
 Kuma (`kuma-cp`) is now running! Now that Kuma has been installed you can access the control-plane via either the GUI, the HTTP API, or the CLI:

--- a/app/docs/1.5.x/quickstart/universal.md
+++ b/app/docs/1.5.x/quickstart/universal.md
@@ -50,6 +50,11 @@ kumactl generate dataplane-token --name=redis > kuma-token-redis
 kumactl generate dataplane-token --name=app > kuma-token-app
 ```
 
+{% warning %}
+This action requires [authentication](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) unless executed against a control-plane running on localhost.
+If `kuma-cp` is running inside docker container please see [docker authentication docs](/docs/{{ page.version }}//installation/docker#21-authentication-optional).
+{% endwarning %}
+
 ## Create a data plane proxy for each service
 
 For Redis:

--- a/app/docs/1.6.x/installation/docker.md
+++ b/app/docs/1.6.x/installation/docker.md
@@ -35,6 +35,39 @@ This example will run Kuma in `standalone` mode for a "flat" deployment, but the
 **Note**: By default this will run Kuma with a `memory` [backend](/docs/{{ page.version }}/explore/backends), but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 {% endtip %}
 
+#### 2.1 Authentication (optional)
+
+Running administrative tasks (like generating a dataplane token) requires [authentication by token](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) or a connection via localhost.
+
+##### 2.1.1 Localhost
+
+For `kuma-cp` to recognize requests issued to docker published port it needs to run the container in the host network.
+To do this, add `--network="host"` parameter to the `docker run` command from point 2.
+
+##### 2.1.2 Authenticating via token
+
+You can also configure `kumactl` to access `kuma-dp` from the container.
+Get the `kuma-cp` container id:
+
+```sh
+docker ps # copy kuma-cp container id
+
+export KUMA_CP_CONTAINER_ID='...'
+```
+
+Configure `kumactl`:
+
+```sh
+TOKEN=$(bash -c "docker exec -it $KUMA_CP_CONTAINER_ID wget -q -O - http://localhost:5681/global-secrets/admin-user-token" | jq -r .data | base64 -d)
+
+kumactl config control-planes add \
+ --name my-control-plane \
+ --address http://localhost:5681 \
+ --auth-type=tokens \
+ --auth-conf token=$TOKEN \
+ --skip-verify
+```
+
 ### 3. Use Kuma
 
 Kuma (`kuma-cp`) is now running! Now that Kuma has been installed you can access the control-plane via either the GUI, the HTTP API, or the CLI:

--- a/app/docs/1.6.x/quickstart/universal.md
+++ b/app/docs/1.6.x/quickstart/universal.md
@@ -50,6 +50,11 @@ kumactl generate dataplane-token --name=redis > kuma-token-redis
 kumactl generate dataplane-token --name=app > kuma-token-app
 ```
 
+{% warning %}
+This action requires [authentication](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) unless executed against a control-plane running on localhost.
+If `kuma-cp` is running inside docker container please see [docker authentication docs](/docs/{{ page.version }}//installation/docker#21-authentication-optional).
+{% endwarning %}
+
 ## Create a data plane proxy for each service
 
 For Redis:

--- a/app/docs/1.7.x/installation/docker.md
+++ b/app/docs/1.7.x/installation/docker.md
@@ -35,6 +35,39 @@ This example will run Kuma in `standalone` mode for a "flat" deployment, but the
 **Note**: By default this will run Kuma with a `memory` [backend](/docs/{{ page.version }}/explore/backends), but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 {% endtip %}
 
+#### 2.1 Authentication (optional)
+
+Running administrative tasks (like generating a dataplane token) requires [authentication by token](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) or a connection via localhost.
+
+##### 2.1.1 Localhost
+
+For `kuma-cp` to recognize requests issued to docker published port it needs to run the container in the host network.
+To do this, add `--network="host"` parameter to the `docker run` command from point 2.
+
+##### 2.1.2 Authenticating via token
+
+You can also configure `kumactl` to access `kuma-dp` from the container.
+Get the `kuma-cp` container id:
+
+```sh
+docker ps # copy kuma-cp container id
+
+export KUMA_CP_CONTAINER_ID='...'
+```
+
+Configure `kumactl`:
+
+```sh
+TOKEN=$(bash -c "docker exec -it $KUMA_CP_CONTAINER_ID wget -q -O - http://localhost:5681/global-secrets/admin-user-token" | jq -r .data | base64 -d)
+
+kumactl config control-planes add \
+ --name my-control-plane \
+ --address http://localhost:5681 \
+ --auth-type=tokens \
+ --auth-conf token=$TOKEN \
+ --skip-verify
+```
+
 ### 3. Use Kuma
 
 Kuma (`kuma-cp`) is now running! Now that Kuma has been installed you can access the control-plane via either the GUI, the HTTP API, or the CLI:

--- a/app/docs/1.7.x/quickstart/universal.md
+++ b/app/docs/1.7.x/quickstart/universal.md
@@ -50,6 +50,11 @@ kumactl generate dataplane-token --name=redis > kuma-token-redis
 kumactl generate dataplane-token --name=app > kuma-token-app
 ```
 
+{% warning %}
+This action requires [authentication](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) unless executed against a control-plane running on localhost.
+If `kuma-cp` is running inside docker container please see [docker authentication docs](/docs/{{ page.version }}//installation/docker#21-authentication-optional).
+{% endwarning %}
+
 ## Create a data plane proxy for each service
 
 For Redis:

--- a/app/docs/1.8.x/installation/docker.md
+++ b/app/docs/1.8.x/installation/docker.md
@@ -35,6 +35,39 @@ This example will run Kuma in `standalone` mode for a "flat" deployment, but the
 **Note**: By default this will run Kuma with a `memory` [store](/docs/{{ page.version }}/documentation/configuration#store), but you can use a persistent storage like PostgreSQL by updating the `conf/kuma-cp.conf` file.
 {% endtip %}
 
+#### 2.1 Authentication (optional)
+
+Running administrative tasks (like generating a dataplane token) requires [authentication by token](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) or a connection via localhost.
+
+##### 2.1.1 Localhost
+
+For `kuma-cp` to recognize requests issued to docker published port it needs to run the container in the host network.
+To do this, add `--network="host"` parameter to the `docker run` command from point 2.
+
+##### 2.1.2 Authenticating via token
+
+You can also configure `kumactl` to access `kuma-dp` from the container.
+Get the `kuma-cp` container id:
+
+```sh
+docker ps # copy kuma-cp container id
+
+export KUMA_CP_CONTAINER_ID='...'
+```
+
+Configure `kumactl`:
+
+```sh
+TOKEN=$(bash -c "docker exec -it $KUMA_CP_CONTAINER_ID wget -q -O - http://localhost:5681/global-secrets/admin-user-token" | jq -r .data | base64 -d)
+
+kumactl config control-planes add \
+ --name my-control-plane \
+ --address http://localhost:5681 \
+ --auth-type=tokens \
+ --auth-conf token=$TOKEN \
+ --skip-verify
+```
+
 ### 3. Use Kuma
 
 Kuma (`kuma-cp`) is now running! Now that Kuma has been installed you can access the control-plane via either the GUI, the HTTP API, or the CLI:

--- a/app/docs/1.8.x/quickstart/universal.md
+++ b/app/docs/1.8.x/quickstart/universal.md
@@ -50,6 +50,11 @@ kumactl generate dataplane-token --name=redis > kuma-token-redis
 kumactl generate dataplane-token --name=app > kuma-token-app
 ```
 
+{% warning %}
+This action requires [authentication](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) unless executed against a control-plane running on localhost.
+If `kuma-cp` is running inside docker container please see [docker authentication docs](/docs/{{ page.version }}//installation/docker#21-authentication-optional).
+{% endwarning %}
+
 ## Create a data plane proxy for each service
 
 For Redis:


### PR DESCRIPTION
Forgot to backport https://github.com/kumahq/kuma-website/pull/1125 in the orignal PR 🤦‍♂️.

Signed-off-by: slonka <slonka@users.noreply.github.com>

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
