### PR TITLE
fix(meshaccesslog): subset bad example

### DIFF
--- a/app/docs/2.0.x/policies/meshaccesslog.md
+++ b/app/docs/2.0.x/policies/meshaccesslog.md
@@ -240,7 +240,7 @@ metadata:
     kuma.io/mesh: default # optional, defaults to `default` if it isn't configured
 spec:
   targetRef:
-    kind: MeshService
+    kind: MeshServiceSubset
     name: frontend
     tags:
       version: canary
@@ -265,7 +265,7 @@ name: default
 mesh: default
 spec:
   targetRef:
-    kind: MeshService
+    kind: MeshServiceSubset
     name: frontend
     tags:
       version: canary

--- a/app/docs/dev/policies/meshaccesslog.md
+++ b/app/docs/dev/policies/meshaccesslog.md
@@ -242,7 +242,7 @@ metadata:
     kuma.io/mesh: default # optional, defaults to `default` if it isn't configured
 spec:
   targetRef:
-    kind: MeshService
+    kind: MeshServiceSubset
     name: frontend
     tags:
       version: canary
@@ -267,7 +267,7 @@ name: default
 mesh: default
 spec:
   targetRef:
-    kind: MeshService
+    kind: MeshServiceSubset
     name: frontend
     tags:
       version: canary


### PR DESCRIPTION
We were using MeshService with tags. Replaced with MeshServiceSubset

Signed-off-by: Charly Molter <charly.molter@konghq.com>
