### PR TITLE
Fix common redirects

### DIFF
--- a/app/_common_redirects
+++ b/app/_common_redirects
@@ -20,7 +20,6 @@
 /docs/:version/explore/backends /docs/:version/documentation/configuration 301
 /docs/:version/security/zone-ingress-auth /docs/:version/security/zoneproxy-auth 301
 /docs/:version/security/zoneegress-auth /docs/:version/security/zoneproxy-auth 301
-/docs/latest/* /docs/LATEST_RELEASE/:splat 302
 /docs/:version/policies/ /docs/:version/policies/introduction 301
 /docs/:version/overview/ /docs/:version/overview/what-is-kuma 301
 /docs/:version/other/ /docs/:version/other/enterprise 301

--- a/app/_common_redirects
+++ b/app/_common_redirects
@@ -15,7 +15,6 @@
 
 # Docs
 /docs/:version/documentation/gateway /docs/:version/explore/gateway 301
-/docs/:version/deployments /docs/:version/:version/deployments 301
 /docs/:version/documentation/deployments /docs/:version/introduction/deployments 301
 /docs/:version/explore/backends /docs/:version/documentation/configuration 301
 /docs/:version/security/zone-ingress-auth /docs/:version/security/zoneproxy-auth 301

--- a/app/_common_redirects
+++ b/app/_common_redirects
@@ -20,7 +20,6 @@
 /docs/:version/security/zone-ingress-auth /docs/:version/security/zoneproxy-auth 301
 /docs/:version/security/zoneegress-auth /docs/:version/security/zoneproxy-auth 301
 /docs/:version/policies/ /docs/:version/policies/introduction 301
-/docs/:version/overview/ /docs/:version/overview/what-is-kuma 301
 /docs/:version/other/ /docs/:version/other/enterprise 301
 /docs/:version/installation/ /docs/:version/installation/kubernetes 301
 /docs/:version/api/ /docs/:version/documentation/http-api 301

--- a/app/_redirects
+++ b/app/_redirects
@@ -6,6 +6,7 @@
 /install /install/LATEST_RELEASE/ 302
 /install/latest/* /install/LATEST_RELEASE/:splat 302
 /install/kong-gateway /docs/LATEST_RELEASE/explore/gateway 302
+/docs/latest/* /docs/LATEST_RELEASE/:splat 302
 
 # Kuma tag redirects
 /builtindns/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiobuiltindns 302

--- a/app/_redirects
+++ b/app/_redirects
@@ -2,6 +2,7 @@
 # See app/_plugins/generators/redirects.rb to understand the above lines
 
 /docs /docs/LATEST_RELEASE/ 302
+/docs/:version/overview/ /docs/:version/overview/what-is-kuma 301
 /latest_version.html /latest_version 301
 /install /install/LATEST_RELEASE/ 302
 /install/latest/* /install/LATEST_RELEASE/:splat 302


### PR DESCRIPTION
Remove a malformed redirect and move `/docs/latest/* /docs/LATEST_RELEASE/:splat 302` from `_common_redirects` to `_redirects`. We use `/latest/` in konghq for our docs.

**Note**:
There are a few redirects that are only valid for a few versions that we definitely want to fix, e.g.:

* `/docs/:version/other/ /docs/:version/other/enterprise 301` is only valid for versions 1.1.x to 1.5.x, should it redirect to `/introduction/enterprise` for newer versions?
* `/docs/:version/api/ /docs/:version/documentation/http-api 301`  ` is only valid for versions 1.1.x to 1.5.x, it should redirect to `/reference/http-api` for newer versions

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? Yes
