### PR TITLE
Parameterize helm commands

### DIFF
--- a/app/docs/1.4.x/deployments/multi-zone.md
+++ b/app/docs/1.4.x/deployments/multi-zone.md
@@ -98,13 +98,13 @@ The global control plane on Kubernetes must reside on its own Kubernetes cluster
 1.  Set the `controlPlane.mode` value to `global` in the chart (`values.yaml`), then install. On the command line, run:
 
     ```sh
-    helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+    helm install {{ site.helm_install_name }} --namespace kuma-system --set controlPlane.mode=global {{ site.helm_repo }} 
     ```
 
-    Or you can edit the chart and pass the file to the `helm install kuma` command. To get the default values, run:
+    Or you can edit the chart and pass the file to the `helm install {{ site.helm_install_name }}` command. To get the default values, run:
 
     ```sh
-    helm show values kuma/kuma
+    helm show values {{ site.helm_repo }}
     ```
 1.  Find the external IP and port of the `global-remote-sync` service in the `kuma-system` namespace:
 
@@ -157,12 +157,12 @@ You need the following values to pass to each zone control plane setup:
 1.  On each zone control plane, run:
 
     ```bash
-    helm install kuma \
+    helm install {{ site.helm_install_name }}\
     --namespace kuma-system \
     --set controlPlane.mode=zone \
     --set controlPlane.zone=<zone-name> \
     --set ingress.enabled=true \
-    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> kuma/kuma
+    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> {{ site.helm_repo }}
     ```
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.

--- a/app/docs/1.5.x/deployments/multi-zone.md
+++ b/app/docs/1.5.x/deployments/multi-zone.md
@@ -96,13 +96,13 @@ The global control plane on Kubernetes must reside on its own Kubernetes cluster
 1.  Set the `controlPlane.mode` value to `global` in the chart (`values.yaml`), then install. On the command line, run:
 
     ```sh
-    helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+    helm install {{ site.helm_install_name }} --namespace kuma-system --set controlPlane.mode=global {{ site.helm_repo }}
     ```
 
-    Or you can edit the chart and pass the file to the `helm install kuma` command. To get the default values, run:
+    Or you can edit the chart and pass the file to the `helm install {{ site.helm_install_name }}` command. To get the default values, run:
 
     ```sh
-    helm show values kuma/kuma
+    helm show values {{ site.helm_repo }}
     ```
 1.  Find the external IP and port of the `global-remote-sync` service in the `kuma-system` namespace:
 
@@ -176,12 +176,12 @@ You need the following values to pass to each zone control plane setup:
 1.  On each zone control plane, run:
 
     ```sh
-    helm install kuma \
+    helm install {{ site.helm_install_name }} \
     --namespace kuma-system \
     --set controlPlane.mode=zone \
     --set controlPlane.zone=<zone-name> \
     --set ingress.enabled=true \
-    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 kuma/kuma
+    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.helm_repo }}
     ```
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.
@@ -191,13 +191,13 @@ You need the following values to pass to each zone control plane setup:
 1.  On each zone control plane, run:
 
     ```sh
-    helm install kuma \
+    helm install {{ site.helm_install_name }} \
     --namespace kuma-system \
     --set controlPlane.mode=zone \
     --set controlPlane.zone=<zone-name> \
     --set ingress.enabled=true \
     --set egress.enabled=true \
-    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 kuma/kuma
+    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.helm_repo }}
     ```
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.

--- a/app/docs/1.6.x/deployments/multi-zone.md
+++ b/app/docs/1.6.x/deployments/multi-zone.md
@@ -96,13 +96,13 @@ The global control plane on Kubernetes must reside on its own Kubernetes cluster
 1.  Set the `controlPlane.mode` value to `global` in the chart (`values.yaml`), then install. On the command line, run:
 
     ```sh
-    helm install kuma --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+    helm install {{ site.helm_install_name }} --namespace kuma-system --set controlPlane.mode=global {{ site.helm_repo }}
     ```
 
-    Or you can edit the chart and pass the file to the `helm install kuma` command. To get the default values, run:
+    Or you can edit the chart and pass the file to the `helm install {{ site.helm_install_command }}` command. To get the default values, run:
 
     ```sh
-    helm show values kuma/kuma
+    helm show values {{ site.helm_repo }}
     ```
 1.  Find the external IP and port of the `global-remote-sync` service in the `kuma-system` namespace:
 
@@ -176,12 +176,12 @@ You need the following values to pass to each zone control plane setup:
 1.  On each zone control plane, run:
 
     ```sh
-    helm install kuma \
+    helm install {{ site.helm_install_name }} \
     --namespace kuma-system \
     --set controlPlane.mode=zone \
     --set controlPlane.zone=<zone-name> \
     --set ingress.enabled=true \
-    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 kuma/kuma
+    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.helm_repo }}
     ```
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.
@@ -191,13 +191,13 @@ You need the following values to pass to each zone control plane setup:
 1.  On each zone control plane, run:
 
     ```sh
-    helm install kuma \
+    helm install {{ site.helm_install_name }} \
     --namespace kuma-system \
     --set controlPlane.mode=zone \
     --set controlPlane.zone=<zone-name> \
     --set ingress.enabled=true \
     --set egress.enabled=true \
-    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 kuma/kuma
+    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.helm_repo }}
     ```
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.

--- a/app/docs/1.7.x/deployments/multi-zone.md
+++ b/app/docs/1.7.x/deployments/multi-zone.md
@@ -114,13 +114,13 @@ The global control plane on Kubernetes must reside on its own Kubernetes cluster
 1.  Set the `controlPlane.mode` value to `global` in the chart (`values.yaml`), then install. On the command line, run:
 
     ```sh
-    helm install kuma --create-namespace --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+    helm install {{ site.helm_install_name }} --create-namespace --namespace kuma-system --set controlPlane.mode=global {{ site.helm_repo }}
     ```
 
-    Or you can edit the chart and pass the file to the `helm install kuma` command. To get the default values, run:
+    Or you can edit the chart and pass the file to the `helm install {{ site.helm_install_name }}` command. To get the default values, run:
 
     ```sh
-    helm show values kuma/kuma
+    helm show values {{ site.helm_repo }}
     ```
 1.  Find the external IP and port of the `global-remote-sync` service in the `kuma-system` namespace:
 
@@ -194,13 +194,13 @@ You need the following values to pass to each zone control plane setup:
 1.  On each zone control plane, run:
 
     ```sh
-    helm install kuma \
+    helm install {{ site.helm_install_name }} \
     --create-namespace \
     --namespace kuma-system \
     --set controlPlane.mode=zone \
     --set controlPlane.zone=<zone-name> \
     --set ingress.enabled=true \
-    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 kuma/kuma
+    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.helm_repo }}
     ```
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.
@@ -210,14 +210,14 @@ You need the following values to pass to each zone control plane setup:
 1.  On each zone control plane, run:
 
     ```sh
-    helm install kuma \
+    helm install {{ site.helm_install_name }} \
     --create-namespace \
     --namespace kuma-system \
     --set controlPlane.mode=zone \
     --set controlPlane.zone=<zone-name> \
     --set ingress.enabled=true \
     --set egress.enabled=true \
-    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 kuma/kuma
+    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.helm_repo }}
     ```
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.

--- a/app/docs/1.8.x/deployments/multi-zone.md
+++ b/app/docs/1.8.x/deployments/multi-zone.md
@@ -116,13 +116,13 @@ The global control plane on Kubernetes must reside on its own Kubernetes cluster
 1.  Set the `controlPlane.mode` value to `global` in the chart (`values.yaml`), then install. On the command line, run:
 
     ```sh
-    helm install kuma --create-namespace --namespace kuma-system --set controlPlane.mode=global kuma/kuma
+    helm install {{ site.helm_install_name }} --create-namespace --namespace kuma-system --set controlPlane.mode=global {{ site.helm_repo }}
     ```
 
-    Or you can edit the chart and pass the file to the `helm install kuma` command. To get the default values, run:
+    Or you can edit the chart and pass the file to the `helm install {{ site.helm_install_name }}` command. To get the default values, run:
 
     ```sh
-    helm show values kuma/kuma
+    helm show values {{ site.helm_repo }}
     ```
 1.  Find the external IP and port of the `global-remote-sync` service in the `kuma-system` namespace:
 
@@ -196,13 +196,13 @@ You need the following values to pass to each zone control plane setup:
 1.  On each zone control plane, run:
 
     ```sh
-    helm install kuma \
+    helm install {{ site.helm_install_name }} \
     --create-namespace \
     --namespace kuma-system \
     --set controlPlane.mode=zone \
     --set controlPlane.zone=<zone-name> \
     --set ingress.enabled=true \
-    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 kuma/kuma
+    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.helm_repo }}
     ```
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.
@@ -212,14 +212,14 @@ You need the following values to pass to each zone control plane setup:
 1.  On each zone control plane, run:
 
     ```sh
-    helm install kuma \
+    helm install {{ site.helm_install_name }} \
     --create-namespace \
     --namespace kuma-system \
     --set controlPlane.mode=zone \
     --set controlPlane.zone=<zone-name> \
     --set ingress.enabled=true \
     --set egress.enabled=true \
-    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 kuma/kuma
+    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.helm_repo }}
     ```
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.

--- a/app/docs/1.8.x/documentation/configuration.md
+++ b/app/docs/1.8.x/documentation/configuration.md
@@ -33,7 +33,7 @@ When using `helm`, you can override the configuration with the `envVars` field. 
 helm install \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s \
-  kuma kuma/kuma
+  {{ site.helm_install_name }} {{ site.helm_repo }}
 ```
 
 Or you can create a `values.yaml` file with:
@@ -46,13 +46,13 @@ controlPlane:
 and then specify it in the helm install command:
 
 ```sh
-helm install -f values.yaml kuma kuma/kuma
+helm install -f values.yaml {{ site.helm_install_name }} {{ site.helm_repo }}
 ```
 
 If you have a lot of configuration you can just write them all in a YAML file and use:
 
 ```shell
-helm install kuma kuma/kuma --set-file controlPlace.config=cp-conf.yaml
+helm install {{ site.helm_install_name }} {{ site.helm_repo }} --set-file controlPlace.config=cp-conf.yaml
 ```
 The value of the configmap `kuma-control-plane-config` is now the content of `cp-conf.yaml`.
 

--- a/app/docs/2.0.x/deployments/multi-zone.md
+++ b/app/docs/2.0.x/deployments/multi-zone.md
@@ -127,13 +127,13 @@ The global control plane on Kubernetes must reside on its own Kubernetes cluster
 1.  Set the `controlPlane.mode` value to `global` in the chart (`values.yaml`), then install. On the command line, run:
 
     ```sh
-    helm install kuma --create-namespace --namespace {{site.default_namespace}} --set controlPlane.mode=global kuma/kuma
+    helm install {{ site.helm_install_name }} --create-namespace --namespace {{site.default_namespace}} --set controlPlane.mode=global {{ site.helm_repo }}
     ```
 
-    Or you can edit the chart and pass the file to the `helm install kuma` command. To get the default values, run:
+    Or you can edit the chart and pass the file to the `helm install {{ site.helm_install_name }}` command. To get the default values, run:
 
     ```sh
-    helm show values kuma/kuma
+    helm show values {{ site.helm_repo }}
     ```
 
 1.  Find the external IP and port of the `global-remote-sync` service in the `{{site.default_namespace}}` namespace:
@@ -206,13 +206,13 @@ You need the following values to pass to each zone control plane setup:
 1.  On each zone control plane, run:
 
     ```sh
-    helm install kuma \
+    helm install {{ site.helm_install_name }} \
     --create-namespace \
     --namespace {{site.default_namespace}} \
     --set controlPlane.mode=zone \
     --set controlPlane.zone=<zone-name> \
     --set ingress.enabled=true \
-    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 kuma/kuma
+    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.helm_repo }}
     ```
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.
@@ -222,14 +222,14 @@ You need the following values to pass to each zone control plane setup:
 1.  On each zone control plane, run:
 
     ```sh
-    helm install kuma \
+    helm install {{ site.helm_install_name }} \
     --create-namespace \
     --namespace {{site.default_namespace}} \
     --set controlPlane.mode=zone \
     --set controlPlane.zone=<zone-name> \
     --set ingress.enabled=true \
     --set egress.enabled=true \
-    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 kuma/kuma
+    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.helm_repo }}
     ```
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.

--- a/app/docs/2.0.x/documentation/configuration.md
+++ b/app/docs/2.0.x/documentation/configuration.md
@@ -33,7 +33,7 @@ When using `helm`, you can override the configuration with the `envVars` field. 
 helm install \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s \
-  kuma kuma/kuma
+  {{ site.helm_install_name }} {{ site.helm_repo }}
 ```
 
 Or you can create a `values.yaml` file with:
@@ -46,13 +46,13 @@ controlPlane:
 and then specify it in the helm install command:
 
 ```sh
-helm install -f values.yaml kuma kuma/kuma
+helm install -f values.yaml {{ site.helm_install_name }} {{ site.helm_repo }}
 ```
 
 If you have a lot of configuration you can just write them all in a YAML file and use:
 
 ```shell
-helm install kuma kuma/kuma --set-file controlPlace.config=cp-conf.yaml
+helm install {{ site.helm_install_name }} {{ site.helm_repo }} --set-file controlPlace.config=cp-conf.yaml
 ```
 The value of the configmap `kuma-control-plane-config` is now the content of `cp-conf.yaml`.
 

--- a/app/docs/dev/deployments/multi-zone.md
+++ b/app/docs/dev/deployments/multi-zone.md
@@ -127,10 +127,10 @@ The global control plane on Kubernetes must reside on its own Kubernetes cluster
 1.  Set the `controlPlane.mode` value to `global` in the chart (`values.yaml`), then install. On the command line, run:
 
     ```sh
-    helm install kuma --create-namespace --namespace {{site.default_namespace}} --set controlPlane.mode=global kuma/kuma
+    helm install {{ site.helm_install_name }} --create-namespace --namespace {{site.default_namespace}} --set controlPlane.mode=global {{ site.helm_repo }}
     ```
 
-    Or you can edit the chart and pass the file to the `helm install kuma` command. To get the default values, run:
+    Or you can edit the chart and pass the file to the `helm install {{ site.helm_install_name }}` command. To get the default values, run:
 
     ```sh
     helm show values kuma/kuma
@@ -206,13 +206,13 @@ You need the following values to pass to each zone control plane setup:
 1.  On each zone control plane, run:
 
     ```sh
-    helm install kuma \
+    helm install {{ site.helm_install_name }} \
     --create-namespace \
     --namespace {{site.default_namespace}} \
     --set controlPlane.mode=zone \
     --set controlPlane.zone=<zone-name> \
     --set ingress.enabled=true \
-    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 kuma/kuma
+    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.helm_repo }}
     ```
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.
@@ -222,14 +222,14 @@ You need the following values to pass to each zone control plane setup:
 1.  On each zone control plane, run:
 
     ```sh
-    helm install kuma \
+    helm install {{ site.helm_install_name }} \
     --create-namespace \
     --namespace {{site.default_namespace}} \
     --set controlPlane.mode=zone \
     --set controlPlane.zone=<zone-name> \
     --set ingress.enabled=true \
     --set egress.enabled=true \
-    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 kuma/kuma
+    --set controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.helm_repo }}
     ```
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.

--- a/app/docs/dev/documentation/configuration.md
+++ b/app/docs/dev/documentation/configuration.md
@@ -33,7 +33,7 @@ When using `helm`, you can override the configuration with the `envVars` field. 
 helm install \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s \
-  kuma kuma/kuma
+  {{ site.helm_install_name }} {{ site.helm_repo }}
 ```
 
 Or you can create a `values.yaml` file with:
@@ -46,13 +46,13 @@ controlPlane:
 and then specify it in the helm install command:
 
 ```sh
-helm install -f values.yaml kuma kuma/kuma
+helm install -f values.yaml {{ site.kuma_install_name }} {{ site.helm_repo }}
 ```
 
 If you have a lot of configuration you can just write them all in a YAML file and use:
 
 ```shell
-helm install kuma kuma/kuma --set-file controlPlace.config=cp-conf.yaml
+helm install {{ site.helm_install_name }} {{ site.helm_repo }} --set-file controlPlace.config=cp-conf.yaml
 ```
 The value of the configmap `kuma-control-plane-config` is now the content of `cp-conf.yaml`.
 

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -68,3 +68,7 @@ jekyll-generator-single-source:
 # Product name variables
 mesh_product_name: Kuma
 default_namespace: kuma-system
+
+# Helm commands
+helm_repo: kuma/kuma
+helm_install_name: kuma

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -80,3 +80,7 @@ jekyll-generator-single-source:
 include:
   - installer.sh
   - robots.txt
+
+# Helm commands
+helm_repo: kuma/kuma
+helm_install_name: kuma


### PR DESCRIPTION
[Related](https://github.com/Kong/docs.konghq.com/issues/4960) issue in Kong 's docs.

## Problem
Helm commands were referencing  `kuma` instead of `kong-mesh` on kong docs,  because the value was hardcoded and we didn't handle it in any way.

This PR adds placeholders for `kuma` and `kuma/kuma` in helm commands, which we can replace in Kong's docs in Jekyll's configuration file.

## Note
This change doesn't affect Kuma's website, everything should look the same, but once we merge this, add the placeholder to `docs.konghq` and update the submodule, it will replace the placeholders with `kong-mesh` and `kong-mesh/kong-mesh`

Did you sign your commit? Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? Yes
