### PR TITLE
chore: add missing spaces around "=" in systemd docs

### DIFF
--- a/app/_src/production/cp-deployment/systemd.md
+++ b/app/_src/production/cp-deployment/systemd.md
@@ -12,7 +12,7 @@ Here are examples of systemd configurations
 [Unit]
 Description = {{ site.mesh_product_name }} Control Plane
 After = network.target
-Documentation={{ site.links.web }}
+Documentation = {{ site.links.web }}
 
 [Service]
 User = {{ site.mesh_product_name | downcase }}


### PR DESCRIPTION
Add missing spaces around "=" in systemd docs.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
