### PR TITLE
ci(.github): fix vale check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
               .map(d => d.filename);
       - uses: actions/checkout@v2
       - uses: errata-ai/vale-action@v2
-        if: fromJSON(steps.changed-files.outputs.result).length > 0
+        if: join(fromJSON(steps.changed-files.outputs.result)) != ''
         name: Run Vale
         with:
           files: "${{ steps.changed-files.outputs.result }}"


### PR DESCRIPTION
`.length` doesn't exist, I'm not sure how or if this ever worked...

See https://github.com/kumahq/kuma-website/pull/1237/files#diff-6b06584addad16d3c7ef039f811a4f13b75edd1fc4785b239e55420291fbb149