### PR TITLE
Update install-kumactl.md

### DIFF
--- a/app/_src/production/install-kumactl.md
+++ b/app/_src/production/install-kumactl.md
@@ -56,7 +56,7 @@ and extract the archive with `tar -xvzf {{ site.mesh_helm_install_name }}-{{ pag
 
 Add the `kumactl` executable to your path:
 ```
-cd kuma-{{ page.version_data.version }}/bin
+cd kong-mesh-{{ page.version_data.version }}/bin
 PATH=$(pwd):$PATH
 ```
 

--- a/app/_src/production/install-kumactl.md
+++ b/app/_src/production/install-kumactl.md
@@ -56,7 +56,7 @@ and extract the archive with `tar -xvzf {{ site.mesh_helm_install_name }}-{{ pag
 
 Add the `kumactl` executable to your path:
 ```
-cd kong-mesh-{{ page.version_data.version }}/bin
+cd {{site.mesh_product_name}}-{{ page.version_data.version }}/bin
 PATH=$(pwd):$PATH
 ```
 


### PR DESCRIPTION
Incorrect folder name for kong-mesh 
kuma is mentioned in the enterprise docs instead of kong-mesh and the copy paste wont work

addressed failed command by replacing `kuma` with `kong-mesh`

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits). yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
yes