### PR TITLE
fix: add redirects from policynames to policy docs

### DIFF
--- a/app/_common_redirects
+++ b/app/_common_redirects
@@ -1,17 +1,26 @@
 # Policy redirects
 /docs/:version/policies/circuit-breakers/ /docs/:version/policies/circuit-breaker/ 301
+/docs/:version/policies/circuitbreaker/ /docs/:version/policies/circuit-breaker/ 301
 /docs/:version/policies/fault-injections/ /docs/:version/policies/fault-injection/ 301
+/docs/:version/policies/faultinjection/ /docs/:version/policies/fault-injection/ 301
 /docs/:version/policies/health-checks/ /docs/:version/policies/health-check/ 301
+/docs/:version/policies/healthcheck/ /docs/:version/policies/health-check/ 301
 /docs/:version/policies/meshgateways/ /docs/:version/policies/mesh-gateway/ 301
+/docs/:version/policies/meshgateway/ /docs/:version/policies/mesh-gateway/ 301
 /docs/:version/policies/meshgatewayroutes/ /docs/:version/policies/mesh-gateway-route/ 301
+/docs/:version/policies/meshgatewayroute/ /docs/:version/policies/mesh-gateway-route/ 301
 /docs/:version/policies/proxytemplates/ /docs/:version/policies/proxy-template/ 301
+/docs/:version/policies/proxytemplate/ /docs/:version/policies/proxy-template/ 301
 /docs/:version/policies/rate-limits/ /docs/:version/policies/rate-limit/ 301
+/docs/:version/policies/ratelimit/ /docs/:version/policies/rate-limit/ 301
 /docs/:version/policies/retries/ /docs/:version/policies/retry/ 301
 /docs/:version/policies/timeouts/ /docs/:version/policies/timeout/ 301
 /docs/:version/policies/traffic-logs/ /docs/:version/policies/traffic-log/ 301
+/docs/:version/policies/trafficlog/ /docs/:version/policies/traffic-log/ 301
 /docs/:version/policies/traffic-routes/ /docs/:version/policies/traffic-route/ 301
-/docs/:version/policies/traffic-traces/ /docs/:version/policies/traffic-trace/ 301
-/docs/:version/policies/virtual-outbounds/ /docs/:version/policies/virtual-outbound/ 301
+/docs/:version/policies/trafficroute/ /docs/:version/policies/traffic-route/ 301
+/docs/:version/policies/traffictrace/ /docs/:version/policies/traffic-trace/ 301
+/docs/:version/policies/virtualoutbound/ /docs/:version/policies/virtual-outbound/ 301
 
 # Docs
 /docs/:version/documentation/gateway /docs/:version/explore/gateway 301


### PR DESCRIPTION
Applies only to legacy policies as the new ones just work

Part of kumahq/kuma-gui#847