### PR TITLE
(docs) Add the new "Install kumactl" page

### DIFF
--- a/app/_data/docs_nav_kuma_dev.yml
+++ b/app/_data/docs_nav_kuma_dev.yml
@@ -31,32 +31,8 @@ items:
     items:
       - text: Install kumactl
         url: /production/install-kumactl/
-  - title: Install
-    group: true
-    items:
-      - text: Kubernetes
-        url: /installation/kubernetes/
-      - text: Helm
-        url: /installation/helm/
-        items:
-          - text: Argo CD
-            url: "/installation/helm/#argo-cd"
-      - text: OpenShift
-        url: /installation/openshift/
-      - text: Docker
-        url: /installation/docker/
-      - text: Amazon Linux
-        url: /installation/amazonlinux/
-      - text: Redhat
-        url: /installation/redhat/
-      - text: CentOS
-        url: /installation/centos/
-      - text: Debian
-        url: /installation/debian/
-      - text: Ubuntu
-        url: /installation/ubuntu/
-      - text: macOS
-        url: /installation/macos/
+      - text: Use Kuma
+        url: /production/use-kuma/
   - title: Deploy
     group: true
     items:

--- a/app/_data/docs_nav_kuma_dev.yml
+++ b/app/_data/docs_nav_kuma_dev.yml
@@ -26,6 +26,11 @@ items:
       - text: Changelog
         absolute_url: true
         url: https://github.com/kumahq/kuma/blob/master/CHANGELOG.md
+  - title: Kuma in Production
+    group: true
+    items:
+      - text: Install kumactl
+        url: /production/install-kumactl/
   - title: Install
     group: true
     items:

--- a/app/_redirects
+++ b/app/_redirects
@@ -37,9 +37,6 @@ https://prometheus.metrics.kuma.io/path /docs/LATEST_RELEASE/reference/kubernete
 https://traffic.kuma.io/exclude-inbound-ports /docs/LATEST_RELEASE/reference/kubernetes-annotations/#traffic-kuma-io-exclude-inbound-ports/ 302
 https://traffic.kuma.io/exclude-outbound-ports /docs/LATEST_RELEASE/reference/kubernetes-annotations/#traffic-kuma-io-exclude-outbound-ports/ 302
 
-
-
-
 # Community section
 
 /contribute/introduction/*  /docs/LATEST_RELEASE/community/contribute-to-kuma/:splat 302

--- a/app/_src/deployments/stand-alone.md
+++ b/app/_src/deployments/stand-alone.md
@@ -63,6 +63,39 @@ Once {{site.mesh_product_name}} is up and running, data plane proxies can now [c
 When the mode is not specified, {{site.mesh_product_name}} will always start in `standalone` mode by default.
 {% endtip %}
 
+#### Optional: Docker authentication
+
+Running administrative tasks (like generating a dataplane token) requires [authentication by token](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) or a connection via localhost.
+
+##### Localhost authentication
+
+For `kuma-cp` to recognize requests issued to docker published port it needs to run the container in the host network.
+To do this, add `--network="host"` parameter to the `docker run` command from point 2.
+
+##### Authenticate via token
+
+You can also configure `kumactl` to access `kuma-dp` from the container.
+Get the `kuma-cp` container id:
+
+```sh
+docker ps # copy kuma-cp container id
+
+export KUMA_CP_CONTAINER_ID='...'
+```
+
+Configure `kumactl`:
+
+```sh
+TOKEN=$(bash -c "docker exec -it $KUMA_CP_CONTAINER_ID wget -q -O - http://localhost:5681/global-secrets/admin-user-token" | jq -r .data | base64 -d)
+
+kumactl config control-planes add \
+ --name my-control-plane \
+ --address http://localhost:5681 \
+ --auth-type=tokens \
+ --auth-conf token=$TOKEN \
+ --skip-verify
+```
+
 ## Failure modes
 
 #### Control plane offline

--- a/app/_src/deployments/stand-alone.md
+++ b/app/_src/deployments/stand-alone.md
@@ -70,7 +70,7 @@ Running administrative tasks (like generating a dataplane token) requires [authe
 ##### Localhost authentication
 
 For `kuma-cp` to recognize requests issued to docker published port it needs to run the container in the host network.
-To do this, add `--network="host"` parameter to the `docker run` command from point 2.
+To do this, add `--network="host"` parameter to the `docker run` command.
 
 ##### Authenticate via token
 

--- a/app/_src/explore/gateway.md
+++ b/app/_src/explore/gateway.md
@@ -73,7 +73,7 @@ Multi-zone requires exposing a dedicated Kubernetes `Service` object with type `
 Follow instructions to setup an echo service reachable through Kong.
 These instructions are mostly taken from the [Kong docs](https://docs.konghq.com/kubernetes-ingress-controller/2.1.x/guides/getting-started/).
 
-1. [Install {{site.mesh_product_name}}](/docs/{{ page.version }}/installation/kubernetes) on your cluster and have the `default` [namespace labelled with sidecar-injection](/docs/{{ page.version }}/explore/dpp-on-kubernetes).
+1. {% if_version lte:2.1.x %}[Install {{site.mesh_product_name}}](/docs/{{ page.version }}/installation/kubernetes){% endif_version %}{% if_version gte:2.2.x %}[Install {{site.mesh_product_name}}](/docs/{{ page.version }}/production/install-kumactl/){% endif_version %} on your cluster and have the `default` [namespace labelled with sidecar-injection](/docs/{{ page.version }}/explore/dpp-on-kubernetes).
 
 2. Install [Kong using helm](https://docs.konghq.com/kubernetes-ingress-controller/2.1.x/deployment/k4k8s/#helm).
 

--- a/app/_src/networking/cni.md
+++ b/app/_src/networking/cni.md
@@ -14,7 +14,9 @@ There are two options to do this with {{site.mesh_product_name}}:
 - use the standard `kuma-init`, which is the default
 - use the {{site.mesh_product_name}} CNI
 
-{{site.mesh_product_name}} CNI can be leveraged in the two installation methods for Kubernetes: using {% if_version lte:2.1.x %}[`kumactl`](/docs/{{ page.version }}/installation/kubernetes) and with [Helm](/docs/{{ page.version }}/installation/helm){% endif_version %}{% if_version gte:2.2.x %}[`kumactl`](/docs/{{ page.version }}/production/install-kumactl/) and with [Helm](/docs/{{ page.version }}/production/install-kumactl/){% endif_version %}.
+{{site.mesh_product_name}} CNI can be leveraged in the two installation methods for Kubernetes: using 
+{% if_version lte:2.1.x %}[`kumactl`](/docs/{{ page.version }}/installation/kubernetes) and with [Helm](/docs/{{ page.version }}/installation/helm){% endif_version %}
+{% if_version gte:2.2.x %}[`kumactl`](/docs/{{ page.version }}/production/install-kumactl/) and with [Helm](/docs/{{ page.version }}/production/install-kumactl/){% endif_version %}.
 The default settings are tuned for OpenShift with Multus,
 therefore to use it in other environments we need to set the relevant configuration parameters.
 

--- a/app/_src/networking/cni.md
+++ b/app/_src/networking/cni.md
@@ -14,7 +14,7 @@ There are two options to do this with {{site.mesh_product_name}}:
 - use the standard `kuma-init`, which is the default
 - use the {{site.mesh_product_name}} CNI
 
-{{site.mesh_product_name}} CNI can be leveraged in the two installation methods for Kubernetes: using [`kumactl`](/docs/{{ page.version }}/installation/kubernetes) and with [Helm](/docs/{{ page.version }}/installation/helm).
+{{site.mesh_product_name}} CNI can be leveraged in the two installation methods for Kubernetes: using {% if_version lte:2.1.x %}[`kumactl`](/docs/{{ page.version }}/installation/kubernetes) and with [Helm](/docs/{{ page.version }}/installation/helm){% endif_version %}{% if_version gte:2.2.x %}[`kumactl`](/docs/{{ page.version }}/production/install-kumactl/) and with [Helm](/docs/{{ page.version }}/production/install-kumactl/){% endif_version %}.
 The default settings are tuned for OpenShift with Multus,
 therefore to use it in other environments we need to set the relevant configuration parameters.
 

--- a/app/_src/production/install-kumactl.md
+++ b/app/_src/production/install-kumactl.md
@@ -1,0 +1,70 @@
+---
+title: Install kumactl
+content_type: how-to
+---
+
+This how-to guide explains how to install kumactl in your environment.
+
+{% navtabs %}
+{% navtab Kubernetes %}
+1. Download {{site.mesh_product_name}}:
+```sh
+curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -
+```
+1. Run {{site.mesh_product_name}}:
+    * Standalone mode:
+    * Multi-zone mode: HOW?
+
+{% endnavtab %}
+{% navtab Helm %}
+1. Download {{site.mesh_product_name}}:
+```sh
+helm repo add kuma https://kumahq.github.io/charts
+helm upgrade -i kuma kuma/kuma
+```
+1. Run {{site.mesh_product_name}}:
+    * Standalone mode:
+    * Multi-zone mode: HOW?
+
+{% endnavtab %}
+{% navtab OpenShift %}
+1. Download {{site.mesh_product_name}}:
+```sh
+curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -
+```
+1. Run {{site.mesh_product_name}}:
+    * Standalone mode:
+    ```sh
+    ./kumactl install control-plane --cni-enabled | oc apply -f -
+    ```
+    * Multi-zone mode: HOW?
+
+{% endnavtab %}
+{% navtab Docker %}
+1. Download {{site.mesh_product_name}}:
+```sh
+docker pull docker.io/kumahq/kuma-cp:{{ page.latest_version }}
+docker pull docker.io/kumahq/kuma-dp:{{ page.latest_version }}
+docker pull docker.io/kumahq/kumactl:{{ page.latest_version }}
+```
+1. Run {{site.mesh_product_name}}:
+    * Standalone mode:
+    ```
+    docker run -p 5681:5681 docker.io/kumahq/kuma-cp:{{ page.latest_version }} run
+    ```
+    * Multi-zone mode: HOW?
+
+{% endnavtab %}
+{% navtab Linux %}
+1. Download {{site.mesh_product_name}}:
+```sh
+curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -
+```
+1. Run {{site.mesh_product_name}}:
+    * Standalone mode:
+    ```
+    kuma-{{ page.latest_version }}/bin/kuma-cp run
+    ```
+    * Multi-zone mode: HOW?
+{% endnavtab %}
+{% endnavtabs %}

--- a/app/_src/production/install-kumactl.md
+++ b/app/_src/production/install-kumactl.md
@@ -14,7 +14,7 @@ The `kumactl` binary is a client to the {{site.mesh_product_name}} HTTP API.
 
 {% tabs install-kumactl useUrlFragment=false %}
 {% tab install-kumactl Kubernetes %}
-1. Download {{site.mesh_product_name}}:
+Download {{site.mesh_product_name}}:
 {% tabs install_kumactl useUrlFragment=false %}
 {% tab install_kumactl Script %}
 
@@ -40,7 +40,7 @@ and extract the archive with `tar xvzf kuma-{{ page.latest_version }}.tar.gz`
 {% endtab %}
 {% endtabs %}
 
-1. Add the `kumactl` executable to your path:
+Add the `kumactl` executable to your path:
 ```
 cd kuma-{{ page.latest_version }}/bin
 PATH=$(pwd):$PATH
@@ -67,6 +67,7 @@ Download {{site.mesh_product_name}}:
 docker pull docker.io/kumahq/kuma-cp:{{ page.latest_version }}
 docker pull docker.io/kumahq/kuma-dp:{{ page.latest_version }}
 docker pull docker.io/kumahq/kumactl:{{ page.latest_version }}
+alias kumactl="docker run --rm -it kumahq/kumactl:{{ page.latest_version }} kumactl"
 ```
 {% endtab %}
 {% tab install-kumactl Linux %}

--- a/app/_src/production/install-kumactl.md
+++ b/app/_src/production/install-kumactl.md
@@ -64,8 +64,6 @@ curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -
 {% tab install-kumactl Docker %}
 Download {{site.mesh_product_name}}:
 ```sh
-docker pull docker.io/kumahq/kuma-cp:{{ page.latest_version }}
-docker pull docker.io/kumahq/kuma-dp:{{ page.latest_version }}
 docker pull docker.io/kumahq/kumactl:{{ page.latest_version }}
 alias kumactl="docker run --rm -it kumahq/kumactl:{{ page.latest_version }} kumactl"
 ```

--- a/app/_src/production/install-kumactl.md
+++ b/app/_src/production/install-kumactl.md
@@ -3,82 +3,85 @@ title: Install kumactl
 content_type: how-to
 ---
 
-This how-to guide explains how to install kumactl in your environment.
+This how-to guide explains how to install `kumactl` in your environment.
+
+`kumactl` is a CLI tool that you can use to access {{site.mesh_product_name}}. It can do the following:
+
+* Perform read-only operations on {{site.mesh_product_name}} resources on Kubernetes. 
+* Read and create resources in {{site.mesh_product_name}} in Universal mode.
+
+The `kumactl` binary is a client to the {{site.mesh_product_name}} HTTP API. 
 
 {% tabs install-kumactl useUrlFragment=false %}
-{% tab Kubernetes %}
+{% tab install-kumactl Kubernetes %}
 1. Download {{site.mesh_product_name}}:
-```sh
-curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -
-```
+{% tabs install_kumactl useUrlFragment=false %}
+{% tab install_kumactl Script %}
+
+Run the following script to automatically detect the operating system and download Kuma:
+
+<div class="language-sh">
+  <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
+</div>
+
+You can omit the `VERSION` variable to install the latest version.
+{% endtab %}
+{% tab install_kumactl Direct Link %}
+
+Download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access Kubernetes:
+
+* <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
+* <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
+* <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
+* <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
+* <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
+
+and extract the archive with `tar xvzf kuma-{{ page.latest_version }}.tar.gz`
+{% endtab %}
+{% endtabs %}
+
 1. Add the `kumactl` executable to your path:
 ```
 cd kuma-{{ page.latest_version }}/bin
 PATH=$(pwd):$PATH
 ```
 
-1. Run {{site.mesh_product_name}}:
-    * Standalone mode:
-    ```sh
-    kumactl install control-plane | kubectl apply -f -
-    ```
-    * Multi-zone mode: HOW?
-
-1. Check the status of the {{site.mesh_product_name}} resources:
-```sh
-kubectl get pod -n kuma-system
-```
-
 {% endtab %}
-{% tab Helm %}
-1. Download {{site.mesh_product_name}}:
+{% tab install-kumactl Helm %}
+Add the {{site.mesh_product_name}} charts repository:
 ```sh
 helm repo add kuma https://kumahq.github.io/charts
 helm upgrade -i kuma kuma/kuma
 ```
-1. Run {{site.mesh_product_name}}:
-    * Standalone mode:
-    * Multi-zone mode: HOW?
 
 {% endtab %}
-{% tab OpenShift %}
-1. Download {{site.mesh_product_name}}:
+{% tab install-kumactl OpenShift %}
+Download {{site.mesh_product_name}}:
 ```sh
 curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -
 ```
-1. Run {{site.mesh_product_name}}:
-    * Standalone mode:
-    ```sh
-    ./kumactl install control-plane --cni-enabled | oc apply -f -
-    ```
-    * Multi-zone mode: HOW?
-
 {% endtab %}
-{% tab Docker %}
-1. Download {{site.mesh_product_name}}:
+{% tab install-kumactl Docker %}
+Download {{site.mesh_product_name}}:
 ```sh
 docker pull docker.io/kumahq/kuma-cp:{{ page.latest_version }}
 docker pull docker.io/kumahq/kuma-dp:{{ page.latest_version }}
 docker pull docker.io/kumahq/kumactl:{{ page.latest_version }}
 ```
-1. Run {{site.mesh_product_name}}:
-    * Standalone mode:
-    ```sh
-    docker run -p 5681:5681 docker.io/kumahq/kuma-cp:{{ page.latest_version }} run
-    ```
-    * Multi-zone mode: HOW?
-
 {% endtab %}
-{% tab Linux %}
-1. Download {{site.mesh_product_name}}:
-```sh
-curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -
-```
-1. Run {{site.mesh_product_name}}:
-    * Standalone mode:
-    ```sh
-    kuma-{{ page.latest_version }}/bin/kuma-cp run
-    ```
-    * Multi-zone mode: HOW?
+{% tab install-kumactl Linux %}
+Download {{site.mesh_product_name}} by doing one of the following:
+* Run the following script to automatically detect the operating system and download {{site.mesh_product_name}}:
+<div class="language-sh">
+<pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
+</div>
+* <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-{{ page.os }}-{{ page.arch }}.tar.gz">Download</a> the distribution manually, and then extract the archive with: `tar xvzf kuma-{{ page.latest_version }}`.
+
+{% tip %}
+Make sure you have tar and gzip installed.
+{% endtip %}
 {% endtab %}
 {% endtabs %}
+
+## Next steps
+After you've installed `kumactl`, you can deploy {{site.mesh_product_name}} in standalone or multi-zone mode.

--- a/app/_src/production/install-kumactl.md
+++ b/app/_src/production/install-kumactl.md
@@ -5,18 +5,32 @@ content_type: how-to
 
 This how-to guide explains how to install kumactl in your environment.
 
-{% navtabs %}
-{% navtab Kubernetes %}
+{% tabs install-kumactl useUrlFragment=false %}
+{% tab Kubernetes %}
 1. Download {{site.mesh_product_name}}:
 ```sh
 curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -
 ```
+1. Add the `kumactl` executable to your path:
+```
+cd kuma-{{ page.latest_version }}/bin
+PATH=$(pwd):$PATH
+```
+
 1. Run {{site.mesh_product_name}}:
     * Standalone mode:
+    ```sh
+    kumactl install control-plane | kubectl apply -f -
+    ```
     * Multi-zone mode: HOW?
 
-{% endnavtab %}
-{% navtab Helm %}
+1. Check the status of the {{site.mesh_product_name}} resources:
+```sh
+kubectl get pod -n kuma-system
+```
+
+{% endtab %}
+{% tab Helm %}
 1. Download {{site.mesh_product_name}}:
 ```sh
 helm repo add kuma https://kumahq.github.io/charts
@@ -26,8 +40,8 @@ helm upgrade -i kuma kuma/kuma
     * Standalone mode:
     * Multi-zone mode: HOW?
 
-{% endnavtab %}
-{% navtab OpenShift %}
+{% endtab %}
+{% tab OpenShift %}
 1. Download {{site.mesh_product_name}}:
 ```sh
 curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -
@@ -39,8 +53,8 @@ curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -
     ```
     * Multi-zone mode: HOW?
 
-{% endnavtab %}
-{% navtab Docker %}
+{% endtab %}
+{% tab Docker %}
 1. Download {{site.mesh_product_name}}:
 ```sh
 docker pull docker.io/kumahq/kuma-cp:{{ page.latest_version }}
@@ -49,22 +63,22 @@ docker pull docker.io/kumahq/kumactl:{{ page.latest_version }}
 ```
 1. Run {{site.mesh_product_name}}:
     * Standalone mode:
-    ```
+    ```sh
     docker run -p 5681:5681 docker.io/kumahq/kuma-cp:{{ page.latest_version }} run
     ```
     * Multi-zone mode: HOW?
 
-{% endnavtab %}
-{% navtab Linux %}
+{% endtab %}
+{% tab Linux %}
 1. Download {{site.mesh_product_name}}:
 ```sh
 curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -
 ```
 1. Run {{site.mesh_product_name}}:
     * Standalone mode:
-    ```
+    ```sh
     kuma-{{ page.latest_version }}/bin/kuma-cp run
     ```
     * Multi-zone mode: HOW?
-{% endnavtab %}
-{% endnavtabs %}
+{% endtab %}
+{% endtabs %}

--- a/app/_src/production/use-kuma.md
+++ b/app/_src/production/use-kuma.md
@@ -1,0 +1,147 @@
+---
+title: Use Kuma
+---
+
+After {{site.mesh_product_name}} is installed, you can access the control plane via the following methods:
+
+| Access method | Mode | Permissions | 
+| ---- | ---- | ----- |
+| {{site.mesh_product_name}} user interface | Kubernetes and Universal | Read-only |
+| HTTP API | Kubernetes and Universal | Read-only |
+| `kumactl` | Kubernetes | Read-only |
+| `kumactl` | Universal | Read and write |
+| `kubectl` | Kubernetes | Read and write |
+
+By accessing the control plane using one of these methods, you can see the current {{site.mesh_product_name}} configuration or with some methods, you can edit the configuration. 
+
+
+## Use {{site.mesh_product_name}} with Kubernetes
+
+{% tabs use-kuma-kubernetes useUrlFragment=false %}
+{% tab use-kuma-kubernetes GUI (Read-Only) %}
+
+Kuma ships with a **read-only** GUI that you can use to retrieve Kuma resources. By default the GUI listens on the API port and defaults to `:5681/gui`.
+
+To access Kuma we need to first port-forward the API service with:
+
+```sh
+kubectl port-forward svc/{{site.mesh_cp_name}} -n {{site.mesh_namespace}} 5681:5681
+```
+
+And then navigate to [`127.0.0.1:5681/gui`](http://127.0.0.1:5681/gui) to see the GUI.
+
+{% endtab %}
+{% tab use-kuma-kubernetes kubectl (Read & Write) %}
+
+You can use Kuma with `kubectl` to perform **read and write** operations on Kuma resources. For example:
+
+```sh
+kubectl get meshes
+# NAME          AGE
+# default       1m
+```
+
+or you can enable mTLS on the `default` Mesh with:
+
+```sh
+echo "apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: default
+spec:
+  mtls:
+    enabledBackend: ca-1
+    backends:
+    - name: ca-1
+      type: builtin" | kubectl apply -f -
+```
+
+{% endtab %}
+{% tab use-kuma-kubernetes HTTP API (Read-Only) %}
+
+Kuma ships with a **read-only** HTTP API that you can use to retrieve Kuma resources.
+
+By default the HTTP API listens on port `5681`. To access Kuma we need to first port-forward the API service with:
+
+```sh
+kubectl port-forward svc/{{site.mesh_cp_name}} -n {{site.mesh_namespace}} 5681:5681
+```
+
+And then you can navigate to [`127.0.0.1:5681`](http://127.0.0.1:5681) to see the HTTP API.
+
+{% endtab %}
+{% tab use-kuma-kubernetes kumactl (Read-Only) %}
+
+You can use the `kumactl` CLI to perform **read-only** operations on Kuma resources. The `kumactl` binary is a client to the Kuma HTTP API, you will need to first port-forward the API service with:
+
+```sh
+kubectl port-forward svc/{{site.mesh_cp_name}} -n {{site.mesh_namespace}} 5681:5681
+```
+
+and then run `kumactl`, for example:
+
+```sh
+kumactl get meshes
+# NAME          mTLS      METRICS      LOGGING   TRACING
+# default       off       off          off       off
+```
+
+You can configure `kumactl` to point to any zone `kuma-cp` instance by running:
+
+```sh
+kumactl config control-planes add --name=XYZ --address=http://{address-to-kuma}:5681
+```
+
+{% endtab %}
+{% endtabs %}
+
+You will notice that Kuma automatically creates a [`Mesh`](/docs/{{ page.version }}/policies/mesh) entity with name `default`.
+
+## Use {{site.mesh_product_name}} with Universal
+
+{% tabs use-kuma-universal useUrlFragment=false %}
+{% tab use-kuma-universal GUI (Read-Only) %}
+
+Kuma ships with a **read-only** GUI that you can use to retrieve Kuma resources. By default the GUI listens on the API port and defaults to `:5681/gui`.
+
+To access Kuma you can navigate to [`127.0.0.1:5681/gui`](http://127.0.0.1:5681/gui) to see the GUI.
+
+{% endtab %}
+{% tab use-kuma-universal HTTP API (Read & Write) %}
+
+Kuma ships with a **read and write** HTTP API that you can use to perform operations on Kuma resources. By default the HTTP API listens on port `5681`.
+
+To access Kuma you can navigate to [`127.0.0.1:5681`](http://127.0.0.1:5681) to see the HTTP API.
+
+{% endtab %}
+{% tab use-kuma-universal kumactl (Read & Write) %}
+
+You can use the `kumactl` CLI to perform **read and write** operations on Kuma resources. The `kumactl` binary is a client to the Kuma HTTP API. For example:
+
+```sh
+kumactl get meshes
+# NAME          mTLS      METRICS      LOGGING   TRACING
+# default       off       off          off       off
+```
+
+or you can enable mTLS on the `default` Mesh with:
+
+```sh
+echo "type: Mesh
+name: default
+mtls:
+  enabledBackend: ca-1
+  backends:
+  - name: ca-1
+    type: builtin" | kumactl apply -f -
+```
+
+You can configure `kumactl` to point to any zone `kuma-cp` instance by running:
+
+```sh
+kumactl config control-planes add --name=XYZ --address=http://{address-to-kuma}:5681
+```
+{% endtab %}
+{% endtabs %}
+
+You will notice that Kuma automatically creates a [`Mesh`](/docs/{{ page.version }}/policies/mesh) entity with name `default`.

--- a/app/_src/production/use-kuma.md
+++ b/app/_src/production/use-kuma.md
@@ -20,9 +20,9 @@ By accessing the control plane using one of these methods, you can see the curre
 {% tabs use-kuma-kubernetes useUrlFragment=false %}
 {% tab use-kuma-kubernetes GUI (Read-Only) %}
 
-Kuma ships with a **read-only** GUI that you can use to retrieve Kuma resources. By default the GUI listens on the API port and defaults to `:5681/gui`.
+{{site.mesh_product_name}} ships with a **read-only** GUI that you can use to retrieve {{site.mesh_product_name}} resources. By default the GUI listens on the API port and defaults to `:5681/gui`.
 
-To access Kuma we need to first port-forward the API service with:
+To access {{site.mesh_product_name}} we need to first port-forward the API service with:
 
 ```sh
 kubectl port-forward svc/{{site.mesh_cp_name}} -n {{site.mesh_namespace}} 5681:5681
@@ -30,10 +30,12 @@ kubectl port-forward svc/{{site.mesh_cp_name}} -n {{site.mesh_namespace}} 5681:5
 
 And then navigate to [`127.0.0.1:5681/gui`](http://127.0.0.1:5681/gui) to see the GUI.
 
+You will notice that {{site.mesh_product_name}} automatically creates a [`Mesh`](/docs/{{ page.version }}/policies/mesh) entity with name `default`.
+
 {% endtab %}
 {% tab use-kuma-kubernetes kubectl (Read & Write) %}
 
-You can use Kuma with `kubectl` to perform **read and write** operations on Kuma resources. For example:
+You can use {{site.mesh_product_name}} with `kubectl` to perform **read and write** operations on {{site.mesh_product_name}} resources. For example:
 
 ```sh
 kubectl get meshes
@@ -56,12 +58,14 @@ spec:
       type: builtin" | kubectl apply -f -
 ```
 
+You will notice that {{site.mesh_product_name}} automatically creates a [`Mesh`](/docs/{{ page.version }}/policies/mesh) entity with name `default`.
+
 {% endtab %}
 {% tab use-kuma-kubernetes HTTP API (Read-Only) %}
 
-Kuma ships with a **read-only** HTTP API that you can use to retrieve Kuma resources.
+{{site.mesh_product_name}} ships with a **read-only** HTTP API that you can use to retrieve {{site.mesh_product_name}} resources.
 
-By default the HTTP API listens on port `5681`. To access Kuma we need to first port-forward the API service with:
+By default the HTTP API listens on port `5681`. To access {{site.mesh_product_name}} we need to first port-forward the API service with:
 
 ```sh
 kubectl port-forward svc/{{site.mesh_cp_name}} -n {{site.mesh_namespace}} 5681:5681
@@ -69,10 +73,12 @@ kubectl port-forward svc/{{site.mesh_cp_name}} -n {{site.mesh_namespace}} 5681:5
 
 And then you can navigate to [`127.0.0.1:5681`](http://127.0.0.1:5681) to see the HTTP API.
 
+You will notice that {{site.mesh_product_name}} automatically creates a [`Mesh`](/docs/{{ page.version }}/policies/mesh) entity with name `default`.
+
 {% endtab %}
 {% tab use-kuma-kubernetes kumactl (Read-Only) %}
 
-You can use the `kumactl` CLI to perform **read-only** operations on Kuma resources. The `kumactl` binary is a client to the Kuma HTTP API, you will need to first port-forward the API service with:
+You can use the `kumactl` CLI to perform **read-only** operations on {{site.mesh_product_name}} resources. The `kumactl` binary is a client to the {{site.mesh_product_name}} HTTP API, you will need to first port-forward the API service with:
 
 ```sh
 kubectl port-forward svc/{{site.mesh_cp_name}} -n {{site.mesh_namespace}} 5681:5681
@@ -92,31 +98,35 @@ You can configure `kumactl` to point to any zone `kuma-cp` instance by running:
 kumactl config control-planes add --name=XYZ --address=http://{address-to-kuma}:5681
 ```
 
+You will notice that {{site.mesh_product_name}} automatically creates a [`Mesh`](/docs/{{ page.version }}/policies/mesh) entity with name `default`.
+
 {% endtab %}
 {% endtabs %}
-
-You will notice that Kuma automatically creates a [`Mesh`](/docs/{{ page.version }}/policies/mesh) entity with name `default`.
 
 ## Use {{site.mesh_product_name}} with Universal
 
 {% tabs use-kuma-universal useUrlFragment=false %}
 {% tab use-kuma-universal GUI (Read-Only) %}
 
-Kuma ships with a **read-only** GUI that you can use to retrieve Kuma resources. By default the GUI listens on the API port and defaults to `:5681/gui`.
+{{site.mesh_product_name}} ships with a **read-only** GUI that you can use to retrieve {{site.mesh_product_name}} resources. By default the GUI listens on the API port and defaults to `:5681/gui`.
 
-To access Kuma you can navigate to [`127.0.0.1:5681/gui`](http://127.0.0.1:5681/gui) to see the GUI.
+To access {{site.mesh_product_name}} you can navigate to [`127.0.0.1:5681/gui`](http://127.0.0.1:5681/gui) to see the GUI.
+
+You will notice that {{site.mesh_product_name}} automatically creates a [`Mesh`](/docs/{{ page.version }}/policies/mesh) entity with name `default`.
 
 {% endtab %}
 {% tab use-kuma-universal HTTP API (Read & Write) %}
 
-Kuma ships with a **read and write** HTTP API that you can use to perform operations on Kuma resources. By default the HTTP API listens on port `5681`.
+{{site.mesh_product_name}} ships with a **read and write** HTTP API that you can use to perform operations on {{site.mesh_product_name}} resources. By default the HTTP API listens on port `5681`.
 
-To access Kuma you can navigate to [`127.0.0.1:5681`](http://127.0.0.1:5681) to see the HTTP API.
+To access {{site.mesh_product_name}} you can navigate to [`127.0.0.1:5681`](http://127.0.0.1:5681) to see the HTTP API.
+
+You will notice that {{site.mesh_product_name}} automatically creates a [`Mesh`](/docs/{{ page.version }}/policies/mesh) entity with name `default`.
 
 {% endtab %}
 {% tab use-kuma-universal kumactl (Read & Write) %}
 
-You can use the `kumactl` CLI to perform **read and write** operations on Kuma resources. The `kumactl` binary is a client to the Kuma HTTP API. For example:
+You can use the `kumactl` CLI to perform **read and write** operations on {{site.mesh_product_name}} resources. The `kumactl` binary is a client to the {{site.mesh_product_name}} HTTP API. For example:
 
 ```sh
 kumactl get meshes
@@ -141,7 +151,8 @@ You can configure `kumactl` to point to any zone `kuma-cp` instance by running:
 ```sh
 kumactl config control-planes add --name=XYZ --address=http://{address-to-kuma}:5681
 ```
+
+You will notice that {{site.mesh_product_name}} automatically creates a [`Mesh`](/docs/{{ page.version }}/policies/mesh) entity with name `default`.
+
 {% endtab %}
 {% endtabs %}
-
-You will notice that Kuma automatically creates a [`Mesh`](/docs/{{ page.version }}/policies/mesh) entity with name `default`.

--- a/app/_src/quickstart/kubernetes.md
+++ b/app/_src/quickstart/kubernetes.md
@@ -15,7 +15,7 @@ The zone key is purely static and arbitrary. Different zone values for different
 
 ## Prerequisites
 
-- [{{site.mesh_product_name}} installed on your Kubernetes cluster](/docs/{{ page.version }}/installation/kubernetes/)
+- {% if_version lte:2.1.x %}[{{site.mesh_product_name}} installed on your Kubernetes cluster](/docs/{{ page.version }}/installation/kubernetes/){% endif_version %}{% if_version gte:2.2.x %}[{{site.mesh_product_name}} installed on your Kubernetes cluster](/docs/{{ page.version }}/production/install-kumactl/){% endif_version %}
 - [Demo app downloaded from GitHub](https://github.com/kumahq/kuma-counter-demo):
 
   ```sh

--- a/app/_src/quickstart/kubernetes.md
+++ b/app/_src/quickstart/kubernetes.md
@@ -15,7 +15,8 @@ The zone key is purely static and arbitrary. Different zone values for different
 
 ## Prerequisites
 
-- {% if_version lte:2.1.x %}[{{site.mesh_product_name}} installed on your Kubernetes cluster](/docs/{{ page.version }}/installation/kubernetes/){% endif_version %}{% if_version gte:2.2.x %}[{{site.mesh_product_name}} installed on your Kubernetes cluster](/docs/{{ page.version }}/production/install-kumactl/){% endif_version %}
+- {% if_version lte:2.1.x %}[{{site.mesh_product_name}} installed on your Kubernetes cluster](/docs/{{ page.version }}/installation/kubernetes/){% endif_version %}
+{% if_version gte:2.2.x %}[{{site.mesh_product_name}} installed on your Kubernetes cluster](/docs/{{ page.version }}/deployments/stand-alone/){% endif_version %}
 - [Demo app downloaded from GitHub](https://github.com/kumahq/kuma-counter-demo):
 
   ```sh

--- a/app/_src/quickstart/universal.md
+++ b/app/_src/quickstart/universal.md
@@ -52,7 +52,7 @@ kumactl generate dataplane-token --name=app > kuma-token-app
 
 {% warning %}
 This action requires [authentication](/docs/{{ page.version }}/security/api-server-auth/#admin-user-token) unless executed against a control-plane running on localhost.
-If `kuma-cp` is running inside docker container please see [docker authentication docs](/docs/{{ page.version }}//installation/docker#21-authentication-optional).
+If `kuma-cp` is running inside docker container please see [docker authentication docs](/docs/{{ page.version }}/deployments/stand-alone/).
 {% endwarning %}
 
 ## Create a data plane proxy for each service


### PR DESCRIPTION
- Created a new page that will replace (at least parts) of the existing pages in the "Install" section. 
- Also, realized I should probably create a "Use Kuma" page as well to cover the remaining content from the install files, so I did that.
- Made redirects for the install files to point to the new "Install kumactl" page.
- Added the new pages to the dev nav file.
- Jira ticket: [DOCU-2859](https://konghq.atlassian.net/browse/DOCU-2859)

Did you sign your commit? Yes [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? Yes

❗ Question for reviewers: Should this topic be Kuma-only or should we bring it over to Mesh? The install instructions for Mesh look different than the Kuma ones and are different files, so I didn't think it would be a 1:1 replacement.
