### PR TITLE
fix(kumadp): add missing info on multizone installation

### DIFF
--- a/app/docs/1.5.x/deployments/multi-zone.md
+++ b/app/docs/1.5.x/deployments/multi-zone.md
@@ -248,9 +248,22 @@ You need the following values to pass to each zone control plane setup:
     --dataplane-file=ingress-dp.yaml
     ```
 
-(Optional) If you want to deploy zone egress:
+   If zone-ingress is running on a different machine than zone-cp you need to
+   copy CA cert file from zone-cp (located in `~/.kuma/kuma-cp.crt`) to somewhere accessible by zone-ingress (e.g. `/tmp/kuma-cp.crt`).
+   Modify the above command and provide the certificate path in `--ca-cert-file` argument.
 
-5. Generate the zone token with `egress` in scope:
+   ```sh
+   kuma-dp run \
+   --proxy-type=ingress \
+   --cp-address=https://<kuma-cp-address>:5678 \
+   --dataplane-token-file=/tmp/zone-token \
+   --ca-cert-file=/tmp/kuma-cp.crt \
+   --dataplane-file=ingress-dp.yaml
+   ```
+
+5. Optional: if you want to deploy zone egress
+
+   Create a `ZoneEgress` data plane proxy configuration to allow `kuma-cp` services
 
    To register the zone egress with the zone control plane, we need to generate
    a zone token first with appropriate scope first:

--- a/app/docs/1.6.x/deployments/multi-zone.md
+++ b/app/docs/1.6.x/deployments/multi-zone.md
@@ -248,9 +248,22 @@ You need the following values to pass to each zone control plane setup:
     --dataplane-file=ingress-dp.yaml
     ```
 
-(Optional) If you want to deploy zone egress:
+   If zone-ingress is running on a different machine than zone-cp you need to
+   copy CA cert file from zone-cp (located in `~/.kuma/kuma-cp.crt`) to somewhere accessible by zone-ingress (e.g. `/tmp/kuma-cp.crt`).
+   Modify the above command and provide the certificate path in `--ca-cert-file` argument.
 
-5. Generate the zone token with `egress` in scope:
+   ```sh
+   kuma-dp run \
+   --proxy-type=ingress \
+   --cp-address=https://<kuma-cp-address>:5678 \
+   --dataplane-token-file=/tmp/zone-token \
+   --ca-cert-file=/tmp/kuma-cp.crt \
+   --dataplane-file=ingress-dp.yaml
+   ```
+
+5. Optional: if you want to deploy zone egress
+
+   Create a `ZoneEgress` data plane proxy configuration to allow `kuma-cp` services
 
    To register the zone egress with the zone control plane, we need to generate
    a zone token first with appropriate scope first:

--- a/app/docs/1.7.x/deployments/multi-zone.md
+++ b/app/docs/1.7.x/deployments/multi-zone.md
@@ -268,9 +268,22 @@ You need the following values to pass to each zone control plane setup:
     --dataplane-file=ingress-dp.yaml
     ```
 
-(Optional) If you want to deploy zone egress:
+   If zone-ingress is running on a different machine than zone-cp you need to
+   copy CA cert file from zone-cp (located in `~/.kuma/kuma-cp.crt`) to somewhere accessible by zone-ingress (e.g. `/tmp/kuma-cp.crt`).
+   Modify the above command and provide the certificate path in `--ca-cert-file` argument.
 
-5. Generate the zone token with `egress` in scope:
+   ```sh
+   kuma-dp run \
+   --proxy-type=ingress \
+   --cp-address=https://<kuma-cp-address>:5678 \
+   --dataplane-token-file=/tmp/zone-token \
+   --ca-cert-file=/tmp/kuma-cp.crt \
+   --dataplane-file=ingress-dp.yaml
+   ```
+
+5. Optional: if you want to deploy zone egress
+
+   Create a `ZoneEgress` data plane proxy configuration to allow `kuma-cp` services
 
    To register the zone egress with the zone control plane, we need to generate
    a zone token first with appropriate scope first:

--- a/app/docs/1.8.x/deployments/multi-zone.md
+++ b/app/docs/1.8.x/deployments/multi-zone.md
@@ -270,9 +270,22 @@ You need the following values to pass to each zone control plane setup:
     --dataplane-file=ingress-dp.yaml
     ```
 
-(Optional) If you want to deploy zone egress:
+   If zone-ingress is running on a different machine than zone-cp you need to
+   copy CA cert file from zone-cp (located in `~/.kuma/kuma-cp.crt`) to somewhere accessible by zone-ingress (e.g. `/tmp/kuma-cp.crt`).
+   Modify the above command and provide the certificate path in `--ca-cert-file` argument.
 
-5. Generate the zone token with `egress` in scope:
+   ```sh
+   kuma-dp run \
+   --proxy-type=ingress \
+   --cp-address=https://<kuma-cp-address>:5678 \
+   --dataplane-token-file=/tmp/zone-token \
+   --ca-cert-file=/tmp/kuma-cp.crt \
+   --dataplane-file=ingress-dp.yaml
+   ```
+
+5. Optional: if you want to deploy zone egress
+
+   Create a `ZoneEgress` data plane proxy configuration to allow `kuma-cp` services
 
    To register the zone egress with the zone control plane, we need to generate
    a zone token first with appropriate scope first:

--- a/app/docs/dev/deployments/multi-zone.md
+++ b/app/docs/dev/deployments/multi-zone.md
@@ -272,9 +272,22 @@ You need the following values to pass to each zone control plane setup:
    --dataplane-file=ingress-dp.yaml
    ```
 
-(Optional) If you want to deploy zone egress:
+   If zone-ingress is running on a different machine than zone-cp you need to
+   copy CA cert file from zone-cp (located in `~/.kuma/kuma-cp.crt`) to somewhere accessible by zone-ingress (e.g. `/tmp/kuma-cp.crt`).
+   Modify the above command and provide the certificate path in `--ca-cert-file` argument.
 
-5.  Create a `ZoneEgress` data plane proxy configuration to allow `kuma-cp` services
+   ```sh
+   kuma-dp run \
+   --proxy-type=ingress \
+   --cp-address=https://<kuma-cp-address>:5678 \
+   --dataplane-token-file=/tmp/zone-token \
+   --ca-cert-file=/tmp/kuma-cp.crt \
+   --dataplane-file=ingress-dp.yaml
+   ```
+
+5.  Optional: if you want to deploy zone egress
+
+    Create a `ZoneEgress` data plane proxy configuration to allow `kuma-cp` services
     to be configured to proxy traffic to other zones or external services through
     zone egress:
 


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

Add info where to get ca when ingress deployed not alongside zone cp.

Closes https://github.com/kumahq/kuma-website/issues/913

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
