### PR TITLE
Check ruby version in makefile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
       terminal-table (~> 2.0)
     jekyll-contentblocks (1.2.0)
       jekyll
-    jekyll-generator-single-source (0.0.3)
+    jekyll-generator-single-source (0.0.4)
       jekyll (>= 4.2, < 5.0)
     jekyll-last-modified-at (1.3.0)
       jekyll (>= 3.7, < 5.0)

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,23 @@
+RUBY_VERSION := "$(shell ruby -v)"
+RUBY_VERSION_REQUIRED := "$(shell cat .ruby-version)"
+RUBY_MATCH := $(shell [[ "$(shell ruby -v)" =~ "ruby $(shell cat .ruby-version)" ]] && echo matched)
+
+.PHONY: ruby-version-check
+ruby-version-check:
+ifndef RUBY_MATCH
+	@printf "ruby $(RUBY_VERSION_REQUIRED) is required. Found %s\n" $(RUBY_VERSION)
+endif
+
 # Installs npm packages and gems.
-install:
+install: ruby-version-check
 	npm install -g netlify-cli
 	yarn install
 	bundle install
 
-run:
+run: ruby-version-check
 	bundle exec foreman start
 
-build:
+build: ruby-version-check
 	bundle exec jekyll build --config jekyll.yml
 
 serve:


### PR DESCRIPTION
Add a check that enforces the right version of ruby is activated before running any ruby-related commands and bump `jekyll-generator-single-source`.

Did you sign your commit? Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? Yes
