### PR TITLE
fix: always use reference/kuma-cp and fix systemd conf

### DIFF
--- a/app/_common_redirects
+++ b/app/_common_redirects
@@ -33,3 +33,14 @@
 /docs/:version/installation/ /docs/:version/installation/kubernetes 301
 /docs/:version/api/ /docs/:version/documentation/http-api 301
 /docs/:version/documentation/deployments/ /docs/:version/introduction/deployments 301
+
+# kuma IA redirects (pages that do exist take precedence on these so it's safe to use `:version` for pages moved in newer versions).
+/docs/:version/deployments/multi-zone /docs/:version/production/cp-deployment/multi-zone/
+/docs/:version/deployments/stand-alone /docs/:version/production/cp-deployment/stand-alone/
+/docs/:version/introduction/what-is-a-service-mesh/ /docs/:version/introduction/about-service-meshes
+/docs/:version/introduction/what-is-kuma/ /docs/:version/introduction/overview-of-kuma
+/docs/:version/introduction/deployments /docs/:version/production/deployment/
+/docs/:version/policies/mesh /docs/:version/production/mesh/
+/docs/:version/policies/proxy-template/ /docs/:version/reference/proxy-template/
+/docs/:version/explore/dpp/* /docs/:version/production/dp-config/dpp/
+/docs/:version/installation/* /docs/:version/production/install-kumactl/

--- a/app/_data/docs_nav_kuma_2.2.x.yml
+++ b/app/_data/docs_nav_kuma_2.2.x.yml
@@ -57,7 +57,7 @@ items:
           - text: Configure zone proxy authentication
             url: /production/cp-deployment/zoneproxy-auth/
           - text: Control plane configuration reference
-            url: /generated/kuma-cp/
+            url: /reference/kuma-cp/
             generate: false
           - text: Systemd
             url: /production/cp-deployment/systemd/

--- a/app/_data/docs_nav_kuma_2.3.x.yml
+++ b/app/_data/docs_nav_kuma_2.3.x.yml
@@ -55,7 +55,7 @@ items:
           - text: Configure zone proxy authentication
             url: /production/cp-deployment/zoneproxy-auth/
           - text: Control plane configuration reference
-            url: /generated/kuma-cp/
+            url: /reference/kuma-cp/
             generate: false
           - text: Systemd
             url: /production/cp-deployment/systemd/

--- a/app/_data/docs_nav_kuma_dev.yml
+++ b/app/_data/docs_nav_kuma_dev.yml
@@ -55,7 +55,7 @@ items:
           - text: Configure zone proxy authentication
             url: /production/cp-deployment/zoneproxy-auth/
           - text: Control plane configuration reference
-            url: /generated/kuma-cp/
+            url: /reference/kuma-cp
             generate: false
           - text: Systemd
             url: /production/cp-deployment/systemd/

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -93,7 +93,6 @@
     </div>
 
     <script async defer src="https://buttons.github.io/buttons.js"></script>
-    <script defer src="https://brianwendt.github.io/json-schema-md-doc/lib/JSONSchemaMarkdown.js"></script>
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.9.0/showdown.min.js"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
   </body>

--- a/app/_redirects
+++ b/app/_redirects
@@ -41,15 +41,3 @@ https://traffic.kuma.io/exclude-outbound-ports /docs/LATEST_RELEASE/reference/ku
 
 /contribute/introduction/*  /docs/LATEST_RELEASE/community/contribute-to-kuma/:splat 302
 /reference/license/   /docs/LATEST_RELEASE/community/license/ 302
-
-# kuma IA redirects (pages that do exist take precedence on these so it's safe to use `:version` for pages moved in newer versions).
-/docs/:version/deployments/multi-zone /docs/:version/production/cp-deployment/multi-zone/
-/docs/:version/deployments/stand-alone /docs/:version/production/cp-deployment/stand-alone/
-/docs/:version/introduction/what-is-a-service-mesh/ /docs/:version/introduction/about-service-meshes
-/docs/:version/introduction/what-is-kuma/ /docs/:version/introduction/overview-of-kuma
-/docs/:version/introduction/deployments /docs/:version/production/deployment/
-/docs/:version/policies/mesh /docs/:version/production/mesh/
-/docs/:version/policies/proxy-template/ /docs/:version/reference/proxy-template/
-/docs/:version/explore/dpp/* /docs/:version/production/dp-config/dpp/
-/docs/:version/installation/* /docs/:version/production/install-kumactl/
-

--- a/app/_src/documentation/configuration.md
+++ b/app/_src/documentation/configuration.md
@@ -10,7 +10,7 @@ There are 2 ways to configure the control plane:
 
 Environment variables take precedence over YAML configuration.
 
-All possible configuration and their default values are in the [`kuma-cp` reference doc](/docs/{{ page.version }}/generated/kuma-cp).
+All possible configuration and their default values are in the [`kuma-cp` reference doc](/docs/{{ page.version }}/reference/kuma-cp).
 
 {% tip %}
 Environment variables usually match the yaml path by replacing `.` with `_`, capitalizing names and prefixing with KUMA.

--- a/app/_src/production/cp-deployment/systemd.md
+++ b/app/_src/production/cp-deployment/systemd.md
@@ -15,9 +15,10 @@ After = network.target
 Documentation = {{ site.links.web }}
 
 [Service]
-User = {{ site.mesh_product_name | downcase }}
+User = < user to use to run the process >
 Environment = KUMA_MODE=standalone
-ExecStart = /home/{{ site.mesh_product_name | downcase }}/{{ site.mesh_product_name | downcase }}-{{ page.latest_version }}/bin/kuma-cp run --config-file=/home/{{ site.mesh_product_name | downcase }}/cp-config.yaml
+WorkingDirectory = <directory of the {{ site.mesh_product_name}} install >
+ExecStart = ./bin/kuma-cp run --config-file=./cp-config.yaml
 # if you need your Control Plane to be able to handle a non-trivial number of concurrent connections
 # (a total of both incoming and outgoing connections), you need to set proper resource limits on
 # the `kuma-cp` process, especially maximum number of open files.
@@ -56,12 +57,13 @@ After = network.target
 Documentation = {{ site.links.web }}
 
 [Service]
-User = {{ site.mesh_product_name | downcase }}
-ExecStart = /home/{{ site.mesh_product_name | downcase }}/{{ site.mesh_product_name | downcase }}-{{ page.latest_version }}/bin/kuma-dp run \
+User = < user to use to run the process >
+WorkingDirectory = <directory of the {{ site.mesh_product_name}} install >
+ExecStart = ./bin/kuma-dp run \
   --cp-address=https://<kuma-cp-address>:5678 \
-  --dataplane-token-file=/home/{{ site.mesh_product_name | downcase }}/echo-service-universal.token \
-  --dataplane-file=/home/{{ site.mesh_product_name | downcase }}/dataplane-notransparent.yaml \
-  --ca-cert-file=/home/{{ site.mesh_product_name | downcase }}/ca.pem
+  --dataplane-token-file=./echo-service-universal.token \
+  --dataplane-file=./dataplane-notransparent.yaml \
+  --ca-cert-file=./ca.pem
 Restart = always
 RestartSec = 1s
 # disable rate limiting on start attempts

--- a/app/_src/production/dp-config/dpp-on-universal.md
+++ b/app/_src/production/dp-config/dpp-on-universal.md
@@ -196,7 +196,7 @@ networking:
 # ...
 ```
 
-If the `admin` section is empty or port is equal to zero then the default value for port will be taken from the [{{site.mesh_product_name}} Control Plane configuration](/docs/{{ page.version }}/generated/kuma-cp).
+If the `admin` section is empty or port is equal to zero then the default value for port will be taken from the [{{site.mesh_product_name}} Control Plane configuration](/docs/{{ page.version }}/reference/kuma-cp).
 
 ## Dataplane configuration
 

--- a/app/_src/production/upgrades-tuning/upgrades.md
+++ b/app/_src/production/upgrades-tuning/upgrades.md
@@ -28,7 +28,7 @@ Despite control-planes within a zone not connecting to each other; they share a 
 
 
 {% warning %}
-Some feature flags may not provide backward compatibility, when this is the case it is clearly documented in [the control-plane configuration](/docs/{{ page.version }}/generated/kuma-cp) and will be part of the `experimental` section.
+Some feature flags may not provide backward compatibility, when this is the case it is clearly documented in [the control-plane configuration](/docs/{{ page.version }}/reference/kuma-cp) and will be part of the `experimental` section.
 
 To guarantee our compatibility policy we will always wait at least two minor versions before making these features enabled by default.
 {% endwarning %}

--- a/app/_src/reference/kubernetes-annotations.md
+++ b/app/_src/reference/kubernetes-annotations.md
@@ -668,7 +668,7 @@ spec: ...
 ### `kuma.io/sidecar-drain-time`
 
 Allows specifying drain time of {{site.mesh_product_name}} DP sidecar. The default value is 30s.
-The default could be changed using [the control-plane configuration](/docs/{{ page.version }}/generated/kuma-cp) or `KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_DRAIN_TIME` env.
+The default could be changed using [the control-plane configuration](/docs/{{ page.version }}/reference/kuma-cp) or `KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_DRAIN_TIME` env.
 
 **Example**
 

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -68,6 +68,7 @@ jekyll-generator-single-source:
 
 # Product name variables
 mesh_product_name: Kuma
+mesh_product_name_path: kuma
 mesh_namespace: kuma-system
 mesh_cp_name: kuma-control-plane
 mesh_base_url: https://kuma.io

--- a/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/jsonschema.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/jsonschema.rb
@@ -25,6 +25,7 @@ module Jekyll
             <<~TIP
               <div id="markdown_html"></div>
 
+              <script defer src="https://brianwendt.github.io/json-schema-md-doc/lib/JSONSchemaMarkdown.js"></script>
               <script type="text/javascript">
               const data = #{JSON.dump(data)};
               document.addEventListener("DOMContentLoaded", function() {

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -73,6 +73,7 @@ include:
   - robots.txt
 
 mesh_product_name: Kuma
+mesh_product_name_path: kuma
 mesh_namespace: kuma-system
 mesh_cp_name: kuma-control-plane
 # Product name variables


### PR DESCRIPTION
We always should use the newest path and systemd conf shouldn't include too much env specific things