### PR TITLE
fix(deployment): add skip crds in universal on k8s instructions

### DIFF
--- a/app/_src/production/cp-deployment/multi-zone.md
+++ b/app/_src/production/cp-deployment/multi-zone.md
@@ -154,7 +154,7 @@ Please read [Kubernetes](https://kubernetes.io/docs/setup/production-environment
 1. Run helm install
 
     ```sh
-    helm install {{ site.mesh_helm_install_name }} -f values.yaml --create-namespace --namespace {{site.mesh_namespace}} {{ site.mesh_helm_repo }}
+    helm install {{ site.mesh_helm_install_name }} -f values.yaml --skip-crds --create-namespace --namespace {{site.mesh_namespace}} {{ site.mesh_helm_repo }}
     ```
 
 1. Find the external IP and port of the `global-remote-sync` service in the `{{site.mesh_namespace}}` namespace:


### PR DESCRIPTION
otherwise crds are installed and we don't want that

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
