### PR TITLE
feat(observability): document OTel for MeshTrace and MeshAccessLog

### DIFF
--- a/app/_src/policies/meshtrace.md
+++ b/app/_src/policies/meshtrace.md
@@ -120,6 +120,18 @@ zipkin:
   sharedSpanContext: false # Default to true. If true, the inbound and outbound traffic will share the same span. 
 ```
 
+{% if_version gte:2.2.x %}
+#### OpenTelemetry
+
+The only field you can set is `endpoint`.
+
+Example:
+```yaml
+openTelemetry:
+  endpoint: otel-collector:4317 # Required. Address of OpenTelemetry collector
+```
+{% endif_version %}
+
 ## Examples
 
 ### Zipkin
@@ -345,6 +357,118 @@ Apply the configuration with `kumactl apply -f [..]` or with the [HTTP API](../.
 
 {% endtab %}
 {% endtabs %}
+
+{% if_version gte:2.2.x %}
+### OpenTelemetry
+
+{% tip %}
+This assumes a OpenTelemetry collector is configured and running.
+If you haven't already check the [OpenTelementry operator](https://github.com/open-telemetry/opentelemetry-operator).
+{% endtip %}
+
+{% tabs meshtrace-otel useUrlFragment=false %}
+{% tab meshtrace-otel Kubernetes %}
+
+Simple Example:
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshTrace
+metadata:
+  name: default
+  namespace: {{site.mesh_namespace}}
+  labels:
+    kuma.io/mesh: default # optional, defaults to `default` if unset
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - openTelemetry:
+          endpoint: otel-collector:4317
+```
+
+Full example:
+```yaml
+type: MeshTrace
+name: default
+mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - openTelemetry:
+          endpoint: otel-collector:4317
+    tags:
+      - name: team
+        literal: core
+      - name: env
+        header:
+          name: x-env
+          default: prod
+      - name: version
+        header:
+          name: x-version
+    sampling:
+      overall: 80
+      random: 60
+      client: 40
+```
+
+where `otel-collector` is the name of the Kubernetes Service for OTel exporter.
+
+Apply the configuration with `kubectl apply -f [..]`.
+
+{% endtab %}
+{% tab meshtrace-otel Universal %}
+
+Simple Example:
+```yaml
+type: MeshTrace
+name: default
+mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - openTelemetry:
+          endpoint: my-otel-collector.com:4317
+```
+
+Full example:
+```yaml
+type: MeshTrace
+name: default
+mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - openTelemetry:
+          endpoint: my-otel-collector.com:4317
+    tags:
+      - name: team
+        literal: core
+      - name: env
+        header:
+          name: x-env
+          default: prod
+      - name: version
+        header:
+          name: x-version
+    sampling:
+      overall: 80
+      random: 60
+      client: 40
+```
+
+Apply the configuration with `kumactl apply -f [..]` or with the [HTTP API](../../reference/http-api).
+
+{% endtab %}
+{% endtabs %}
+{% endif_version %}
 
 ### Targeting parts of the infrastructure
 

--- a/app/docs/2.0.x/policies/meshaccesslog.md
+++ b/app/docs/2.0.x/policies/meshaccesslog.md
@@ -307,7 +307,7 @@ spec:
         kind: Mesh
       default:
         backends:
-          - file:
+          - tcp:
               address: 127.0.0.1:5000
               format:
                 json:
@@ -336,7 +336,7 @@ spec:
         kind: Mesh
       default:
         backends:
-          - file:
+          - tcp:
               address: 127.0.0.1:5000
               format:
                 json:


### PR DESCRIPTION
closes https://github.com/kumahq/kuma-website/issues/1284

Rendered:
- MeshAccessLog [1](https://deploy-preview-1288--kuma.netlify.app/docs/dev/policies/meshaccesslog/#opentelemetry), [2](https://deploy-preview-1288--kuma.netlify.app/docs/dev/policies/meshaccesslog/#logging-to-multiple-backends)
- MeshTrace [1](https://deploy-preview-1288--kuma.netlify.app/docs/dev/policies/meshtrace/#opentelemetry), [2](https://deploy-preview-1288--kuma.netlify.app/docs/dev/policies/meshtrace/#opentelemetry-1)

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
