### PR TITLE
fix: use 302 redirects for latest and pagination doc

### DIFF
--- a/app/_common_redirects
+++ b/app/_common_redirects
@@ -14,13 +14,13 @@
 /docs/:version/policies/virtual-outbounds/ /docs/:version/policies/virtual-outbound/ 301
 
 # Docs
-/docs/latest/documentation/gateway /docs/LATEST_RELEASE/explore/gateway 301
-/docs/latest/deployments /docs/:version/LATEST_RELEASE/deployments 301
-/docs/latest/documentation/deployments /docs/LATEST_RELEASE/introduction/deployments 301
-/docs/latest/explore/backends /docs/LATEST_RELEASE/documentation/configuration 301
-/docs/latest/security/zone-ingress-auth /docs/LATEST_RELEASE/security/zoneproxy-auth 301
-/docs/latest/security/zoneegress-auth /docs/LATEST_RELEASE/security/zoneproxy-auth 301
-/docs/latest/* /docs/LATEST_RELEASE/:splat 301
+/docs/:version/documentation/gateway /docs/:version/explore/gateway 301
+/docs/:version/deployments /docs/:version/:version/deployments 301
+/docs/:version/documentation/deployments /docs/:version/introduction/deployments 301
+/docs/:version/explore/backends /docs/:version/documentation/configuration 301
+/docs/:version/security/zone-ingress-auth /docs/:version/security/zoneproxy-auth 301
+/docs/:version/security/zoneegress-auth /docs/:version/security/zoneproxy-auth 301
+/docs/latest/* /docs/LATEST_RELEASE/:splat 302
 /docs/:version/policies/ /docs/:version/policies/introduction 301
 /docs/:version/overview/ /docs/:version/overview/what-is-kuma 301
 /docs/:version/other/ /docs/:version/other/enterprise 301

--- a/app/_posts/2023-02-01-kuma-2-1-0.md
+++ b/app/_posts/2023-02-01-kuma-2-1-0.md
@@ -3,6 +3,7 @@ title: Kuma 2.1 released with full suite of next-gen policies
 description: Next gen policy, cross control-plane API and UI improvements. 
 date: 2023-02-01
 headerImage: /assets/images/blog/kuma_2_1_blog_banner.jpg
+canonicalUrl: https://konghq.com/blog/kong-mesh-kuma-2-1
 tags:
   - Release
 ---

--- a/app/_redirects
+++ b/app/_redirects
@@ -1,36 +1,36 @@
 # Anything after this line is manually maintained in _redirects
 # See app/_plugins/generators/redirects.rb to understand the above lines
 
-/docs /docs/LATEST_RELEASE/ 301
+/docs /docs/LATEST_RELEASE/ 302
 /latest_version.html /latest_version 301
-/install /install/LATEST_RELEASE/ 301
-/install/latest/* /install/LATEST_RELEASE/:splat 301
-/install/kong-gateway /docs/LATEST_RELEASE/explore/gateway 301
+/install /install/LATEST_RELEASE/ 302
+/install/latest/* /install/LATEST_RELEASE/:splat 302
+/install/kong-gateway /docs/LATEST_RELEASE/explore/gateway 302
 
 # Kuma tag redirects
-/builtindns/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiobuiltindns 301
-/builtindnsport/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiobuiltindnsport 301
-/container-patches/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiocontainer-patches 301
-/direct-access-services/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiodirect-access-services 301
-/envoy-admin-port/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaioenvoy-admin-port 301
-/gateway/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiogateway 301
-/ignore/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaioignore 301
-/ingress-public-address/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaioingress-public-address 301
-/ingress-public-port/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaio#builtindns 301
-/ingress/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaioingress 301
-/mesh/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiomesh 301
-/service-account-token-volume/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaioservice-account-token-volume 301
-/sidecar-drain-time/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiosidecar-drain-time 301
-/sidecar-env-vars/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiosidecar-env-vars 301
-/sidecar-injection/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiosidecar-injection 301
-/transparent-proxying-experimental-engine/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiotransparent-proxying-experimental-engine 301
-/transparent-proxying-inbound-v6-port/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiotransparent-proxying-inbound-v6-port 301
-/transparent-proxying-reachable-services/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiotransparent-proxying-reachable-services 301
-/virtual-probes-port/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiovirtual-probes-port 301
-/virtual-probes/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiovirtual-probes 301
+/builtindns/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiobuiltindns 302
+/builtindnsport/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiobuiltindnsport 302
+/container-patches/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiocontainer-patches 302
+/direct-access-services/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiodirect-access-services 302
+/envoy-admin-port/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaioenvoy-admin-port 302
+/gateway/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiogateway 302
+/ignore/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaioignore 302
+/ingress-public-address/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaioingress-public-address 302
+/ingress-public-port/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaio#builtindns 302
+/ingress/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaioingress 302
+/mesh/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiomesh 302
+/service-account-token-volume/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaioservice-account-token-volume 302
+/sidecar-drain-time/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiosidecar-drain-time 302
+/sidecar-env-vars/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiosidecar-env-vars 302
+/sidecar-injection/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiosidecar-injection 302
+/transparent-proxying-experimental-engine/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiotransparent-proxying-experimental-engine 302
+/transparent-proxying-inbound-v6-port/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiotransparent-proxying-inbound-v6-port 302
+/transparent-proxying-reachable-services/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiotransparent-proxying-reachable-services 302
+/virtual-probes-port/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiovirtual-probes-port 302
+/virtual-probes/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiovirtual-probes 302
 
 # kuma.io subdomain redirects
-https://prometheus.metrics.kuma.io/port /docs/LATEST_RELEASE/reference/kubernetes-annotations/#prometheus-metrics-kuma-io-port/ 301
-https://prometheus.metrics.kuma.io/path /docs/LATEST_RELEASE/reference/kubernetes-annotations/#prometheus-metrics-kuma-io-path/ 301
-https://traffic.kuma.io/exclude-inbound-ports /docs/LATEST_RELEASE/reference/kubernetes-annotations/#traffic-kuma-io-exclude-inbound-ports/ 301
-https://traffic.kuma.io/exclude-outbound-ports /docs/LATEST_RELEASE/reference/kubernetes-annotations/#traffic-kuma-io-exclude-outbound-ports/ 301
+https://prometheus.metrics.kuma.io/port /docs/LATEST_RELEASE/reference/kubernetes-annotations/#prometheus-metrics-kuma-io-port/ 302
+https://prometheus.metrics.kuma.io/path /docs/LATEST_RELEASE/reference/kubernetes-annotations/#prometheus-metrics-kuma-io-path/ 302
+https://traffic.kuma.io/exclude-inbound-ports /docs/LATEST_RELEASE/reference/kubernetes-annotations/#traffic-kuma-io-exclude-inbound-ports/ 302
+https://traffic.kuma.io/exclude-outbound-ports /docs/LATEST_RELEASE/reference/kubernetes-annotations/#traffic-kuma-io-exclude-outbound-ports/ 302

--- a/app/_src/reference/http-api.md
+++ b/app/_src/reference/http-api.md
@@ -83,7 +83,7 @@ You can use `GET` requests to retrieve the state of {{site.mesh_product_name}} o
 ## Pagination
 
 Every resource list in {{site.mesh_product_name}} is paginated. To use pagination, you can use following query parameters:
-* `size` - size of the page (default - 1000, maximum value - 10000).
+* `size` - size of the page (default - 100, maximum value - 1000).
 * `offset` - offset from which the page will be listed. The offset is a `string`, it does not have to be a number (it depends on the environment).
 
 A response with a pagination contains `next` field with URL to fetch the next page. Example:

--- a/app/docs/1.6.x/reference/http-api.md
+++ b/app/docs/1.6.x/reference/http-api.md
@@ -81,7 +81,7 @@ You can use `GET` requests to retrieve the state of Kuma on both Universal and K
 ## Pagination
 
 Every resource list in Kuma is paginated. To use pagination, you can use following query parameters:
-* `size` - size of the page (default - 1000, maximum value - 10000).
+* `size` - size of the page (default - 100, maximum value - 1000).
 * `offset` - offset from which the page will be listed. The offset is a `string`, it does not have to be a number (it depends on the environment).
 
 A response with a pagination contains `next` field with URL to fetch the next page. Example:

--- a/app/docs/1.7.x/reference/http-api.md
+++ b/app/docs/1.7.x/reference/http-api.md
@@ -81,7 +81,7 @@ You can use `GET` requests to retrieve the state of Kuma on both Universal and K
 ## Pagination
 
 Every resource list in Kuma is paginated. To use pagination, you can use following query parameters:
-* `size` - size of the page (default - 1000, maximum value - 10000).
+* `size` - size of the page (default - 100, maximum value - 1000).
 * `offset` - offset from which the page will be listed. The offset is a `string`, it does not have to be a number (it depends on the environment).
 
 A response with a pagination contains `next` field with URL to fetch the next page. Example:

--- a/app/docs/1.8.x/reference/http-api.md
+++ b/app/docs/1.8.x/reference/http-api.md
@@ -82,7 +82,7 @@ You can use `GET` requests to retrieve the state of Kuma on both Universal and K
 ## Pagination
 
 Every resource list in Kuma is paginated. To use pagination, you can use following query parameters:
-* `size` - size of the page (default - 1000, maximum value - 10000).
+* `size` - size of the page (default - 100, maximum value - 1000).
 * `offset` - offset from which the page will be listed. The offset is a `string`, it does not have to be a number (it depends on the environment).
 
 A response with a pagination contains `next` field with URL to fetch the next page. Example:

--- a/app/docs/2.0.x/reference/http-api.md
+++ b/app/docs/2.0.x/reference/http-api.md
@@ -83,7 +83,7 @@ You can use `GET` requests to retrieve the state of {{site.mesh_product_name}} o
 ## Pagination
 
 Every resource list in {{site.mesh_product_name}} is paginated. To use pagination, you can use following query parameters:
-* `size` - size of the page (default - 1000, maximum value - 10000).
+* `size` - size of the page (default - 100, maximum value - 1000).
 * `offset` - offset from which the page will be listed. The offset is a `string`, it does not have to be a number (it depends on the environment).
 
 A response with a pagination contains `next` field with URL to fetch the next page. Example:


### PR DESCRIPTION
Using 301 was causing browsers to cache the redirect which was causing problems when the latest version changed

Signed-off-by: Charly Molter <charly.molter@konghq.com>