### PR TITLE
docs(GatewayAPI): add short GAMMA mention

### DIFF
--- a/.github/styles/Vocab/Base/accept.txt
+++ b/.github/styles/Vocab/Base/accept.txt
@@ -35,6 +35,7 @@ dev
 DNS
 etcd
 Fargate
+GAMMA
 Gateway API
 Github
 Goroutine
@@ -127,6 +128,7 @@ stdin
 stdout
 Bagdi
 subcommand
+subproject
 sudo
 Syslog
 tbl

--- a/app/_data/docs_nav_kuma_dev.yml
+++ b/app/_data/docs_nav_kuma_dev.yml
@@ -188,8 +188,8 @@ items:
         items:
           - text: Installation
             url: "/explore/gateway-api/#installation"
-          - text: Usage
-            url: "/explore/gateway-api/#usage"
+          - text: Gateways
+            url: "/explore/gateway-api/#gateways"
           - text: TLS termination
             url: "/explore/gateway-api/#tls-termination"
           - text: Customization
@@ -198,6 +198,8 @@ items:
             url: "/explore/gateway-api/#multi-mesh"
           - text: Multi-zone
             url: "/explore/gateway-api/#multi-zone"
+          - text: GAMMA
+            url: "/explore/gateway-api/#service-to-service-routing"
           - text: How it works
             url: "/explore/gateway-api/#how-it-works"
   - title: Networking

--- a/app/_src/explore/gateway-api.md
+++ b/app/_src/explore/gateway-api.md
@@ -13,7 +13,7 @@ as well as traffic routing using the experimental
 {% warning %}
 [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) is still beta, therefore {{site.mesh_product_name}}'s integration provides the same level of stability.
 
-Gateway API `Gateways` aren't supported in multi-zone. To use the builtin Gateway, you need to use the [`MeshGateway` resources](/docs/{{ page.version }}/explore/gateway).
+Gateway API [`Gateways`](https://gateway-api.sigs.k8s.io/api-types/gateway/) aren't supported in multi-zone. To use the builtin Gateway, you need to use the [`MeshGateway` resources](/docs/{{ page.version }}/explore/gateway).
 {% endwarning %}
 
 1. Install the Gateway API CRDs.
@@ -38,11 +38,14 @@ Gateway API `Gateways` aren't supported in multi-zone. To use the builtin Gatewa
    kumactl install demo | kubectl apply -f -
    ```
 
-2. Add a `Gateway`.
+2. Add a [`Gateway`](https://gateway-api.sigs.k8s.io/api-types/gateway/).
 
    The `Gateway` resource represents the proxy instance that handles traffic for a set of Gateway API routes.
 
-   Every `Gateway` refers to a `GatewayClass` by name.
+   Every `Gateway` refers to a [`GatewayClass`](https://gateway-api.sigs.k8s.io/api-types/gatewayclass/).
+   The `GatewayClass` represents the class of `Gateway`, in this case Kuma's builtin edge
+   gateway, and points to a controller that should manage these `Gateways`. It can also hold
+   [additional configuration](#customization).
 
 {% capture gateway %}
 {% tabs usage useUrlFragment=false %}
@@ -106,7 +109,7 @@ kuma-pfh4s   LoadBalancer   10.43.122.93    172.20.0.3    8080:30627/TCP   87s
 {{ gateway | indent }}
 The `Gateway` is now accessible using the external address `172.20.0.3:8080`.
 
-3. Add an `HTTPRoute`.
+3. Add an [`HTTPRoute`](https://gateway-api.sigs.k8s.io/api-types/httproute/).
 
    `HTTPRoute` resources contain a set of matching criteria for HTTP requests and upstream `Services` to route those requests to.
 

--- a/app/_src/explore/gateway-api.md
+++ b/app/_src/explore/gateway-api.md
@@ -2,14 +2,18 @@
 title: Kubernetes Gateway API
 ---
 
-{{site.mesh_product_name}} supports configuring [built-in gateway](/docs/{{ page.version }}/explore/gateway) using [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/).
+{{site.mesh_product_name}} supports [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/)
+for configuring [built-in gateway](/docs/{{ page.version }}/explore/gateway)
+as well as traffic routing using the experimental
+[GAMMA](https://gateway-api.sigs.k8s.io/contributing/gamma/)
+[routing spec](https://gateway-api.sigs.k8s.io/geps/gep-1426/).
 
 ## Installation
 
 {% warning %}
 [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) is still beta, therefore {{site.mesh_product_name}}'s integration provides the same level of stability.
 
-Gateway API is not supported in multi-zone. To use the builtin Gateway, you need to use the [`MeshGateway` resources](/docs/{{ page.version }}/explore/gateway).
+Gateway API `Gateways` aren't supported in multi-zone. To use the builtin Gateway, you need to use the [`MeshGateway` resources](/docs/{{ page.version }}/explore/gateway).
 {% endwarning %}
 
 1. Install the Gateway API CRDs.
@@ -21,7 +25,12 @@ Gateway API is not supported in multi-zone. To use the builtin Gateway, you need
    - With `kumactl`, use the `--experimental-gatewayapi` flag.
    - With Helm, use the `experimental.gatewayAPI=true` value.
 
+{% if_version lte:2.2.x %}
 ## Usage
+{% endif_version %}
+{% if_version gte:2.3.x %}
+## Gateways
+{% endif_version %}
 
 1. Install the [counter demo](https://github.com/kumahq/kuma-counter-demo).
 
@@ -91,6 +100,7 @@ redis        ClusterIP      10.43.223.223   <none>        6379/TCP         3m27s
 demo-app     ClusterIP      10.43.216.203   <none>        5000/TCP         3m27s
 kuma-pfh4s   LoadBalancer   10.43.122.93    172.20.0.3    8080:30627/TCP   87s
 ```
+
 {% endcapture %}
 
 {{ gateway | indent }}
@@ -114,8 +124,7 @@ The `Gateway` is now accessible using the external address `172.20.0.3:8080`.
        namespace: kuma-demo
      rules:
      - backendRefs:
-       - group: ''
-         kind: Service
+       - kind: Service
          name: demo-app
          port: 5000
          weight: 1
@@ -150,7 +159,7 @@ The `Gateway` is now accessible using the external address `172.20.0.3:8080`.
    ...
    ```
 
-## TLS termination
+### TLS termination
 
 Gateway API supports TLS termination by using standard `kubernetes.io/tls` Secrets.
 
@@ -189,7 +198,7 @@ spec:
 Under the hood, {{site.mesh_product_name}} CP copies the `Secret` to `{{site.mesh_namespace}}` namespace and converts it to {% if_version lte:2.1.x %}[{{site.mesh_product_name}} secret](/docs/{{ page.version }}/security/secrets){% endif_version %}{% if_version gte:2.2.x %}[{{site.mesh_product_name}} secret](/docs/{{ page.version }}/production/secure-deployment/secrets/){% endif_version %}.
 It tracks all the changes to the secret and deletes it upon deletion of the original secret.
 
-## Customization
+### Customization
 
 Gateway API provides the `parametersRef` field on `GatewayClass.spec`
 to provide additional, implementation-specific configuration to `Gateways`.
@@ -213,14 +222,14 @@ except that the `tags` field is optional.
 With a `MeshGatewayConfig` you can then customize
 the generated `Service` and `Deployment` resources.
 
-## Multi-mesh
+### Multi-mesh
 
 You can specify a `Mesh` for `Gateway` and `HTTPRoute` resources
 by setting the [`kuma.io/mesh` annotation](/docs/{{ page.version }}/reference/kubernetes-annotations#kumaiomesh)
 Note that `HTTPRoutes` must also have the annotation to reference a
 `Gateway` from a non-default `Mesh`.
 
-## Cross-mesh
+### Cross-mesh
 
 [Cross-mesh gateways](/docs/{{ page.version }}/explore/gateway#cross-mesh) are supported with Gateway API.
 You'll just need to create a corresponding `GatewayClass`
@@ -260,14 +269,58 @@ spec:
   gatewayClassName: kuma-cross-mesh
 ```
 
-## Multi-zone
+### Multi-zone
 
 Gateway API isn't supported with multi-zone deployments, use {{site.mesh_product_name}}'s `MeshGateways`/`MeshGatewayRoutes` instead.
 
+{% if_version gte:2.3.x %}
+
+## Service to service routing
+
+{{site.mesh_product_name}} also supports routing between services with
+`HTTPRoute` in conformance with
+[the GAMMA specifications](https://gateway-api.sigs.k8s.io/geps/gep-1426/).
+
+GAMMA is a Gateway API subproject focused on mesh implementations of Gateway API
+and extending the Gateway API resources to mesh use cases.
+
+The key feature of `HTTPRoute` for mesh routing is specifying a Kubernetes
+`Service` as the `parentRef`, as opposed to a `Gateway`.
+All requests to this `Service` are then filtered and routed as specified in the
+`HTTPRoute`.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: canary-demo-app
+  namespace: kuma-demo
+spec:
+  parentRefs:
+    - name: demo-app
+      port: 5000
+      kind: Service
+  rules:
+    - backendRefs:
+        - name: demo-app-v1
+          port: 5000
+        - name: demo-app-v2
+          port: 5000
+```
+
+The namespace of the `HTTPRoute` is key. If the route's namespace and the
+`parentRef`'s namespace are identical, {{site.mesh_product_name}} applies
+the route to _requests from all workloads_.
+If the route's namespace differs from its `parentRef`'s namespace,
+the `HTTPRoute` applies only to requests
+_from workloads in the route's namespace_.
+
+{% endif_version %}
+
 ## How it works
 
-{{site.mesh_product_name}} includes controllers that reconcile Gateway API CRDs and convert them into the corresponding {{site.mesh_product_name}} gateway CRDs.
-This is why in the GUI, {{site.mesh_product_name}} `MeshGateways`/`MeshGatewayRoutes` are visible and not Kubernetes Gateway API resources.
+{{site.mesh_product_name}} includes controllers that reconcile Gateway API CRDs and convert them into the corresponding {{site.mesh_product_name}} CRDs.
+This is why in the GUI, {{site.mesh_product_name}} `MeshGateways`/`MeshGatewayRoutes`/`MeshHTTPRoutes` are visible and not Kubernetes Gateway API resources.
 
-Kubernetes Gateway API resources serve as the source of truth for {{site.mesh_product_name}} gateways and
-any edits to {{site.mesh_product_name}} gateway resources are overwritten.
+Kubernetes Gateway API resources serve as the source of truth for {{site.mesh_product_name}} gateways and routes.
+Any edits to the corresponding {{site.mesh_product_name}} resources are overwritten.


### PR DESCRIPTION
Eventually I'd like to link to a blog post/avoid summarizing GEP again here.

[rendered](https://deploy-preview-1352--kuma.netlify.app/docs/dev/explore/gateway-api/#service-to-service-routing)