### PR TITLE
docs: remove references to MeshGatewayRoute as targetRef kind

### DIFF
--- a/app/_src/policies/meshcircuitbreaker.md
+++ b/app/_src/policies/meshcircuitbreaker.md
@@ -44,7 +44,6 @@ target proxies are healthy or not.
 | MeshSubset        | ✅         | ❌   | ❌    |
 | MeshService       | ✅         | ✅   | ❌    |
 | MeshServiceSubset | ✅         | ❌   | ❌    |
-| MeshGatewayRoute  | ❌         | ❌   | ❌    |
 
 To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
 

--- a/app/_src/policies/meshhealthcheck.md
+++ b/app/_src/policies/meshhealthcheck.md
@@ -30,7 +30,6 @@ This mode generates extra traffic to other proxies and services as described in 
 | MeshSubset        | ✅        | ❌  | ❌   |
 | MeshService       | ✅        | ✅  | ❌   |
 | MeshServiceSubset | ✅        | ❌  | ❌   |
-| MeshGatewayRoute  | ❌        | ❌  | ❌   |
 
 
 To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).

--- a/app/_src/policies/meshhttproute.md
+++ b/app/_src/policies/meshhttproute.md
@@ -24,7 +24,6 @@ depending on where the request coming from and where it's going to.
 | MeshSubset        | ✅        | ❌  | ❌   |
 | MeshService       | ✅        | ✅  | ❌   |
 | MeshServiceSubset | ✅        | ❌  | ❌   |
-| MeshGatewayRoute  | ❌        | ❌  | ❌   |
 
 If you don't understand this table you should read [matching docs](/docs/{{ page.version }}/policies/targetref).
 

--- a/app/_src/policies/meshloadbalancingstrategy.md
+++ b/app/_src/policies/meshloadbalancingstrategy.md
@@ -18,7 +18,6 @@ flag is going to be replaced by the current policy and will be deprecated in the
 | MeshSubset        | ✅        | ❌  | ❌   |
 | MeshService       | ✅        | ✅  | ❌   |
 | MeshServiceSubset | ✅        | ❌  | ❌   |
-| MeshGatewayRoute  | ❌        | ❌  | ❌   |
 
 To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
 

--- a/app/_src/policies/meshratelimit.md
+++ b/app/_src/policies/meshratelimit.md
@@ -28,7 +28,6 @@ Rate limiting supports an [ExternalService](/docs/{{ page.version }}/policies/ex
 | MeshSubset        | ✅        | ❌  | ❌   |
 | MeshService       | ✅        | ❌  | ❌   |
 | MeshServiceSubset | ✅        | ❌  | ❌   |
-| MeshGatewayRoute  | ❌        | ❌  | ❌   |
 
 To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
 

--- a/app/_src/policies/meshretry.md
+++ b/app/_src/policies/meshretry.md
@@ -17,7 +17,6 @@ This policy enables {{site.mesh_product_name}} to know how to behave if there is
 | MeshSubset        | ✅        | ❌  | ❌   |
 | MeshService       | ✅        | ✅  | ❌   |
 | MeshServiceSubset | ✅        | ❌  | ❌   |
-| MeshGatewayRoute  | ❌        | ❌  | ❌   |
 
 To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
 

--- a/app/_src/policies/meshtimeout.md
+++ b/app/_src/policies/meshtimeout.md
@@ -15,7 +15,6 @@ it should not be mixed with [Timeout policy](../timeout).
 | MeshSubset        | ✅         | ❌   | ❌    |
 | MeshService       | ✅         | ✅   | ❌    |
 | MeshServiceSubset | ✅         | ❌   | ❌    |
-| MeshGatewayRoute  | ❌         | ❌   | ❌    |
 
 To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
 

--- a/app/_src/policies/meshtrace.md
+++ b/app/_src/policies/meshtrace.md
@@ -39,7 +39,6 @@ For HTTP you can also manually forward the following headers:
 | MeshSubset        | ✅        | ❌  | ❌   |
 | MeshService       | ✅        | ❌  | ❌   |
 | MeshServiceSubset | ✅        | ❌  | ❌   |
-| MeshGatewayRoute  | ✅        | ❌  | ❌   |
 
 To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
 


### PR DESCRIPTION
It's not supported by `MeshTrace` or any other policy. Closes https://github.com/kumahq/kuma/issues/6497