### PR TITLE
Fix community form submission

### DIFF
--- a/app/_assets/javascripts/form.js
+++ b/app/_assets/javascripts/form.js
@@ -25,7 +25,6 @@ export default class Form {
         type: this.elem.method || 'GET',
         dataType: 'jsonp',
         crossDomain: true,
-
         data: $(this.elem).serialize(),
         xhrFields: {
           withCredentials: true
@@ -35,19 +34,11 @@ export default class Form {
           this.elem.querySelector('.btn').classList.add('is-sending');
           this.elem.querySelector('.spinner').classList.remove('hidden');
         },
-        success: (data, textStatus) => {
+        complete: (event, textStatus) => {
           this.elem
             .parentNode
             .querySelector('.form-success')
             .classList.remove('hidden')
-        },
-        error: (data, textStatus) => {
-          this.elem
-            .parentNode
-            .querySelector('.form-error')
-            .classList.remove('hidden');
-        },
-        complete: (data, textStatus) => {
           this.elem.remove();
         }
       })


### PR DESCRIPTION
Pardot issues an http request to a specified url in their config once the ajax call is submited, in this case it is
https://kuma.io/community?form_success=true

Before migrating to Jekyll, we just ignored that callback and rendered a success message, even in the unlikely case that it could fail. After migrating to Jekyll, we added a success and error callbacks to handle both scenarios. However, the error handler gets executed in both scenarios, this is because the response the Ajax gets is a redirect and a parseError and there is no way to know whether the call was a success or not.

We are opting here to ignore the error case as before and just show the success message.

Signed-off-by: Fabian Rodriguez <fabian.rodriguez@konghq.com>

<Explain your change!>

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? Yes
