### PR TITLE
fix: add link to mesh traffic permission

### DIFF
--- a/app/docs/2.0.x/policies/introduction.md
+++ b/app/docs/2.0.x/policies/introduction.md
@@ -12,19 +12,19 @@ Going forward from version 2.0, {{site.mesh_product_name}} is transitioning from
 
 The following table shows the equivalence between source/destination and `targetRef` policies:
 
-| source/destination policy                    | `targetRef` policy                |
-|----------------------------------------------|-----------------------------------|
-| [CircuitBreaker](../circuit-breaker)         | N/A                               |
-| [FaultInjection](../fault-injection)         | N/A                               |
-| [HealthCheck](../health-check)               | N/A                               |
-| [RateLimit](../rate-limit)                   | N/A                               |
-| [Retry](../retry)                            | N/A                               |
-| [Timeout](../timeout)                        | N/A                               |
-| [TrafficLog](../traffic-log)                 | [MeshAccessLog](../meshaccesslog) |
-| [TrafficMetrics](../traffic-metrics)         | N/A                               |
-| [TrafficPermissions](../traffic-permissions) | MeshTrafficPermission             |
-| [TrafficRoute](../traffic-route)             | N/A                               |
-| [TrafficTrace](../traffic-trace)             | [MeshTrace](../meshtrace)         |
+| source/destination policy                    | `targetRef` policy                                |
+|----------------------------------------------|---------------------------------------------------|
+| [CircuitBreaker](../circuit-breaker)         | N/A                                               |
+| [FaultInjection](../fault-injection)         | N/A                                               |
+| [HealthCheck](../health-check)               | N/A                                               |
+| [RateLimit](../rate-limit)                   | N/A                                               |
+| [Retry](../retry)                            | N/A                                               |
+| [Timeout](../timeout)                        | N/A                                               |
+| [TrafficLog](../traffic-log)                 | [MeshAccessLog](../meshaccesslog)                 |
+| [TrafficMetrics](../traffic-metrics)         | N/A                                               |
+| [TrafficPermissions](../traffic-permissions) | [MeshTrafficPermission](../meshtrafficpermission) |
+| [TrafficRoute](../traffic-route)             | N/A                                               |
+| [TrafficTrace](../traffic-trace)             | [MeshTrace](../meshtrace)                         |
 
 {% warning %}
 `targetRef` policies are still beta and it is therefore not supported to mix source/destination and targetRef policies together.

--- a/app/docs/dev/policies/introduction.md
+++ b/app/docs/dev/policies/introduction.md
@@ -12,19 +12,19 @@ Going forward from version 2.0, {{site.mesh_product_name}} is transitioning from
 
 The following table shows the equivalence between source/destination and `targetRef` policies:
 
-| source/destination policy                    | `targetRef` policy                |
-|----------------------------------------------|-----------------------------------|
-| [CircuitBreaker](../circuit-breaker)         | N/A                               |
-| [FaultInjection](../fault-injection)         | N/A                               |
-| [HealthCheck](../health-check)               | N/A                               |
-| [RateLimit](../rate-limit)                   | N/A                               |
-| [Retry](../retry)                            | N/A                               |
-| [Timeout](../timeout)                        | N/A                               |
-| [TrafficLog](../traffic-log)                 | [MeshAccessLog](../meshaccesslog) |
-| [TrafficMetrics](../traffic-metrics)         | N/A                               |
-| [TrafficPermissions](../traffic-permissions) | MeshTrafficPermission             |
-| [TrafficRoute](../traffic-route)             | N/A                               |
-| [TrafficTrace](../traffic-trace)             | [MeshTrace](../meshtrace)         |
+| source/destination policy                    | `targetRef` policy                                |
+|----------------------------------------------|---------------------------------------------------|
+| [CircuitBreaker](../circuit-breaker)         | N/A                                               |
+| [FaultInjection](../fault-injection)         | N/A                                               |
+| [HealthCheck](../health-check)               | N/A                                               |
+| [RateLimit](../rate-limit)                   | N/A                                               |
+| [Retry](../retry)                            | N/A                                               |
+| [Timeout](../timeout)                        | N/A                                               |
+| [TrafficLog](../traffic-log)                 | [MeshAccessLog](../meshaccesslog)                 |
+| [TrafficMetrics](../traffic-metrics)         | N/A                                               |
+| [TrafficPermissions](../traffic-permissions) | [MeshTrafficPermission](../meshtrafficpermission) |
+| [TrafficRoute](../traffic-route)             | N/A                                               |
+| [TrafficTrace](../traffic-trace)             | [MeshTrace](../meshtrace)                         |
 
 {% warning %}
 `targetRef` policies are still beta and it is therefore not supported to mix source/destination and targetRef policies together.


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

Add link to MeshTrafficPermission.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
