### PR TITLE
docs: update headers modifier format in MeshHealthCheck

### DIFF
--- a/app/_src/policies/meshhealthcheck.md
+++ b/app/_src/policies/meshhealthcheck.md
@@ -275,8 +275,6 @@ HTTP health checks are executed using HTTP2
 - **`add`** - (optional) - list of headers to add. Appends value if the header exists.
   - **`name`** - header's name
   - **`value`** - header's value
-- **`remove`** - (optional) - list of headers' names to remove
-
 
 ### TCP
 

--- a/app/_src/policies/meshhealthcheck.md
+++ b/app/_src/policies/meshhealthcheck.md
@@ -265,11 +265,18 @@ HTTP health checks are executed using HTTP2
   - only statuses in the range `[100, 600)` are allowed
   - by default, when this property is not provided only responses with
     status code `200` are being considered healthy
-- **`requestHeadersToAdd`** (optional) - list of HTTP headers which should be added to each health check request
-  - **`append`** (default, optional) - should the value of the provided
-    header be appended to already existing headers, if not specified then equal to `true`
-  - **`key`** - the name of the header
-  - **`value`** - the value of the header
+- **`requestHeadersToAdd`** (optional) - [HeaderModifier](#headermodifier) list of HTTP headers which should be added to each health check request
+
+#### HeaderModifier
+
+- **`set`** - (optional) - list of headers to set. Overrides value if the header exists.
+  - **`name`** - header's name
+  - **`value`** - header's value
+- **`add`** - (optional) - list of headers to add. Appends value if the header exists.
+  - **`name`** - header's name
+  - **`value`** - header's value
+- **`remove`** - (optional) - list of headers' names to remove
+
 
 ### TCP
 


### PR DESCRIPTION
Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

The format of header modifiers has changed in https://github.com/kumahq/kuma/pull/5757. This PR updates the doc for MeshHealthCheck

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
