### PR TITLE
Move redirects to files so we can reuse them in kong-mesh

### DIFF
--- a/app/_common_redirects
+++ b/app/_common_redirects
@@ -1,0 +1,29 @@
+# Policy redirects
+/docs/:version/policies/circuit-breakers/ /docs/:version/policies/circuit-breaker/ 301
+/docs/:version/policies/fault-injections/ /docs/:version/policies/fault-injection/ 301
+/docs/:version/policies/health-checks/ /docs/:version/policies/health-check/ 301
+/docs/:version/policies/meshgateways/ /docs/:version/policies/mesh-gateway/ 301
+/docs/:version/policies/meshgatewayroutes/ /docs/:version/policies/mesh-gateway-route/ 301
+/docs/:version/policies/proxytemplates/ /docs/:version/policies/proxy-template/ 301
+/docs/:version/policies/rate-limits/ /docs/:version/policies/rate-limit/ 301
+/docs/:version/policies/retries/ /docs/:version/policies/retry/ 301
+/docs/:version/policies/timeouts/ /docs/:version/policies/timeout/ 301
+/docs/:version/policies/traffic-logs/ /docs/:version/policies/traffic-log/ 301
+/docs/:version/policies/traffic-routes/ /docs/:version/policies/traffic-route/ 301
+/docs/:version/policies/traffic-traces/ /docs/:version/policies/traffic-trace/ 301
+/docs/:version/policies/virtual-outbounds/ /docs/:version/policies/virtual-outbound/ 301
+
+# Docs
+/docs/latest/documentation/gateway /docs/LATEST_RELEASE/explore/gateway 301
+/docs/latest/deployments /docs/:version/LATEST_RELEASE/deployments 301
+/docs/latest/documentation/deployments /docs/LATEST_RELEASE/introduction/deployments 301
+/docs/latest/explore/backends /docs/LATEST_RELEASE/documentation/configuration 301
+/docs/latest/security/zone-ingress-auth /docs/LATEST_RELEASE/security/zoneproxy-auth 301
+/docs/latest/security/zoneegress-auth /docs/LATEST_RELEASE/security/zoneproxy-auth 301
+/docs/latest/* /docs/LATEST_RELEASE/:splat 301
+/docs/:version/policies/ /docs/:version/policies/introduction 301
+/docs/:version/overview/ /docs/:version/overview/what-is-kuma 301
+/docs/:version/other/ /docs/:version/other/enterprise 301
+/docs/:version/installation/ /docs/:version/installation/kubernetes 301
+/docs/:version/api/ /docs/:version/documentation/http-api 301
+/docs/:version/documentation/deployments/ /docs/:version/introduction/deployments 301

--- a/app/_plugins/generators/redirects.rb
+++ b/app/_plugins/generators/redirects.rb
@@ -5,116 +5,37 @@ module Jekyll
     priority :low
 
     def generate(site)
-      current_redirects = File.read("app/_redirects")
       active_versions = site.data['versions'].filter {|v| v['release'] != "dev"}
 
       # Generate redirects for the latest version
       latest_release = site.data['latest_version']['release']
-      redirects = [
-        "# Generated redirects",
-        "/docs /docs/#{latest_release} 301",
-        "/install/kong-gateway /docs/#{latest_release}/explore/gateway 301",
-        "/docs/latest/documentation/gateway /docs/#{latest_release}/explore/gateway 301",
-        "/docs/latest/deployments /docs/:version/#{latest_release}/deployments 301",
-        "/docs/latest/documentation/deployments /docs/#{latest_release}/introduction/deployments 301",
-        "/docs/latest/explore/backends /docs/#{latest_release}/documentation/configuration 301",
-        "/docs/latest/security/zone-ingress-auth /docs/#{latest_release}/security/zoneproxy-auth 301",
-        "/docs/latest/security/zoneegress-auth /docs/#{latest_release}/security/zoneproxy-auth 301",
-        "/install /install/#{latest_release} 301",
-        "/docs/latest/* /docs/#{latest_release}/:splat 301",
-        "/install/latest/* /install/#{latest_release}/:splat 301",
-        "/docs/:version/policies/ /docs/:version/policies/introduction 301",
-        "/docs/:version/overview/ /docs/:version/overview/what-is-kuma 301",
-        "/docs/:version/other/ /docs/:version/other/enterprise 301",
-        "/docs/:version/installation/ /docs/:version/installation/kubernetes 301",
-        "/docs/:version/api/ /docs/:version/documentation/http-api 301",
-        "/docs/:version/documentation/deployments/ /docs/:version/introduction/deployments 301",
-        "/latest_version.html /latest_version 301",
-      ].join("\n")
+
+      kuma_redirects = existing_redirects(latest_release).join("\n")
+      common_redirects = common_redirects(latest_release).join("\n")
 
       # Generate redirects for specific versions
-      redirects = "#{redirects}\n\n# Specific version to release\n"
-      active_versions.each do |v|
+      version_specific_redirects = active_versions.each_with_object([]) do |v, redirects|
         vp = v['version'].split('.').map(&:to_i)
 
         # Generate redirects for x.y.0, x.y.1, x.y.2 etc
         # Until we hit the actual version stored in versions.yml
         for idx in 0..vp[2] do
           current = "#{vp[0]}.#{vp[1]}.#{idx}"
-          redirects = <<~RDR
-          #{redirects}/docs/#{current}/*  /docs/#{v['release']}/:splat  301
-          /install/#{current}/*  /install/#{v['release']}/:splat  301
-          RDR
+          redirects << "/docs/#{current}/*  /docs/#{v['release']}/:splat  301"
+          redirects << "/install/#{current}/*  /install/#{v['release']}/:splat  301"
         end
-      end
-
-      # Generate policy redirects
-      policy_redirects = [
-        ['circuit-breakers', 'circuit-breaker'],
-        ['fault-injections', 'fault-injection'],
-        ['health-checks', 'health-check'],
-        ['meshgateways', 'mesh-gateway'],
-        ['meshgatewayroutes', 'mesh-gateway-route'],
-        ['proxytemplates', 'proxy-template'],
-        ['rate-limits', 'rate-limit'],
-        ['retries', 'retry'],
-        ['timeouts', 'timeout'],
-        ['traffic-logs', 'traffic-log'],
-        ['traffic-routes', 'traffic-route'],
-        ['traffic-traces', 'traffic-trace'],
-        ['virtual-outbounds', 'virtual-outbound'],
-      ].map {|v| "/docs/:version/policies/#{v[0]}/ /docs/:version/policies/#{v[1]}/ 301"}.join("\n")
-
-      # Kuma tag redirects
-      kuma_tag_redirects = [
-        'builtindns',
-        'builtindnsport',
-        'container-patches',
-        'direct-access-services',
-        'envoy-admin-port',
-        'gateway',
-        'ignore',
-        'ingress-public-address',
-        'ingress-public-port',
-        'ingress',
-        'mesh',
-        'service-account-token-volume',
-        'sidecar-drain-time',
-        'sidecar-env-vars',
-        'sidecar-injection',
-        'transparent-proxying-experimental-engine',
-        'transparent-proxying-inbound-v6-port',
-        'transparent-proxying-reachable-services',
-        'virtual-probes-port',
-       'virtual-probes',
-      ].map{ |source_path| "/#{source_path}/ /docs/#{latest_release}/reference/kubernetes-annotations/#kumaio#{source_path} 301" }.join("\n")
-
-      kuma_subdomain_redirects = [
-        ['https://prometheus.metrics.kuma.io/port', "/docs/#{latest_release}/reference/kubernetes-annotations/#prometheus-metrics-kuma-io-port"],
-        ['https://prometheus.metrics.kuma.io/path', "/docs/#{latest_release}/reference/kubernetes-annotations/#prometheus-metrics-kuma-io-path"],
-        ['https://traffic.kuma.io/exclude-inbound-ports', "/docs/#{latest_release}/reference/kubernetes-annotations/#traffic-kuma-io-exclude-inbound-ports"],
-        ['https://traffic.kuma.io/exclude-outbound-ports', "/docs/#{latest_release}/reference/kubernetes-annotations/#traffic-kuma-io-exclude-outbound-ports"],
-      ].map{ |v| "#{v[0]} #{v[1]}/ 301" }.join("\n")
-
-
-      redirects = <<~RDR
-      #{redirects}
-      # Policy redirects
-      #{policy_redirects}
-
-      # kuma.io/* tag redirects
-      #{kuma_tag_redirects}
-
-      # kuma.io subdomain redirects
-      #{kuma_subdomain_redirects}
-      RDR
+      end.join("\n")
 
       # Add all hand-crafted redirects
       redirects = <<~RDR
-        #{redirects}
+        # Specific version to release
+        #{version_specific_redirects}
 
-        # Original _redirects file:
-        #{current_redirects}
+        # _redirects file:
+        #{kuma_redirects}
+
+        # _common_redirects file:
+        #{common_redirects}
       RDR
 
       write_file(site, "_redirects", redirects)
@@ -125,6 +46,22 @@ module Jekyll
       page.content = content
       page.data['layout'] = nil
       site.pages << page
+    end
+
+    private
+
+    def existing_redirects(latest_release)
+      @existing_redirects ||= File.readlines(
+        'app/_redirects',
+        chomp: true
+      ).map { |l| l.gsub('/LATEST_RELEASE/', "/#{latest_release}/") }
+    end
+
+    def common_redirects(latest_release)
+      @common_redirects ||= File.readlines(
+        'app/_common_redirects',
+        chomp: true
+      ).map { |l| l.gsub('/LATEST_RELEASE/', "/#{latest_release}/") }
     end
   end
 end

--- a/app/_redirects
+++ b/app/_redirects
@@ -1,2 +1,36 @@
 # Anything after this line is manually maintained in _redirects
 # See app/_plugins/generators/redirects.rb to understand the above lines
+
+/docs /docs/LATEST_RELEASE/ 301
+/latest_version.html /latest_version 301
+/install /install/LATEST_RELEASE/ 301
+/install/latest/* /install/LATEST_RELEASE/:splat 301
+/install/kong-gateway /docs/LATEST_RELEASE/explore/gateway 301
+
+# Kuma tag redirects
+/builtindns/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiobuiltindns 301
+/builtindnsport/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiobuiltindnsport 301
+/container-patches/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiocontainer-patches 301
+/direct-access-services/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiodirect-access-services 301
+/envoy-admin-port/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaioenvoy-admin-port 301
+/gateway/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiogateway 301
+/ignore/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaioignore 301
+/ingress-public-address/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaioingress-public-address 301
+/ingress-public-port/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaio#builtindns 301
+/ingress/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaioingress 301
+/mesh/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiomesh 301
+/service-account-token-volume/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaioservice-account-token-volume 301
+/sidecar-drain-time/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiosidecar-drain-time 301
+/sidecar-env-vars/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiosidecar-env-vars 301
+/sidecar-injection/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiosidecar-injection 301
+/transparent-proxying-experimental-engine/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiotransparent-proxying-experimental-engine 301
+/transparent-proxying-inbound-v6-port/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiotransparent-proxying-inbound-v6-port 301
+/transparent-proxying-reachable-services/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiotransparent-proxying-reachable-services 301
+/virtual-probes-port/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiovirtual-probes-port 301
+/virtual-probes/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiovirtual-probes 301
+
+# kuma.io subdomain redirects
+https://prometheus.metrics.kuma.io/port /docs/LATEST_RELEASE/reference/kubernetes-annotations/#prometheus-metrics-kuma-io-port/ 301
+https://prometheus.metrics.kuma.io/path /docs/LATEST_RELEASE/reference/kubernetes-annotations/#prometheus-metrics-kuma-io-path/ 301
+https://traffic.kuma.io/exclude-inbound-ports /docs/LATEST_RELEASE/reference/kubernetes-annotations/#traffic-kuma-io-exclude-inbound-ports/ 301
+https://traffic.kuma.io/exclude-outbound-ports /docs/LATEST_RELEASE/reference/kubernetes-annotations/#traffic-kuma-io-exclude-outbound-ports/ 301


### PR DESCRIPTION
Signed-off-by: Fabian Rodriguez <fabian.rodriguez@konghq.com>

Move most of the redirects to files so we can re-use them in kong-mesh, instead of having a list of hardcoded urls.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
