### PR TITLE
formatting

### DIFF
--- a/app/docs/dev/security/secrets.md
+++ b/app/docs/dev/security/secrets.md
@@ -88,7 +88,7 @@ data: dGVzdAo=" | kumactl apply -f -
 {% endtab %}
 {% endtabs %}
 
-{% tip %}
+
 The `data` field of a {{site.mesh_product_name}} `Secret` is a Base64 encoded value.
 Use the `base64` command in Linux or macOS to encode any value in Base64:
 
@@ -100,7 +100,6 @@ cat cert.pem | base64
 echo "value" | base64
 ```
 
-{% endtip %}
 
 ### Access to the Secret HTTP API
 


### PR DESCRIPTION
Signed-off-by: angel <angel.guarisma@konghq.com>

Removed the tip, the information was stronger without a tip but it was also breaking the formatting on the mesh website. 
![image](https://user-images.githubusercontent.com/23319190/199988193-8c96146d-ea25-4acd-8cb0-e1bd30916297.png)


<Explain your change!>

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
