### PR TITLE
fix: add missing "site." prefix to jekyll variables

### DIFF
--- a/app/_src/documentation/configuration.md
+++ b/app/_src/documentation/configuration.md
@@ -31,8 +31,8 @@ kumactl install control plane \
 When using `helm`, you can override the configuration with the `envVars` field. For example, to configure the refresh interval for configuration with the data plane proxy, specify:
 ```sh
 helm install \
-  --set {{set_flag_values_prefix}}controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
-  --set {{set_flag_values_prefix}}controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s \
+  --set {{site.set_flag_values_prefix}}controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
+  --set {{site.set_flag_values_prefix}}controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s \
   {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }}
 ```
 
@@ -52,7 +52,7 @@ helm install -f values.yaml {{ site.kuma_install_name }} {{ site.mesh_helm_repo 
 If you have a lot of configuration you can just write them all in a YAML file and use:
 
 ```shell
-helm install {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }} --set-file {{set_flag_values_prefix}}controlPlane.config=cp-conf.yaml
+helm install {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }} --set-file {{site.set_flag_values_prefix}}controlPlane.config=cp-conf.yaml
 ```
 The value of the configmap `{{site.mesh_cp_name}}-config` is now the content of `cp-conf.yaml`.
 

--- a/app/_src/explore/gateway-api.md
+++ b/app/_src/explore/gateway-api.md
@@ -23,7 +23,7 @@ Gateway API [`Gateways`](https://gateway-api.sigs.k8s.io/api-types/gateway/) are
 2. Enable Gateway API support.
 
    - With `kumactl`, use the `--experimental-gatewayapi` flag.
-   - With Helm, use the `{{set_flag_values_prefix}}experimental.gatewayAPI=true` value.
+   - With Helm, use the `{{site.set_flag_values_prefix}}experimental.gatewayAPI=true` value.
 
 {% if_version lte:2.2.x %}
 ## Usage

--- a/app/_src/production/cp-deployment/multi-zone.md
+++ b/app/_src/production/cp-deployment/multi-zone.md
@@ -51,13 +51,13 @@ The global control plane on Kubernetes must reside on its own Kubernetes cluster
 1.  Set the `controlPlane.mode` value to `global` in the chart (`values.yaml`), then install. On the command line, run:
 
     ```sh
-    helm install {{ site.mesh_helm_install_name }} --create-namespace --namespace {{site.mesh_namespace}} --set {{set_flag_values_prefix}}controlPlane.mode=global {{ site.mesh_helm_repo }}
+    helm install {{ site.mesh_helm_install_name }} --create-namespace --namespace {{site.mesh_namespace}} --set {{site.set_flag_values_prefix}}controlPlane.mode=global {{ site.mesh_helm_repo }}
     ```
 
     Or you can edit the chart and pass the file to the `helm install {{ site.mesh_helm_install_name }}` command. To get the default values, run:
 
     ```sh
-    helm show values {{mesh_helm_repo}}
+    helm show values {{site.mesh_helm_repo}}
     ```
 
 1.  Find the external IP and port of the `global-remote-sync` service in the `{{site.mesh_namespace}}` namespace:
@@ -201,7 +201,7 @@ You need the following values to pass to each zone control plane setup:
     --zone=<zone name> \
     --ingress-enabled \
     --kds-global-address grpcs://<global-kds-address>:5685 \
-    --set {{set_flag_values_prefix}}controlPlane.tls.kdsZoneClient.skipVerify=true | kubectl apply -f -
+    --set {{site.set_flag_values_prefix}}controlPlane.tls.kdsZoneClient.skipVerify=true | kubectl apply -f -
     ```
     {% endif_version %}
     {% if_version lte:2.2.x %}
@@ -219,7 +219,7 @@ You need the following values to pass to each zone control plane setup:
     Add `--egress-enabled` to list of arguments if you want to deploy optional [Zone Egress](/docs/{{ page.version }}/production/cp-deployment/zoneegress/).
 
     {% if_version gte:2.3.x %}
-    `--set {{set_flag_values_prefix}}controlPlane.tls.kdsZoneClient.skipVerify=true` is required because the default global control plane's certificate is self-signed.
+    `--set {{site.set_flag_values_prefix}}controlPlane.tls.kdsZoneClient.skipVerify=true` is required because the default global control plane's certificate is self-signed.
     It is recommended to use a certificate signed by a trusted CA in production. See [Secure access across services](/docs/{{ page.version }}/production/secure-deployment/certificates/) page for more information.
     {% endif_version %}
 
@@ -233,11 +233,11 @@ You need the following values to pass to each zone control plane setup:
     helm install {{ site.mesh_helm_install_name }} \
     --create-namespace \
     --namespace {{site.mesh_namespace}} \
-    --set {{set_flag_values_prefix}}controlPlane.mode=zone \
-    --set {{set_flag_values_prefix}}controlPlane.zone=<zone-name> \
-    --set {{set_flag_values_prefix}}ingress.enabled=true \
-    --set {{set_flag_values_prefix}}controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 \
-    --set {{set_flag_values_prefix}}controlPlane.tls.kdsZoneClient.skipVerify=true {{ site.mesh_helm_repo }}
+    --set {{site.set_flag_values_prefix}}controlPlane.mode=zone \
+    --set {{site.set_flag_values_prefix}}controlPlane.zone=<zone-name> \
+    --set {{site.set_flag_values_prefix}}ingress.enabled=true \
+    --set {{site.set_flag_values_prefix}}controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 \
+    --set {{site.set_flag_values_prefix}}controlPlane.tls.kdsZoneClient.skipVerify=true {{ site.mesh_helm_repo }}
     ```
     {% endif_version %}
     {% if_version lte:2.2.x %}
@@ -245,19 +245,19 @@ You need the following values to pass to each zone control plane setup:
     helm install {{ site.mesh_helm_install_name }} \
     --create-namespace \
     --namespace {{site.mesh_namespace}} \
-    --set {{set_flag_values_prefix}}controlPlane.mode=zone \
-    --set {{set_flag_values_prefix}}controlPlane.zone=<zone-name> \
-    --set {{set_flag_values_prefix}}ingress.enabled=true \
-    --set {{set_flag_values_prefix}}controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.mesh_helm_repo }}
+    --set {{site.set_flag_values_prefix}}controlPlane.mode=zone \
+    --set {{site.set_flag_values_prefix}}controlPlane.zone=<zone-name> \
+    --set {{site.set_flag_values_prefix}}ingress.enabled=true \
+    --set {{site.set_flag_values_prefix}}controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.mesh_helm_repo }}
     ```
     {% endif_version %}
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.
 
-    Add `--set {{set_flag_values_prefix}}egress.enabled=true` to list of arguments if you want to deploy optional [Zone Egress](/docs/{{ page.version }}/production/cp-deployment/zoneegress/).
+    Add `--set {{site.set_flag_values_prefix}}egress.enabled=true` to list of arguments if you want to deploy optional [Zone Egress](/docs/{{ page.version }}/production/cp-deployment/zoneegress/).
 
     {% if_version gte:2.3.x %}
-    `--set {{set_flag_values_prefix}}controlPlane.tls.kdsZoneClient.skipVerify=true` is required because the default global control plane's certificate is self-signed.
+    `--set {{site.set_flag_values_prefix}}controlPlane.tls.kdsZoneClient.skipVerify=true` is required because the default global control plane's certificate is self-signed.
     It is recommended to use a certificate signed by a trusted CA in production. See [Secure access across services](/docs/{{ page.version }}/production/secure-deployment/certificates/) page for more information.
     {% endif_version %}
 

--- a/app/_src/production/cp-deployment/zone-ingress.md
+++ b/app/_src/production/cp-deployment/zone-ingress.md
@@ -34,7 +34,7 @@ Zone Ingress without `advertisedAddress` and `advertisedPort` is not taken into 
 
 {% tabs usage useUrlFragment=false %}
 {% tab usage Kubernetes %}
-To install `ZoneIngress` in Kubernetes when doing `kumactl install control-plane` use the `--ingress-enabled`. If using helm add `{{set_flag_values_prefix}}ingress.enabled: true` to your `values.yaml`.
+To install `ZoneIngress` in Kubernetes when doing `kumactl install control-plane` use the `--ingress-enabled`. If using helm add `{{site.set_flag_values_prefix}}ingress.enabled: true` to your `values.yaml`.
 
 {{site.mesh_product_name}} will set `advertisedAddress` and `advertisedPort` automatically by checking the Service associated with this Zone Ingress.
 

--- a/app/_src/production/cp-deployment/zoneegress.md
+++ b/app/_src/production/cp-deployment/zoneegress.md
@@ -43,7 +43,7 @@ The `ZoneEgress` entity includes a few sections:
 
 {% tabs usage useUrlFragment=false %}
 {% tab usage Kubernetes %}
-To install `ZoneEgress` in Kubernetes when doing `kumactl install control-plane` use the `--egress-enabled`. If using helm add `{{set_flag_values_prefix}}egress.enabled: true` to your `values.yaml`.
+To install `ZoneEgress` in Kubernetes when doing `kumactl install control-plane` use the `--egress-enabled`. If using helm add `{{site.set_flag_values_prefix}}egress.enabled: true` to your `values.yaml`.
 
 {% endtab %}
 {% tab usage Universal %}

--- a/app/_src/production/dp-config/cni.md
+++ b/app/_src/production/dp-config/cni.md
@@ -38,11 +38,11 @@ Below are the details of how to set up {{site.mesh_product_name}} CNI in differe
 
 ```shell
 kumactl install control-plane \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.chained=true" \
-  --set "{{set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{set_flag_values_prefix}}cni.confName=10-calico.conflist"
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
+  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
+  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
+  --set "{{site.set_flag_values_prefix}}cni.confName=10-calico.conflist"
 ```
 
 {% endtab %}
@@ -50,12 +50,12 @@ kumactl install control-plane \
 
 ```shell
 helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.chained=true" \
-  --set "{{set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{set_flag_values_prefix}}cni.confName=10-calico.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
+  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
+  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
+  --set "{{site.set_flag_values_prefix}}cni.confName=10-calico.conflist" \
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -68,11 +68,11 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
 
 ```shell
 kumactl install control-plane \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.chained=true" \
-  --set "{{set_flag_values_prefix}}cni.netDir=/var/lib/rancher/k3s/agent/etc/cni/net.d" \
-  --set "{{set_flag_values_prefix}}cni.binDir=/bin" \
-  --set "{{set_flag_values_prefix}}cni.confName=10-flannel.conflist"
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
+  --set "{{site.set_flag_values_prefix}}cni.netDir=/var/lib/rancher/k3s/agent/etc/cni/net.d" \
+  --set "{{site.set_flag_values_prefix}}cni.binDir=/bin" \
+  --set "{{site.set_flag_values_prefix}}cni.confName=10-flannel.conflist"
 ```
 
 {% endtab %}
@@ -80,12 +80,12 @@ kumactl install control-plane \
 
 ```shell
 helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.chained=true" \
-  --set "{{set_flag_values_prefix}}cni.netDir=/var/lib/rancher/k3s/agent/etc/cni/net.d" \
-  --set "{{set_flag_values_prefix}}cni.binDir=/bin" \
-  --set "{{set_flag_values_prefix}}cni.confName=10-flannel.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
+  --set "{{site.set_flag_values_prefix}}cni.netDir=/var/lib/rancher/k3s/agent/etc/cni/net.d" \
+  --set "{{site.set_flag_values_prefix}}cni.binDir=/bin" \
+  --set "{{site.set_flag_values_prefix}}cni.confName=10-flannel.conflist" \
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -98,11 +98,11 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
 
 ```shell
 kumactl install control-plane \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.chained=true" \
-  --set "{{set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{set_flag_values_prefix}}cni.confName=10-kindnet.conflist"
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
+  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
+  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
+  --set "{{site.set_flag_values_prefix}}cni.confName=10-kindnet.conflist"
 ```
 
 {% endtab %}
@@ -110,12 +110,12 @@ kumactl install control-plane \
 
 ```shell
 helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.chained=true" \
-  --set "{{set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{set_flag_values_prefix}}cni.confName=10-kindnet.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
+  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
+  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
+  --set "{{site.set_flag_values_prefix}}cni.confName=10-kindnet.conflist" \
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -128,11 +128,11 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
 
 ```shell
 kumactl install control-plane \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.chained=true" \
-  --set "{{set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{set_flag_values_prefix}}cni.confName=10-azure.conflist"
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
+  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
+  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
+  --set "{{site.set_flag_values_prefix}}cni.confName=10-azure.conflist"
 ```
 
 {% endtab %}
@@ -140,12 +140,12 @@ kumactl install control-plane \
 
 ```shell
 helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.chained=true" \
-  --set "{{set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{set_flag_values_prefix}}cni.confName=10-azure.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
+  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
+  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
+  --set "{{site.set_flag_values_prefix}}cni.confName=10-azure.conflist" \
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -158,11 +158,11 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
 
 ```shell
 kumactl install control-plane \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.chained=true" \
-  --set "{{set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{set_flag_values_prefix}}cni.confName=15-azure-swift-overlay.conflist"
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
+  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
+  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
+  --set "{{site.set_flag_values_prefix}}cni.confName=15-azure-swift-overlay.conflist"
 ```
 
 {% endtab %}
@@ -170,12 +170,12 @@ kumactl install control-plane \
 
 ```shell
 helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.chained=true" \
-  --set "{{set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{set_flag_values_prefix}}cni.confName=15-azure-swift-overlay.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
+  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
+  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
+  --set "{{site.set_flag_values_prefix}}cni.confName=15-azure-swift-overlay.conflist" \
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -188,12 +188,12 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
 
 ```shell
 kumactl install control-plane \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.chained=true" \
-  --set "{{set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{set_flag_values_prefix}}cni.confName=10-aws.conflist" \
-  --set "{{set_flag_values_prefix}}runtime.kubernetes.injector.sidecarContainer.redirectPortInboundV6=0" # EKS does not have ipv6 enabled by default
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
+  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
+  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
+  --set "{{site.set_flag_values_prefix}}cni.confName=10-aws.conflist" \
+  --set "{{site.set_flag_values_prefix}}runtime.kubernetes.injector.sidecarContainer.redirectPortInboundV6=0" # EKS does not have ipv6 enabled by default
 ```
 
 {% endtab %}
@@ -201,12 +201,12 @@ kumactl install control-plane \
 
 ```shell
 helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.chained=true" \
-  --set "{{set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{set_flag_values_prefix}}cni.confName=10-aws.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
+  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
+  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
+  --set "{{site.set_flag_values_prefix}}cni.confName=10-aws.conflist" \
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -222,11 +222,11 @@ You need to [enable network-policy](https://cloud.google.com/kubernetes-engine/d
 
 ```shell
 kumactl install control-plane \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.chained=true" \
-  --set "{{set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{set_flag_values_prefix}}cni.binDir=/home/kubernetes/bin" \
-  --set "{{set_flag_values_prefix}}cni.confName=10-calico.conflist"
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
+  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
+  --set "{{site.set_flag_values_prefix}}cni.binDir=/home/kubernetes/bin" \
+  --set "{{site.set_flag_values_prefix}}cni.confName=10-calico.conflist"
 ```
 
 {% endtab %}
@@ -234,12 +234,12 @@ kumactl install control-plane \
 
 ```shell
 helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.chained=true" \
-  --set "{{set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{set_flag_values_prefix}}cni.binDir=/home/kubernetes/bin" \
-  --set "{{set_flag_values_prefix}}cni.confName=10-calico.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
+  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
+  --set "{{site.set_flag_values_prefix}}cni.binDir=/home/kubernetes/bin" \
+  --set "{{site.set_flag_values_prefix}}cni.confName=10-calico.conflist" \
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -262,8 +262,8 @@ oc adm policy add-scc-to-user privileged -z kuma-cni -n kube-system
 
 ```shell
 kumactl install control-plane \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.containerSecurityContext.privileged=true"
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.containerSecurityContext.privileged=true"
 ```
 
 {% endtab %}
@@ -271,9 +271,9 @@ kumactl install control-plane \
 
 ```shell
 helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{set_flag_values_prefix}}cni.containerSecurityContext.privileged=true" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+  --set "{{site.set_flag_values_prefix}}cni.containerSecurityContext.privileged=true" \
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -287,7 +287,7 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
 
 ```shell
 kumactl install control-plane \
-  --set "{{set_flag_values_prefix}}cni.enabled=true"
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true"
 ```
 
 {% endtab %}
@@ -295,8 +295,8 @@ kumactl install control-plane \
 
 ```shell
 helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{set_flag_values_prefix}}cni.enabled=true" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -317,8 +317,8 @@ To install v2 CNI append the following options to the command from [installation
 
 ```
 --set ... \
---set "{{set_flag_values_prefix}}cni.enabled=true" \
---set "{{set_flag_values_prefix}}experimental.cni=true"
+--set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+--set "{{site.set_flag_values_prefix}}experimental.cni=true"
 ```
 
 Currently, the v2 CNI is behind an `experimental` flag, but it's intended to be the default CNI in future releases.
@@ -350,8 +350,8 @@ and have `cgroup2` available
 
 ```
 --set ... \
---set "{{set_flag_values_prefix}}cni.enabled=true" \
---set "{{set_flag_values_prefix}}experimental.ebpf.enabled=true"
+--set "{{site.set_flag_values_prefix}}cni.enabled=true" \
+--set "{{site.set_flag_values_prefix}}experimental.ebpf.enabled=true"
 ```
 
 ### Merbridge CNI with eBPF Logs

--- a/app/_src/production/dp-config/ipv6.md
+++ b/app/_src/production/dp-config/ipv6.md
@@ -38,7 +38,7 @@ In some cases you might not want to use IPv6 at all.
 {% tabs disabling useUrlFragment=false %}
 {% tab disabling Kubernetes %}
 To turn it off for all workloads set either:
-- `{{set_flag_values_prefix}}runtime.kubernetes.injector.sidecarContainer.redirectPortInboundV6` to 0
+- `{{site.set_flag_values_prefix}}runtime.kubernetes.injector.sidecarContainer.redirectPortInboundV6` to 0
 - the environment variable: `KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_REDIRECT_PORT_INBOUND_V6=0`
 
 To turn it off for a specific pod add the annotation `kuma.io/transparent-proxying-inbound-v6-port: "0"`.

--- a/app/_src/production/secure-deployment/api-server-auth.md
+++ b/app/_src/production/secure-deployment/api-server-auth.md
@@ -441,7 +441,7 @@ All users that provide client certificate are authenticated as a user with the n
    ```
    You can provide as many client certificates as you want. Remember to only provide certificates without keys.
 
-   Set `{{set_flag_values_prefix}}controlPlane.tls.apiServer.clientCertsSecretName` to `api-server-client-certs` via HELM
+   Set `{{site.set_flag_values_prefix}}controlPlane.tls.apiServer.clientCertsSecretName` to `api-server-client-certs` via HELM
    {% endtab %}
    {% tab usage Universal %}
    Put all the certificates in one directory

--- a/app/_src/production/secure-deployment/certificates.md
+++ b/app/_src/production/secure-deployment/certificates.md
@@ -89,9 +89,9 @@ kubectl create secret generic general-tls-certs -n <namespace> \
 
 Point to this secret when installing {{site.mesh_product_name}}:
 ```sh
-helm install --create-namespace --namespace <namespace> {{mesh_helm_install_name}} {{mesh_helm_repo}} \
-  --set {{set_flag_values_prefix}}controlPlane.tls.general.secretName=general-tls-certs \
-  --set {{set_flag_values_prefix}}controlPlane.tls.general.caBundle=$(cat /tmp/ca.crt | base64)
+helm install --create-namespace --namespace <namespace> {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}} \
+  --set {{site.set_flag_values_prefix}}controlPlane.tls.general.secretName=general-tls-certs \
+  --set {{site.set_flag_values_prefix}}controlPlane.tls.general.caBundle=$(cat /tmp/ca.crt | base64)
 ```
 
 The data plane proxy Injector in the control plane automatically provides the CA to the {{site.mesh_product_name}} DP sidecar 
@@ -221,8 +221,8 @@ kubectl create secret tls api-server-tls -n <namespace> \
 
 Point to this secret when installing {{site.mesh_product_name}}:
 ```sh
-helm install --create-namespace --namespace <namespace> {{mesh_helm_install_name}} {{mesh_helm_repo}} \
-  --set {{set_flag_values_prefix}}controlPlane.tls.apiServer.secretName=api-server-tls
+helm install --create-namespace --namespace <namespace> {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}} \
+  --set {{site.set_flag_values_prefix}}controlPlane.tls.apiServer.secretName=api-server-tls
 ```
 
 {% endtab %}
@@ -310,8 +310,8 @@ kubectl create secret tls kds-server-tls -n <namespace> \
 
 Point to this secret when installing {{site.mesh_product_name}}:
 ```sh
-helm install --create-namespace --namespace <namespace> {{mesh_helm_install_name}} {{mesh_helm_repo}} \
-  --set {{set_flag_values_prefix}}controlPlane.tls.kdsGlobalServer.secretName=kds-server-tls
+helm install --create-namespace --namespace <namespace> {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}} \
+  --set {{site.set_flag_values_prefix}}controlPlane.tls.kdsGlobalServer.secretName=kds-server-tls
 ```
 
 {% endtab %}
@@ -352,8 +352,8 @@ kubectl create secret generic kds-ca-certs -n <namespace> \
 
 Point to this secret when installing {{site.mesh_product_name}}:
 ```sh
-helm install --create-namespace --namespace <namespace> {{mesh_helm_install_name}} {{mesh_helm_repo}} \
-  --set {{set_flag_values_prefix}}controlPlane.tls.kdsZoneClient.secretName=kds-ca-certs
+helm install --create-namespace --namespace <namespace> {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}} \
+  --set {{site.set_flag_values_prefix}}controlPlane.tls.kdsZoneClient.secretName=kds-ca-certs
 ```
 
 {% endtab %}

--- a/app/docs/1.2.x/deployments/multi-zone.md
+++ b/app/docs/1.2.x/deployments/multi-zone.md
@@ -75,7 +75,7 @@ In this example it is `35.226.196.103:5685`. This will be used as `<global-kds-a
 Install the `global` control plane by setting the `controlPlane.mode` value to `global` when installing the chart. This can be done on the command line, or in a provided file:
 
 ```sh
-helm install --version 0.6.3 kuma --namespace {{site.mesh_namespace}} --set controlPlane.mode=global {{mesh_helm_repo}}
+helm install --version 0.6.3 kuma --namespace {{site.mesh_namespace}} --set controlPlane.mode=global {{site.mesh_helm_repo}}
 ```
 {% endtab %}
 {% tab global Universal %}
@@ -114,7 +114,7 @@ To install the Zone Control plane we need to provide the following parameters:
  * `controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>`:
 
 ```bash
-helm install --version 0.6.3 kuma --namespace {{site.mesh_namespace}} --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> {{mesh_helm_repo}}
+helm install --version 0.6.3 kuma --namespace {{site.mesh_namespace}} --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> {{site.mesh_helm_repo}}
 ```
 
 {% tip %}

--- a/app/docs/1.2.x/installation/helm.md
+++ b/app/docs/1.2.x/installation/helm.md
@@ -29,7 +29,7 @@ Once the repo is added, all following updates can be fetched with `helm repo upd
 At this point we can install and run Kuma using the following commands. We could use any Kubernetes namespace to install Kuma, by default we suggest using `{{site.mesh_namespace}}`:
 
 ```sh
-helm install --verison 0.6.3 --create-namespace --namespace {{site.mesh_namespace}} {{mesh_helm_install_name}} {{mesh_helm_repo}}
+helm install --verison 0.6.3 --create-namespace --namespace {{site.mesh_namespace}} {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/{{ page.version }}/documentation/deployments/) like "multi-zone".

--- a/app/docs/1.2.x/networking/cni.md
+++ b/app/docs/1.2.x/networking/cni.md
@@ -35,7 +35,7 @@ When using [Helm](/docs/{{ page.version }}/installation/helm), we should use the
 ```shell
 helm install --version 0.6.3 --namespace {{site.mesh_namespace}} \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}

--- a/app/docs/1.2.x/networking/dns.md
+++ b/app/docs/1.2.x/networking/dns.md
@@ -78,7 +78,7 @@ Set the environment variable:
 ```shell
 helm install --version 0.6.3 --namespace {{site.mesh_namespace}} \
   --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=false \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}

--- a/app/docs/1.3.x/deployments/multi-zone.md
+++ b/app/docs/1.3.x/deployments/multi-zone.md
@@ -75,7 +75,7 @@ In this example it is `35.226.196.103:5685`. This will be used as `<global-kds-a
 Install the `global` control plane by setting the `controlPlane.mode` value to `global` when installing the chart. This can be done on the command line, or in a provided file:
 
 ```sh
-helm install --version 0.7.1 kuma --namespace {{site.mesh_namespace}} --set controlPlane.mode=global {{mesh_helm_repo}}
+helm install --version 0.7.1 kuma --namespace {{site.mesh_namespace}} --set controlPlane.mode=global {{site.mesh_helm_repo}}
 ```
 {% endtab %}
 {% tab global-control-plane Universal %}
@@ -114,7 +114,7 @@ To install the Zone Control plane we need to provide the following parameters:
  * `controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>`:
 
 ```bash
-helm install --version 0.7.1 kuma --namespace {{site.mesh_namespace}} --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> {{mesh_helm_repo}}
+helm install --version 0.7.1 kuma --namespace {{site.mesh_namespace}} --set controlPlane.mode=zone,controlPlane.zone=<zone-name>,ingress.enabled=true,controlPlane.kdsGlobalAddress=grpcs://<global-kds-address> {{site.mesh_helm_repo}}
 ```
 
 {% tip %}

--- a/app/docs/1.3.x/documentation/configuration.md
+++ b/app/docs/1.3.x/documentation/configuration.md
@@ -29,7 +29,7 @@ If you install the control plane with HELM, you can override the configuration w
 helm install --version 0.7.1 \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s \
-  {{mesh_helm_install_name}} {{mesh_helm_repo}}
+  {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 Or you can edit the `Values.yaml` file:
@@ -39,7 +39,7 @@ controlPlane:
   envVars:
     KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL: 5s
     KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL: 5s
-helm install --version 0.7.1 -f Values.yaml {{mesh_helm_install_name}} {{mesh_helm_repo}}
+helm install --version 0.7.1 -f Values.yaml {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 {% endtab %}
 {% tab control-plane Universal %}

--- a/app/docs/1.3.x/installation/helm.md
+++ b/app/docs/1.3.x/installation/helm.md
@@ -29,7 +29,7 @@ Once the repo is added, all following updates can be fetched with `helm repo upd
 At this point we can install and run Kuma using the following commands. We could use any Kubernetes namespace to install Kuma, by default we suggest using `{{site.mesh_namespace}}`:
 
 ```sh
-helm install --version 0.7.1 --create-namespace --namespace {{site.mesh_namespace}} {{mesh_helm_install_name}} {{mesh_helm_repo}}
+helm install --version 0.7.1 --create-namespace --namespace {{site.mesh_namespace}} {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/{{ page.version }}/documentation/deployments) like "multi-zone".

--- a/app/docs/1.3.x/networking/cni.md
+++ b/app/docs/1.3.x/networking/cni.md
@@ -35,7 +35,7 @@ When using [Helm](/docs/{{ page.version }}/installation/helm), we should use the
 ```shell
 helm install --version 0.7.1 --namespace {{site.mesh_namespace}} \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}

--- a/app/docs/1.3.x/networking/dns.md
+++ b/app/docs/1.3.x/networking/dns.md
@@ -96,7 +96,7 @@ Set the environment variable:
 ```shell
 helm install --version 0.7.1 --namespace {{site.mesh_namespace}} \
   --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=false \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}

--- a/app/docs/1.4.x/documentation/configuration.md
+++ b/app/docs/1.4.x/documentation/configuration.md
@@ -29,7 +29,7 @@ If you install the control plane with HELM, you can override the configuration w
 helm install --version 0.7.1 \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s \
-  {{mesh_helm_install_name}} {{mesh_helm_repo}}
+  {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 Or you can create a `values.yaml` file with:
@@ -42,7 +42,7 @@ controlPlane:
 and then specify it in the helm install command:
 
 ```sh
-helm install --version 0.7.1 -f values.yaml {{mesh_helm_install_name}} {{mesh_helm_repo}}
+helm install --version 0.7.1 -f values.yaml {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 {% endtab %}
 {% tab control-plane Universal %}

--- a/app/docs/1.4.x/installation/helm.md
+++ b/app/docs/1.4.x/installation/helm.md
@@ -29,7 +29,7 @@ Once the repo is added, all following updates can be fetched with `helm repo upd
 At this point we can install and run Kuma using the following commands. We could use any Kubernetes namespace to install Kuma, by default we suggest using `{{site.mesh_namespace}}`:
 
 ```sh
-helm install --version 0.8.1 --create-namespace --namespace {{site.mesh_namespace}} {{mesh_helm_install_name}} {{mesh_helm_repo}}
+helm install --version 0.8.1 --create-namespace --namespace {{site.mesh_namespace}} {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/{{ page.version }}/documentation/deployments/) like "multi-zone".

--- a/app/docs/1.4.x/networking/cni.md
+++ b/app/docs/1.4.x/networking/cni.md
@@ -35,7 +35,7 @@ When using [Helm](/docs/{{ page.version }}/installation/helm), we should use the
 ```shell
 helm install --namespace {{site.mesh_namespace}} \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}

--- a/app/docs/1.4.x/networking/dns.md
+++ b/app/docs/1.4.x/networking/dns.md
@@ -96,7 +96,7 @@ Set the environment variable:
 ```shell
 helm install --namespace {{site.mesh_namespace}} \
   --set controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_ENABLED=false \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}

--- a/app/docs/1.5.x/documentation/configuration.md
+++ b/app/docs/1.5.x/documentation/configuration.md
@@ -29,7 +29,7 @@ If you install the control plane with HELM, you can override the configuration w
 helm install --version 0.7.1 \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s \
-  {{mesh_helm_install_name}} {{mesh_helm_repo}}
+  {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 Or you can create a `values.yaml` file with:
@@ -42,7 +42,7 @@ controlPlane:
 and then specify it in the helm install command:
 
 ```sh
-helm install --version 0.7.1 -f values.yaml {{mesh_helm_install_name}} {{mesh_helm_repo}}
+helm install --version 0.7.1 -f values.yaml {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 {% endtab %}
 {% tab control-plane Universal %}

--- a/app/docs/1.5.x/installation/helm.md
+++ b/app/docs/1.5.x/installation/helm.md
@@ -29,7 +29,7 @@ Once the repo is added, all following updates can be fetched with `helm repo upd
 At this point we can install and run Kuma using the following commands. We could use any Kubernetes namespace to install Kuma, by default we suggest using `{{site.mesh_namespace}}`:
 
 ```sh
-helm install --create-namespace --namespace {{site.mesh_namespace}} {{mesh_helm_install_name}} {{mesh_helm_repo}}
+helm install --create-namespace --namespace {{site.mesh_namespace}} {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/{{ page.version }}/documentation/deployments/) like "multi-zone".

--- a/app/docs/1.5.x/networking/cni.md
+++ b/app/docs/1.5.x/networking/cni.md
@@ -35,7 +35,7 @@ When using [Helm](/docs/{{ page.version }}/installation/helm), we should use the
 ```shell
 helm install --namespace {{site.mesh_namespace}} \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}

--- a/app/docs/1.6.x/documentation/configuration.md
+++ b/app/docs/1.6.x/documentation/configuration.md
@@ -29,7 +29,7 @@ When using `helm`, you can override the configuration with the `envVars` field. 
 helm install --version 0.7.1 \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s \
-  {{mesh_helm_install_name}} {{mesh_helm_repo}}
+  {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 Or you can create a `values.yaml` file with:
@@ -42,7 +42,7 @@ controlPlane:
 and then specify it in the helm install command:
 
 ```sh
-helm install --version 0.7.1 -f values.yaml {{mesh_helm_install_name}} {{mesh_helm_repo}}
+helm install --version 0.7.1 -f values.yaml {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 {% endtab %}
 {% tab control-plane Universal %}

--- a/app/docs/1.6.x/installation/helm.md
+++ b/app/docs/1.6.x/installation/helm.md
@@ -31,7 +31,7 @@ Once the repo is added, all following updates can be fetched with `helm repo upd
 At this point we can install and run Kuma using the following commands. We could use any Kubernetes namespace to install Kuma, by default we suggest using `{{site.mesh_namespace}}`:
 
 ```sh
-helm install --create-namespace --namespace {{site.mesh_namespace}} {{mesh_helm_install_name}} {{mesh_helm_repo}}
+helm install --create-namespace --namespace {{site.mesh_namespace}} {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/{{ page.version }}/introduction/deployments) like "multi-zone".

--- a/app/docs/1.6.x/networking/cni.md
+++ b/app/docs/1.6.x/networking/cni.md
@@ -35,7 +35,7 @@ When using [Helm](/docs/{{ page.version }}/installation/helm), we should use the
 ```shell
 helm install --namespace {{site.mesh_namespace}} \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}

--- a/app/docs/1.7.x/documentation/configuration.md
+++ b/app/docs/1.7.x/documentation/configuration.md
@@ -29,7 +29,7 @@ When using `helm`, you can override the configuration with the `envVars` field. 
 helm install --version 0.7.1 \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
   --set controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s \
-  {{mesh_helm_install_name}} {{mesh_helm_repo}}
+  {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 Or you can create a `values.yaml` file with:
@@ -42,7 +42,7 @@ controlPlane:
 and then specify it in the helm install command:
 
 ```sh
-helm install --version 0.7.1 -f values.yaml {{mesh_helm_install_name}} {{mesh_helm_repo}}
+helm install --version 0.7.1 -f values.yaml {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 {% endtab %}
 {% tab control-plane Universal %}

--- a/app/docs/1.7.x/installation/helm.md
+++ b/app/docs/1.7.x/installation/helm.md
@@ -31,7 +31,7 @@ Once the repo is added, all following updates can be fetched with `helm repo upd
 At this point we can install and run Kuma using the following commands. We could use any Kubernetes namespace to install Kuma, by default we suggest using `{{site.mesh_namespace}}`:
 
 ```sh
-helm install --create-namespace --namespace {{site.mesh_namespace}} {{mesh_helm_install_name}} {{mesh_helm_repo}}
+helm install --create-namespace --namespace {{site.mesh_namespace}} {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/{{ page.version }}/introduction/deployments) like "multi-zone".

--- a/app/docs/1.7.x/networking/cni.md
+++ b/app/docs/1.7.x/networking/cni.md
@@ -35,7 +35,7 @@ When using [Helm](/docs/{{ page.version }}/installation/helm), we should use the
 ```shell
 helm install --namespace {{site.mesh_namespace}} \
   --set cni.enabled=true,cni.chained=true,cni.netDir="/etc/cni/net.d",cni.binDir=/opt/cni/bin,cni.confName=10-calico.conflist \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}

--- a/app/docs/1.8.x/documentation/configuration.md
+++ b/app/docs/1.8.x/documentation/configuration.md
@@ -52,7 +52,7 @@ helm install -f values.yaml {{ site.mesh_helm_install_name }} {{ site.mesh_helm_
 If you have a lot of configuration you can just write them all in a YAML file and use:
 
 ```shell
-helm install {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }} --set-file {{set_flag_values_prefix}}controlPlane.config=cp-conf.yaml
+helm install {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }} --set-file {{site.set_flag_values_prefix}}controlPlane.config=cp-conf.yaml
 ```
 The value of the configmap `{{site.mesh_cp_name}}-config` is now the content of `cp-conf.yaml`.
 

--- a/app/docs/1.8.x/installation/helm.md
+++ b/app/docs/1.8.x/installation/helm.md
@@ -31,7 +31,7 @@ Once the repo is added, all following updates can be fetched with `helm repo upd
 At this point we can install and run Kuma using the following commands. We could use any Kubernetes namespace to install Kuma, by default we suggest using `{{site.mesh_namespace}}`:
 
 ```sh
-helm install --create-namespace --namespace {{site.mesh_namespace}} {{mesh_helm_install_name}} {{mesh_helm_repo}}
+helm install --create-namespace --namespace {{site.mesh_namespace}} {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 This example will run Kuma in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/{{ page.version }}/introduction/deployments) like "multi-zone".

--- a/app/docs/1.8.x/networking/cni.md
+++ b/app/docs/1.8.x/networking/cni.md
@@ -52,7 +52,7 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.netDir=/etc/cni/net.d" \
   --set "cni.binDir=/opt/cni/bin" \
   --set "cni.confName=10-calico.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -82,7 +82,7 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.netDir=/var/lib/rancher/k3s/agent/etc/cni/net.d" \
   --set "cni.binDir=/bin" \
   --set "cni.confName=10-flannel.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -112,7 +112,7 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.netDir=/etc/cni/net.d" \
   --set "cni.binDir=/opt/cni/bin" \
   --set "cni.confName=10-kindnet.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -142,7 +142,7 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.netDir=/etc/cni/net.d" \
   --set "cni.binDir=/opt/cni/bin" \
   --set "cni.confName=10-azure.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -172,7 +172,7 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.netDir=/etc/cni/net.d" \
   --set "cni.binDir=/opt/cni/bin" \
   --set "cni.confName=10-aws.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -205,7 +205,7 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.netDir=/etc/cni/net.d" \
   --set "cni.binDir=/home/kubernetes/bin" \
   --set "cni.confName=10-calico.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -239,7 +239,7 @@ kumactl install control-plane \
 helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.enabled=true" \
   --set "cni.containerSecurityContext.privileged=true" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -262,7 +262,7 @@ kumactl install control-plane \
 ```shell
 helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.enabled=true" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}

--- a/app/docs/2.0.x/deployments/multi-zone.md
+++ b/app/docs/2.0.x/deployments/multi-zone.md
@@ -127,7 +127,7 @@ The global control plane on Kubernetes must reside on its own Kubernetes cluster
 1.  Set the `controlPlane.mode` value to `global` in the chart (`values.yaml`), then install. On the command line, run:
 
     ```sh
-    helm install {{ site.mesh_helm_install_name }} --create-namespace --namespace {{site.mesh_namespace}} --set {{set_flag_values_prefix}}controlPlane.mode=global {{ site.mesh_helm_repo }}
+    helm install {{ site.mesh_helm_install_name }} --create-namespace --namespace {{site.mesh_namespace}} --set {{site.set_flag_values_prefix}}controlPlane.mode=global {{ site.mesh_helm_repo }}
     ```
 
     Or you can edit the chart and pass the file to the `helm install {{ site.mesh_helm_install_name }}` command. To get the default values, run:
@@ -209,10 +209,10 @@ You need the following values to pass to each zone control plane setup:
     helm install {{ site.mesh_helm_install_name }} \
     --create-namespace \
     --namespace {{site.mesh_namespace}} \
-    --set {{set_flag_values_prefix}}controlPlane.mode=zone \
-    --set {{set_flag_values_prefix}}controlPlane.zone=<zone-name> \
-    --set {{set_flag_values_prefix}}ingress.enabled=true \
-    --set {{set_flag_values_prefix}}controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.mesh_helm_repo }}
+    --set {{site.set_flag_values_prefix}}controlPlane.mode=zone \
+    --set {{site.set_flag_values_prefix}}controlPlane.zone=<zone-name> \
+    --set {{site.set_flag_values_prefix}}ingress.enabled=true \
+    --set {{site.set_flag_values_prefix}}controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.mesh_helm_repo }}
     ```
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.
@@ -225,11 +225,11 @@ You need the following values to pass to each zone control plane setup:
     helm install {{ site.mesh_helm_install_name }} \
     --create-namespace \
     --namespace {{site.mesh_namespace}} \
-    --set {{set_flag_values_prefix}}controlPlane.mode=zone \
-    --set {{set_flag_values_prefix}}controlPlane.zone=<zone-name> \
-    --set {{set_flag_values_prefix}}ingress.enabled=true \
-    --set {{set_flag_values_prefix}}egress.enabled=true \
-    --set {{set_flag_values_prefix}}controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.mesh_helm_repo }}
+    --set {{site.set_flag_values_prefix}}controlPlane.mode=zone \
+    --set {{site.set_flag_values_prefix}}controlPlane.zone=<zone-name> \
+    --set {{site.set_flag_values_prefix}}ingress.enabled=true \
+    --set {{site.set_flag_values_prefix}}egress.enabled=true \
+    --set {{site.set_flag_values_prefix}}controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 {{ site.mesh_helm_repo }}
     ```
 
     where `controlPlane.zone` is the same value for all zone control planes in the same zone.

--- a/app/docs/2.0.x/documentation/configuration.md
+++ b/app/docs/2.0.x/documentation/configuration.md
@@ -31,8 +31,8 @@ kumactl install control plane \
 When using `helm`, you can override the configuration with the `envVars` field. For example, to configure the refresh interval for configuration with the data plane proxy, specify:
 ```sh
 helm install \
-  --set {{set_flag_values_prefix}}controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
-  --set {{set_flag_values_prefix}}controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s \
+  --set {{site.set_flag_values_prefix}}controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
+  --set {{site.set_flag_values_prefix}}controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s \
   {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }}
 ```
 
@@ -52,7 +52,7 @@ helm install -f values.yaml {{ site.mesh_helm_install_name }} {{ site.mesh_helm_
 If you have a lot of configuration you can just write them all in a YAML file and use:
 
 ```shell
-helm install {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }} --set-file {{set_flag_values_prefix}}controlPlane.config=cp-conf.yaml
+helm install {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }} --set-file {{site.set_flag_values_prefix}}controlPlane.config=cp-conf.yaml
 ```
 The value of the configmap `{{site.mesh_cp_name}}-config` is now the content of `cp-conf.yaml`.
 

--- a/app/docs/2.0.x/installation/helm.md
+++ b/app/docs/2.0.x/installation/helm.md
@@ -31,7 +31,7 @@ Once the repo is added, all following updates can be fetched with `helm repo upd
 At this point we can install and run {{site.mesh_product_name}} using the following commands. We could use any Kubernetes namespace to install {{site.mesh_product_name}}, by default we suggest using `{{site.mesh_namespace}}`:
 
 ```sh
-helm install --create-namespace --namespace {{site.mesh_namespace}} {{mesh_helm_install_name}} {{mesh_helm_repo}}
+helm install --create-namespace --namespace {{site.mesh_namespace}} {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 This example will run {{site.mesh_product_name}} in `standalone` mode for a "flat" deployment, but there are more advanced [deployment modes](/docs/{{ page.version }}/introduction/deployments) like "multi-zone".

--- a/app/docs/2.0.x/networking/cni.md
+++ b/app/docs/2.0.x/networking/cni.md
@@ -52,7 +52,7 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.netDir=/etc/cni/net.d" \
   --set "cni.binDir=/opt/cni/bin" \
   --set "cni.confName=10-calico.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -82,7 +82,7 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.netDir=/var/lib/rancher/k3s/agent/etc/cni/net.d" \
   --set "cni.binDir=/bin" \
   --set "cni.confName=10-flannel.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -112,7 +112,7 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.netDir=/etc/cni/net.d" \
   --set "cni.binDir=/opt/cni/bin" \
   --set "cni.confName=10-kindnet.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -142,7 +142,7 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.netDir=/etc/cni/net.d" \
   --set "cni.binDir=/opt/cni/bin" \
   --set "cni.confName=10-azure.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -172,7 +172,7 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.netDir=/etc/cni/net.d" \
   --set "cni.binDir=/opt/cni/bin" \
   --set "cni.confName=10-aws.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -205,7 +205,7 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.netDir=/etc/cni/net.d" \
   --set "cni.binDir=/home/kubernetes/bin" \
   --set "cni.confName=10-calico.conflist" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -239,7 +239,7 @@ kumactl install control-plane \
 helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.enabled=true" \
   --set "cni.containerSecurityContext.privileged=true" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}
@@ -262,7 +262,7 @@ kumactl install control-plane \
 ```shell
 helm install --create-namespace --namespace {{site.mesh_namespace}} \
   --set "cni.enabled=true" \
-   {{mesh_helm_install_name}} {{mesh_helm_repo}}
+   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
 ```
 
 {% endtab %}

--- a/app/docs/2.0.x/security/certificates.md
+++ b/app/docs/2.0.x/security/certificates.md
@@ -88,9 +88,9 @@ kubectl create secret generic general-tls-certs -n <namespace> \
 
 Point to this secret when installing {{site.mesh_product_name}}:
 ```sh
-helm install --create-namespace --namespace <namespace> {{mesh_helm_install_name}} {{mesh_helm_repo}} \
-  --set {{set_flag_values_prefix}}controlPlane.tls.general.secretName=general-tls-certs \
-  --set {{set_flag_values_prefix}}controlPlane.tls.general.caBundle=$(cat /tmp/ca.crt | base64)
+helm install --create-namespace --namespace <namespace> {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}} \
+  --set {{site.set_flag_values_prefix}}controlPlane.tls.general.secretName=general-tls-certs \
+  --set {{site.set_flag_values_prefix}}controlPlane.tls.general.caBundle=$(cat /tmp/ca.crt | base64)
 ```
 
 The data plane proxy Injector in the control plane automatically provides the CA to the {{site.mesh_product_name}} DP sidecar 
@@ -220,8 +220,8 @@ kubectl create secret tls api-server-tls -n <namespace> \
 
 Point to this secret when installing {{site.mesh_product_name}}:
 ```sh
-helm install --create-namespace --namespace <namespace> {{mesh_helm_install_name}} {{mesh_helm_repo}} \
-  --set {{set_flag_values_prefix}}controlPlane.tls.apiServer.secretName=api-server-tls
+helm install --create-namespace --namespace <namespace> {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}} \
+  --set {{site.set_flag_values_prefix}}controlPlane.tls.apiServer.secretName=api-server-tls
 ```
 
 {% endtab %}
@@ -309,8 +309,8 @@ kubectl create secret tls kds-server-tls -n <namespace> \
 
 Point to this secret when installing {{site.mesh_product_name}}:
 ```sh
-helm install --create-namespace --namespace <namespace> {{mesh_helm_install_name}} {{mesh_helm_repo}} \
-  --set {{set_flag_values_prefix}}controlPlane.tls.kdsGlobalServer.secretName=kds-server-tls
+helm install --create-namespace --namespace <namespace> {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}} \
+  --set {{site.set_flag_values_prefix}}controlPlane.tls.kdsGlobalServer.secretName=kds-server-tls
 ```
 
 {% endtab %}
@@ -351,8 +351,8 @@ kubectl create secret generic kds-ca-certs -n <namespace> \
 
 Point to this secret when installing {{site.mesh_product_name}}:
 ```sh
-helm install --create-namespace --namespace <namespace> {{mesh_helm_install_name}} {{mesh_helm_repo}} \
-  --set {{set_flag_values_prefix}}controlPlane.tls.kdsZoneClient.secretName=kds-ca-certs
+helm install --create-namespace --namespace <namespace> {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}} \
+  --set {{site.set_flag_values_prefix}}controlPlane.tls.kdsZoneClient.secretName=kds-ca-certs
 ```
 
 {% endtab %}

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -81,7 +81,7 @@ mesh_cp_name: kuma-control-plane
 # It's useful for projects based on Kuma, which expects Kuma options
 # to be prefixed with for example "kuma."
 # kumactl install control-plane \
-#   --set "{{set_flag_values_prefix}}experimental.ebpf.enabled=true"
+#   --set "{{site.set_flag_values_prefix}}experimental.ebpf.enabled=true"
 set_flag_values_prefix: ""
 
 # Helm commands


### PR DESCRIPTION
There were places which were using variables which had to be prefixed with `site.` to work. This PR's changes include:
- `{{set_flag_values_prefix}}` -> `{{site.set_flag_values_prefix}}`
- `{{mesh_product_name}}` -> `{{site.mesh_product_name}}`
- `{{mesh_namespace}}` -> `{{site.mesh_namespace}}`
- `{{mesh_cp_name}}` -> `{{site.mesh_cp_name}}`
- `{{mesh_helm_repo}}` -> `{{site.mesh_helm_repo}}`
- `{{mesh_helm_install_name}}` -> `{{site.mesh_helm_install_name}}`
- `{{mesh_install_archive_name}}` -> `{{site.mesh_install_archive_name}}`

Closes: https://github.com/kumahq/kuma-website/issues/1389

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
