### PR TITLE
feat(lifecycle): document waiting for sidecar to be ready

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -30,6 +30,7 @@
 /transparent-proxying-reachable-services/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiotransparent-proxying-reachable-services 302
 /virtual-probes-port/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiovirtual-probes-port 302
 /virtual-probes/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiovirtual-probes 302
+/wait-for-dataplane-ready/ /docs/LATEST_RELEASE/reference/kubernetes-annotations/#kumaiowait-for-dataplane-ready 302
 
 # kuma.io subdomain redirects
 https://prometheus.metrics.kuma.io/port /docs/LATEST_RELEASE/reference/kubernetes-annotations/#prometheus-metrics-kuma-io-port/ 302

--- a/app/_src/production/dp-config/dpp-on-kubernetes.md
+++ b/app/_src/production/dp-config/dpp-on-kubernetes.md
@@ -202,7 +202,9 @@ The `waitForDataplaneReady` setting relies on the fact that defining a `postStar
 This isn't documented and could change in the future.
 It also depends on injecting the kuma-sidecar container as the first container in the pod, which isn't guaranteed since other mutating webhooks can rearrange the containers.
 
+<!-- vale off -->
 A better solution will be available when [sidecar containers](https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/) are more stable and widely available.
+<!-- vale on -->
 {% endwarning %}
 
 {% endif_version %}

--- a/app/_src/production/dp-config/dpp-on-kubernetes.md
+++ b/app/_src/production/dp-config/dpp-on-kubernetes.md
@@ -187,22 +187,22 @@ When `Pod` is converted to a `Dataplane` object it will be marked as unhealthy u
 {% if_version gte:2.4.x %}
 ### Waiting for the dataplane to be ready
 
-By default, containers are started in any order, so an application container can start even though a dataplane container might not be ready to receive traffic.
+By default, containers start in any order, so an app container can start even though a dataplane container might not be ready to receive traffic.
 
-This can make initial requests (like connecting to a database) fail for short time after starting the pod.
+Making initial requests, such as connecting to a database, can fail for a brief period after the pod is started. ```
 
-To mitigate this problem we suggest setting
+To mitigate this problem try setting
 * `runtime.kubernetes.injector.sidecarContainer.waitForDataplaneReady` to `true`, or 
 * [kuma.io/wait-for-dataplane-ready](/docs/{{ page.version }}/reference/kubernetes-annotations/#wait-for-dataplane-ready) annotation to `true`
 so that the app container waits for the dataplane container to be ready to serve traffic.
 
 {% warning %}
 
-The `waitForDataplaneReady` setting relies on the fact that when a `postStart` hook is defined Kubernetes runs containers in sequence of occurrence in `containers` list.
-This is not documented and could change in the future.
-It also relies on the kuma-sidecar container being injected as the first container in the pod, which is not guaranteed because other mutating webhooks can rearrange the containers.
+The `waitForDataplaneReady` setting relies on the fact that defining a `postStart` hook causes Kubernetes to run containers sequentially based on their order of occurrence in the `containers` list.
+This isn't documented and could change in the future.
+It also depends on injecting the kuma-sidecar container as the first container in the pod, which isn't guaranteed since other mutating webhooks can rearrange the containers.
 
-A better solution will be available when [sidecar containers](https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/) are more stable and widely available.
+As [sidecar containers](https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/) gain stability and wider availability, a better solution is going to be implemented.
 {% endwarning %}
 
 {% endif_version %}

--- a/app/_src/production/dp-config/dpp-on-kubernetes.md
+++ b/app/_src/production/dp-config/dpp-on-kubernetes.md
@@ -189,7 +189,7 @@ When `Pod` is converted to a `Dataplane` object it will be marked as unhealthy u
 
 By default, containers start in any order, so an app container can start even though a dataplane container might not be ready to receive traffic.
 
-Making initial requests, such as connecting to a database, can fail for a brief period after the pod is started. ```
+Making initial requests, such as connecting to a database, can fail for a brief period after the pod starts. 
 
 To mitigate this problem try setting
 * `runtime.kubernetes.injector.sidecarContainer.waitForDataplaneReady` to `true`, or 
@@ -202,7 +202,7 @@ The `waitForDataplaneReady` setting relies on the fact that defining a `postStar
 This isn't documented and could change in the future.
 It also depends on injecting the kuma-sidecar container as the first container in the pod, which isn't guaranteed since other mutating webhooks can rearrange the containers.
 
-As [sidecar containers](https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/) gain stability and wider availability, a better solution is going to be implemented.
+A better solution will be available when [sidecar containers](https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/) are more stable and widely available.
 {% endwarning %}
 
 {% endif_version %}

--- a/app/_src/production/dp-config/dpp-on-kubernetes.md
+++ b/app/_src/production/dp-config/dpp-on-kubernetes.md
@@ -193,7 +193,7 @@ Making initial requests, such as connecting to a database, can fail for a brief 
 
 To mitigate this problem try setting
 * `runtime.kubernetes.injector.sidecarContainer.waitForDataplaneReady` to `true`, or 
-* [kuma.io/wait-for-dataplane-ready](/docs/{{ page.version }}/reference/kubernetes-annotations/#wait-for-dataplane-ready) annotation to `true`
+* [kuma.io/wait-for-dataplane-ready](/docs/{{ page.version }}/reference/kubernetes-annotations/#kumaiowait-for-dataplane-ready) annotation to `true`
 so that the app container waits for the dataplane container to be ready to serve traffic.
 
 {% warning %}

--- a/app/_src/production/dp-config/dpp-on-kubernetes.md
+++ b/app/_src/production/dp-config/dpp-on-kubernetes.md
@@ -180,6 +180,18 @@ On Kubernetes, `Dataplane` resource is automatically created by kuma-cp. For eac
 
 To join the mesh in a graceful way, we need to first make sure the application is ready to serve traffic before it can be considered a valid traffic destination.
 
+{% if_version lte:2.3.x %}
+
+If any of the init containers experience network connectivity issues we suggest trying setting `runtime.kubernetes.injector.sidecarContainer.waitForDataplaneReady` to `true` so that the init container for the sidecar finishes only when the sidecar is ready to serve traffic.
+
+{% warning %}
+The `waitForDataplaneReady` setting relies on Kubernetes container creation sequence (which is undocumented, so it might be changed in the future) and injecting kuma-init as the first init container (which we can't guarantee, because other mutating webhooks can rearrange the init containers) with a `postStart` hook.
+
+This will be properly solved when [sidecar containers](https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/) are stable and widely available.
+{% endwarning %}
+
+{% endif_version %}
+
 When `Pod` is converted to a `Dataplane` object it will be marked as unhealthy until Kubernetes considers all containers to be ready.
 
 ### Leaving the mesh

--- a/app/_src/reference/kubernetes-annotations.md
+++ b/app/_src/reference/kubernetes-annotations.md
@@ -603,6 +603,14 @@ spec:
         [...]
 ```
 
+{% if_version gte:2.4.x %}
+### `kuma.io/wait-for-dataplane-ready`
+
+Define if you want the init container to wait for the dataplane to be ready before exiting.
+Read relevant [Data plane on Kubernetes](/docs/{{ page.version }}/production/dp-config/dpp-on-kubernetes/#wait-for-dataplane-ready) section for more information.
+
+{% endif_version %}
+
 ### `prometheus.metrics.kuma.io/aggregate-<name>-enabled`
 
 Define if `kuma-dp` should scrape metrics from the application that has been defined in the `Mesh` configuration. Default value: `true`. For more details see the [applications metrics docs](/docs/{{ page.version }}/policies/traffic-metrics#expose-metrics-from-applications)

--- a/app/_src/reference/kubernetes-annotations.md
+++ b/app/_src/reference/kubernetes-annotations.md
@@ -608,7 +608,7 @@ spec:
 {% if_version gte:2.4.x %}
 ### `kuma.io/wait-for-dataplane-ready`
 
-Define if you want the init container to wait for the dataplane to be ready before exiting.
+Define if you want the kuma-sidecar container to wait for the dataplane to be ready before exiting.
 Read relevant [Data plane on Kubernetes](/docs/{{ page.version }}/production/dp-config/dpp-on-kubernetes/#waiting-for-the-dataplane-to-be-ready) section for more information.
 
 {% endif_version %}

--- a/app/_src/reference/kubernetes-annotations.md
+++ b/app/_src/reference/kubernetes-annotations.md
@@ -608,7 +608,7 @@ spec:
 {% if_version gte:2.4.x %}
 ### `kuma.io/wait-for-dataplane-ready`
 
-Define if you want the kuma-sidecar container to wait for the dataplane to be ready before exiting.
+Define if you want the kuma-sidecar container to wait for the dataplane to be ready before starting app container.
 Read relevant [Data plane on Kubernetes](/docs/{{ page.version }}/production/dp-config/dpp-on-kubernetes/#waiting-for-the-dataplane-to-be-ready) section for more information.
 
 {% endif_version %}

--- a/app/_src/reference/kubernetes-annotations.md
+++ b/app/_src/reference/kubernetes-annotations.md
@@ -607,7 +607,7 @@ spec:
 ### `kuma.io/wait-for-dataplane-ready`
 
 Define if you want the init container to wait for the dataplane to be ready before exiting.
-Read relevant [Data plane on Kubernetes](/docs/{{ page.version }}/production/dp-config/dpp-on-kubernetes/#wait-for-dataplane-ready) section for more information.
+Read relevant [Data plane on Kubernetes](/docs/{{ page.version }}/production/dp-config/dpp-on-kubernetes/#waiting-for-the-dataplane-to-be-ready) section for more information.
 
 {% endif_version %}
 


### PR DESCRIPTION
document waiting for sidecar to be ready before running other init containers

closes https://github.com/kumahq/kuma-website/issues/1448

xref https://github.com/kumahq/kuma/pull/7583

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
