### PR TITLE
Update `make run` to use jekyll serve instead of build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ install:
 	bundle install
 
 run:
-	bundle exec jekyll build --config jekyll.yml --watch
+	bundle exec jekyll serve --config jekyll.yml
 
 build:
-	bundle exec jekyll build --config jekyll.yml 
+	bundle exec jekyll build --config jekyll.yml
 
 serve:
 	netlify dev


### PR DESCRIPTION
Re-generates the corresponding pages when the source content changes.

Fixes https://github.com/kumahq/kuma-website/issues/1128

Signed-off-by: Fabian Rodriguez <fabian.rodriguez@konghq.com>

<Explain your change!>

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? Yes
