### PR TITLE
Symbolic link to `kumactl` does not contain the full path

### DIFF
--- a/app/_includes/snippets/install_kumactl.md
+++ b/app/_includes/snippets/install_kumactl.md
@@ -36,5 +36,5 @@ So we enter the `bin` folder by executing: `cd kuma-{{ page.latest_version }}/bi
 We suggest adding the `kumactl` executable to your `PATH` (by executing: `PATH=$(pwd):$PATH`) so that it's always available in every working directory. Or - alternatively - you can also create link in `/usr/local/bin/` by executing:
 
 ```sh
-ln -s kuma-{{ page.latest_version }}/bin/kumactl /usr/local/bin/kumactl
+ln -s $PWD/kuma-{{ page.latest_version }}/bin/kumactl /usr/local/bin/kumactl
 ```


### PR DESCRIPTION
The command

```text
ln -s kuma-2.0.0/bin/kumactl /usr/local/bin/kumactl
```

was not working. Adding the current path - using the $PWD environment variable - make it work:

```text
ln -s $PWD/kuma-2.0.0/bin/kumactl /usr/local/bin/kumactl
```
