### PR TITLE
chore: add some "end*" wods to vale vocabulary

### DIFF
--- a/.github/styles/Vocab/Base/accept.txt
+++ b/.github/styles/Vocab/Base/accept.txt
@@ -168,3 +168,13 @@ Multizone
 multizone
 VM
 VMs
+endwarning
+endif
+endif_version
+endunless
+endfor
+endcontentfor
+endcapture
+endtab
+endtabs
+endtip


### PR DESCRIPTION
Add some missing words with `end` prefix (used in jekyll templating) to vale accepted vocabulary, to get rid of some of the false-positive warnings.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
