### PR TITLE
docs(production): systemd

### DIFF
--- a/app/_data/docs_nav_kuma_dev.yml
+++ b/app/_data/docs_nav_kuma_dev.yml
@@ -50,7 +50,7 @@ items:
           - text: Deploy a standalone control plane
             url: /production/cp-deployment/stand-alone/
           - text: Deploy a multi-zone global control plane
-            url: /production/cp-deployment/multi-zone/ 
+            url: /production/cp-deployment/multi-zone/
           - text: Zone Ingress
             url: /production/cp-deployment/zone-ingress/
           - text: Zone Egress
@@ -60,6 +60,8 @@ items:
           - text: Control plane configuration reference
             url: /generated/kuma-cp/
             generate: false
+          - text: Systemd
+            url: /production/cp-deployment/systemd/
       - text: Create multiple service meshes in a cluster
         url: /production/mesh/
       - title: Data plane configuration
@@ -560,11 +562,11 @@ items:
       - text: Kuma data collection
         url: /reference/data-collection/
       - # Auto-generated
-        text: Control plane configuration reference 
+        text: Control plane configuration reference
         url: /generated/kuma-cp
         generate: false
       - text: Envoy proxy template
-        url: /reference/proxy-template/  
+        url: /reference/proxy-template/
       - # Auto-generated
         title: Resources
         group: true

--- a/app/_src/production/cp-deployment/systemd.md
+++ b/app/_src/production/cp-deployment/systemd.md
@@ -1,0 +1,73 @@
+---
+title: Systemd
+content_type: how-to
+---
+
+When using {{site.mesh_product_name}} on VMs it is recommended to use a process manager like systemd.
+Here are examples of systemd configurations
+
+## kuma-cp
+
+```
+[Unit]
+Description = Kuma Control Plane
+After = network.target
+Documentation=https://kuma.io
+
+[Service]
+User=kuma
+Environment=KUMA_MODE=standalone
+ExecStart = /path/to/kuma/bin/kuma-cp run --config-file=/home/kuma/cp-config.yaml
+# if you need your Control Plane to be able to handle a non-trivial number of concurrent connections
+# (a total of both incoming and outgoing connections), you need to set proper resource limits on
+# the `kuma-cp` process, especially maximum number of open files.
+#
+# it happens that `systemd` units are not affected by the traditional `ulimit` configuration,
+# and you must set resource limits as part of `systemd` unit itself.
+#
+# to check effective resource limits set on a running `kuma-cp` instance, execute
+#
+#   $ cat /proc/`pgrep kuma-cp`/limits
+#
+#   Limit                     Soft Limit           Hard Limit           Units
+#   ...
+#   Max open files            1024                 4096                 files
+#   ...
+#
+# for Kuma demo setup, we chose the same limit as `docker` and `containerd` set by default.
+# See https://github.com/containerd/containerd/issues/3201
+LimitNOFILE=1048576
+Restart=always
+RestartSec=1s
+# disable rate limiting on start attempts
+StartLimitIntervalSec=0
+StartLimitBurst=0
+
+[Install]
+WantedBy = multi-user.target
+```
+
+## kuma-dp
+
+```
+[Unit]
+Description=Kuma data plane proxy
+After=network.target
+Documentation=https://kuma.io
+
+[Service]
+User=kuma
+ExecStart=/home/kuma/kong-mesh-1.9.1/bin/kuma-dp run \
+  --cp-address=https://<kuma-cp-address>:5678 \
+  --dataplane-token-file=/home/kuma/echo-service-universal.token \
+  --dataplane-file=/home/kuma/dataplane-notransparent.yaml \
+  --ca-cert-file=/home/kuma/ca.pem
+Restart=always
+RestartSec=1s
+# disable rate limiting on start attempts
+StartLimitIntervalSec=0
+StartLimitBurst=0
+
+[Install]
+WantedBy=multi-user.target
+```


### PR DESCRIPTION
A combination of what John Harris gave me and what we had in kuma-demo that was removed
https://github.com/kumahq/kuma-demo/commit/510ec77fee38640f1d443ac475fe07258ad532a8#diff-af067b38fa148f59b6355262554dcc230dc1dab6171075ae232bb9c4a81fb9cb

In JH examples, logging was configured to a specific file, but I think logging to stdout have the advantage of browsing logs through `journalctl -u kuma-cp.service`

I put env in kuma-cp  `KUMA_MODE=standalone` which is default just to show an example.

<Explain your change!>

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
