### PR TITLE
fix(docs): fix ebpf install docs

### DIFF
--- a/app/docs/2.0.x/networking/transparent-proxying.md
+++ b/app/docs/2.0.x/networking/transparent-proxying.md
@@ -218,7 +218,7 @@ and have `cgroup2` available
 
 ```shell
 kumactl install control-plane \
-  --set "kuma.experimental.ebpf.enabled=true" | kubectl apply -f-
+  --set "{{site.set_flag_values_prefix}}experimental.ebpf.enabled=true" | kubectl apply -f-
 ```
 
 {% endtab %}

--- a/app/docs/dev/networking/transparent-proxying.md
+++ b/app/docs/dev/networking/transparent-proxying.md
@@ -218,7 +218,7 @@ and have `cgroup2` available
 
 ```shell
 kumactl install control-plane \
-  --set "kuma.experimental.ebpf.enabled=true" | kubectl apply -f-
+  --set "{{site.set_flag_values_prefix}}experimental.ebpf.enabled=true" | kubectl apply -f-
 ```
 
 {% endtab %}

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -39,6 +39,13 @@ defaults:
 # Product name variables
 mesh_product_name: Kuma
 default_namespace: kuma-system
+# Prefix for the values of "--set" flag for "kumactl install [...]" or
+# "helm install [...]" commands.
+# It's useful for projects based on Kuma, which expects Kuma options
+# to be prefixed with for example "kuma."
+# kumactl install control-plane \
+#   --set "{{set_flag_values_prefix}}experimental.ebpf.enabled=true"
+set_flag_values_prefix: ""
 
 # Pagination
 pagination:


### PR DESCRIPTION
Fixed value of `--set` flag for installing control plane with ebpf as it was always prefixed with `kuma.` which was wrong.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
