### PR TITLE
docs: MeshTrace optional fields without 'value'

### DIFF
--- a/app/docs/2.0.x/policies/meshtrace.md
+++ b/app/docs/2.0.x/policies/meshtrace.md
@@ -63,12 +63,9 @@ Example:
 
 ```yaml
 sampling:
-  overall:
-    value: 80
-  random:
-    value: 60
-  client:
-    value: 40
+  overall: 80
+  random: 60
+  client: 40
 ```
 
 ### Tags
@@ -176,12 +173,9 @@ spec:
         header:
           name: x-version
     sampling:
-      overall:
-        value: 80
-      random:
-        value: 60
-      client:
-        value: 40
+      overall: 80
+      random: 60
+      client: 40
 ```
 
 Apply the configuration with `kubectl apply -f [..]`.
@@ -227,12 +221,9 @@ spec:
         header:
           name: x-version
     sampling:
-      overall:
-        value: 80
-      random:
-        value: 60
-      client:
-        value: 40
+      overall: 80
+      random: 60
+      client: 40
 ```
 
 Apply the configuration with `kumactl apply -f [..]` or with the [HTTP API](../../reference/http-api).
@@ -295,12 +286,9 @@ spec:
         header:
           name: x-version
     sampling:
-      overall:
-        value: 80
-      random:
-        value: 60
-      client:
-        value: 40
+      overall: 80
+      random: 60
+      client: 40
 ```
 
 where `trace-svc` is the name of the Kubernetes Service you specified when you configured the Datadog APM agent.
@@ -348,12 +336,9 @@ spec:
         header:
           name: x-version
     sampling:
-      overall:
-        value: 80
-      random:
-        value: 60
-      client:
-        value: 40
+      overall: 80
+      random: 60
+      client: 40
 ```
 
 Apply the configuration with `kumactl apply -f [..]` or with the [HTTP API](../../reference/http-api).

--- a/app/docs/dev/policies/meshtrace.md
+++ b/app/docs/dev/policies/meshtrace.md
@@ -63,12 +63,9 @@ Example:
 
 ```yaml
 sampling:
-  overall:
-    value: 80
-  random:
-    value: 60
-  client:
-    value: 40
+  overall: 80
+  random: 60
+  client: 40
 ```
 
 ### Tags
@@ -176,12 +173,9 @@ spec:
         header:
           name: x-version
     sampling:
-      overall:
-        value: 80
-      random:
-        value: 60
-      client:
-        value: 40
+      overall: 80
+      random: 60
+      client: 40
 ```
 
 Apply the configuration with `kubectl apply -f [..]`.
@@ -227,12 +221,9 @@ spec:
         header:
           name: x-version
     sampling:
-      overall:
-        value: 80
-      random:
-        value: 60
-      client:
-        value: 40
+      overall: 80
+      random: 60
+      client: 40
 ```
 
 Apply the configuration with `kumactl apply -f [..]` or with the [HTTP API](../../reference/http-api).
@@ -295,12 +286,9 @@ spec:
         header:
           name: x-version
     sampling:
-      overall:
-        value: 80
-      random:
-        value: 60
-      client:
-        value: 40
+      overall: 80
+      random: 60
+      client: 40
 ```
 
 where `trace-svc` is the name of the Kubernetes Service you specified when you configured the Datadog APM agent.
@@ -348,12 +336,9 @@ spec:
         header:
           name: x-version
     sampling:
-      overall:
-        value: 80
-      random:
-        value: 60
-      client:
-        value: 40
+      overall: 80
+      random: 60
+      client: 40
 ```
 
 Apply the configuration with `kumactl apply -f [..]` or with the [HTTP API](../../reference/http-api).


### PR DESCRIPTION
Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

When Kuma got rid of protobuf for the new policies, we use pointers to express field optionality instead of the type wrappers.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
