### PR TITLE
Improve dev experience

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ group :development do
   # https://github.com/jekyll/jekyll/issues/8523
   gem "webrick", "~> 1.7"
   gem 'byebug'
+  gem 'foreman'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.15.5)
+    foreman (0.87.2)
     forwardable-extended (2.6.0)
     http_parser.rb (0.8.0)
     i18n (1.12.0)
@@ -93,6 +94,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  foreman
   jekyll (~> 4.2)
   jekyll-contentblocks
   jekyll-generator-single-source

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ install:
 	bundle install
 
 run:
-	bundle exec jekyll serve --config jekyll.yml
+	bundle exec foreman start
 
 build:
 	bundle exec jekyll build --config jekyll.yml

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+vite: bin/vite dev
+jekyll: bin/jekyll-vite wait && bundle exec jekyll serve --livereload --config jekyll-dev.yml
+netlify: sleep 50 && netlify dev

--- a/bin/jekyll-vite
+++ b/bin/jekyll-vite
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'socket'
+require 'vite_ruby'
+
+def wait_for_dev_server(timeout_at:)
+  while Time.now <= timeout_at
+    return if ViteRuby.instance.dev_server_running?
+
+    sleep 1
+  end
+  raise "Timeout: vite dev server is not running on #{ ViteRuby.config.host_with_port }"
+end
+
+case cmd = ARGV[0]
+when 'wait'
+  puts 'Waiting for vite dev server to start'
+  wait_for_dev_server(timeout_at: Time.now + (ENV['VITE_TIMEOUT'] || 10).to_i)
+else
+  raise ArgumentError, "unknown command #{ cmd.inspect }"
+end

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "bundle exec jekyll build --config jekyll.yml"
   environment = { JEKYLL_ENV = "development", BUNDLE_WITHOUT = "development", NODE_OPTIONS = "--max_old_space_size=8192" }
 
-[context.main.environment]
+[context.production.environment]
   JEKYLL_ENV = "production"
 
 [context.deploy-preview.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,3 +12,9 @@
 [dev]
   autoLaunch = false
   framework = "#static"
+
+[[redirects]]
+from = "/vite-dev/*"
+to = "http://localhost:3036/vite-dev/:splat"
+force = true
+status = 301


### PR DESCRIPTION
Contributors can now run just one command locally `make run` locally, and it will take care of setting everything up for them.
It spins up:
* the `vite` server for the assets
* `Jekyll serve`
* `netlify dev` so that they can test the site locally with all the redirects in place. The `50s` sleep before running `netlify` is to allow `Jekyll` to build the site first, because it needs to generate the `_redirect` that is required by `netlify`.

It also fixes an issue with vite generating a `development` build in `production` due to a bad config.

cc @mheap 

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? Yes
