### PR TITLE
Link to newest version of the page in the version alert banner

### DIFF
--- a/app/_includes/version_alert.html
+++ b/app/_includes/version_alert.html
@@ -1,6 +1,8 @@
 {% assign current_version = page.version %}
 {% assign latest_version = site.data.latest_version.release %}
 {% assign page_path = page.url | split: '/' | shift: 3 | join: '/' %}
+{% assign latest_version_path = "docs/" | append: latest_version | append: '/' | append: page_path | append: '.md' %}
+{% assign latest_page = site.pages | find: 'path', latest_version_path %}
 
 {% if current_version != site.data.latest_version.release %}
   <div>
@@ -12,9 +14,12 @@
         {% else %}
           <p>You are browsing documentation for a version of {{ site.title }} that is not the latest release.</p>
         {% endif %}
-        <p>
-          <a href="/docs/latest/{{ page_path }}">Go here</a> to browse the documentation for the latest version.
-        </p>
+
+        {% if latest_page != nil %}
+          <p>
+            <a href="/docs/latest/{{ page_path }}">Go here</a> to browse the documentation for the latest version.
+          </p>
+        {% endif %}
         {% if current_version != 'dev' %}
           <p>Looking for even older versions? <a href="{% post_url 2021-04-16-website-reorg %}">Learn more</a>.</p>
         {% endif %}

--- a/app/_includes/version_alert.html
+++ b/app/_includes/version_alert.html
@@ -1,5 +1,6 @@
 {% assign current_version = page.version %}
 {% assign latest_version = site.data.latest_version.release %}
+{% assign page_path = page.url | split: '/' | shift: 3 | join: '/' %}
 
 {% if current_version != site.data.latest_version.release %}
   <div>
@@ -12,7 +13,7 @@
           <p>You are browsing documentation for a version of {{ site.title }} that is not the latest release.</p>
         {% endif %}
         <p>
-          <a href="/docs/{{ latest_version }}/">Go here</a> to browse the documentation for the latest version.
+          <a href="/docs/{{ latest_version }}/{{ page_path }}">Go here</a> to browse the documentation for the latest version.
         </p>
         {% if current_version != 'dev' %}
           <p>Looking for even older versions? <a href="{% post_url 2021-04-16-website-reorg %}">Learn more</a>.</p>

--- a/app/_includes/version_alert.html
+++ b/app/_includes/version_alert.html
@@ -13,7 +13,7 @@
           <p>You are browsing documentation for a version of {{ site.title }} that is not the latest release.</p>
         {% endif %}
         <p>
-          <a href="/docs/{{ latest_version }}/{{ page_path }}">Go here</a> to browse the documentation for the latest version.
+          <a href="/docs/latest/{{ page_path }}">Go here</a> to browse the documentation for the latest version.
         </p>
         {% if current_version != 'dev' %}
           <p>Looking for even older versions? <a href="{% post_url 2021-04-16-website-reorg %}">Learn more</a>.</p>

--- a/app/_includes/version_selector.html
+++ b/app/_includes/version_selector.html
@@ -2,7 +2,11 @@
 
 <select name="{{ include.name }}" class="version-selector" id="version-selector">
   {% for version in site.data.versions %}
-    <option value="{{ version.release }}" {% if version.release == current_version %} selected {% endif %}>
+    {% assign option_value = version.release %}
+    {% if version == site.data.latest_version %}
+      {% assign option_value = 'latest' %}
+    {% endif %}
+    <option value="{{ option_value }}" {% if version.release == current_version %} selected {% endif %}>
       {{ version.release }}
       {% if version == site.data.latest_version %}
         (latest)

--- a/app/_plugins/generators/redirects.rb
+++ b/app/_plugins/generators/redirects.rb
@@ -18,6 +18,8 @@ module Jekyll
         "/docs/latest/deployments /docs/:version/#{latest_release}/deployments 301",
         "/docs/latest/documentation/deployments /docs/#{latest_release}/introduction/deployments 301",
         "/docs/latest/explore/backends /docs/#{latest_release}/documentation/configuration 301",
+        "/docs/latest/security/zone-ingress-auth /docs/#{latest_release}/security/zoneproxy-auth 301",
+        "/docs/latest/security/zoneegress-auth /docs/#{latest_release}/security/zoneproxy-auth 301",
         "/install /install/#{latest_release} 301",
         "/docs/latest/* /docs/#{latest_release}/:splat 301",
         "/install/latest/* /install/#{latest_release}/:splat 301",
@@ -43,7 +45,7 @@ module Jekyll
           #{redirects}/docs/#{current}/*  /docs/#{v['release']}/:splat  301
           /install/#{current}/*  /install/#{v['release']}/:splat  301
           RDR
-        end 
+        end
       end
 
       # Generate policy redirects
@@ -108,7 +110,7 @@ module Jekyll
       RDR
 
       # Add all hand-crafted redirects
-      redirects = <<~RDR 
+      redirects = <<~RDR
         #{redirects}
 
         # Original _redirects file:


### PR DESCRIPTION
Related https://github.com/kumahq/kuma-website/issues/857

Make the `Go here` link point to the newest version of the page instead of the docs' index page

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? Yes
