### PR TITLE
Reformatting descriptions for the organization of multiple Prometheus instances in multi-zone environments

### DIFF
--- a/app/_src/explore/observability.md
+++ b/app/_src/explore/observability.md
@@ -331,12 +331,12 @@ When {{site.mesh_product_name}} is used in multi-zone the recommended approach i
 
 Prometheus offers different ways to do this:
 
-- [Federation](https://prometheus.io/docs/prometheus/latest/federation/) the global Prometheus will scrape each zone Prometheuses.
-- [Remote Write](https://prometheus.io/docs/prometheus/latest/storage/#remote-storage-integrations) each zone Prometheuses will directly write their metrics to the global, this is meant to be more efficient the API the federation.
-- [Remote Read](https://prometheus.io/docs/prometheus/latest/storage/#remote-storage-integrations) like remote write but the other way around.
+- [Federation](https://prometheus.io/docs/prometheus/latest/federation/) The global Prometheus will scrape Prometheus in each zone.
+- [Remote Write](https://prometheus.io/docs/prometheus/latest/storage/#remote-storage-integrations) Prometheus in each zone will directly write metrics to the global, this is meant to be more efficient than the federation.
+- [Remote Read](https://prometheus.io/docs/prometheus/latest/storage/#remote-storage-integrations) like remote write, but the other way around.
 
 ### Jaeger, Loki, Datadog and others
 
 Most telemetry components don't have a hierarchical setup like Prometheus.
 If you want to have a central view of everything you can set up the system in global and have each zone send their data to it.
-Because zone is present in data plane tags you shouldn't be worried about metrics, logs and traces overlapping between zones.
+Because zone is present in data plane tags you shouldn't be worried about metrics, logs, and traces overlapping between zones.


### PR DESCRIPTION

Reformatting descriptions for the organization of multiple Prometheus instances in multi-zone environments.