### PR TITLE
Fix tabs generation in single sourced pages

### DIFF
--- a/app/_plugins/tags/tabs/tabs.rb
+++ b/app/_plugins/tags/tabs/tabs.rb
@@ -17,7 +17,7 @@ module Jekyll
       def render(context)
         environment = context.environments.first
         environment['tabs'] ||= {}
-        file_path = context.registers[:page]['path']
+        file_path = context.registers[:page]['dir']
         environment['tabs'][file_path] ||= {}
 
         if environment['tabs'][file_path].key? @name
@@ -47,7 +47,7 @@ module Jekyll
       def render(context)
         site = context.registers[:site]
         converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
-        file_path = context.registers[:page]['path']
+        file_path = context.registers[:page]['dir']
 
         environment = context.environments.first
 


### PR DESCRIPTION
When creating a tabs group, we check whether there is one already with the same name within a page. Unfortunately, we were using checking whether it existed within a file and not the whole page. After a file was read, the tabs were cached, causing it to raise an error if the file was used again, e.g. when including a file in several docs. This was causing the check to raise.

The fix consists of checking whether the tab group exists on the page instead of within a file.

Signed-off-by: Fabian Rodriguez <fabian.rodriguez@konghq.com>

<Explain your change!>

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? Yes
