### PR TITLE
fix(changelog): 2.4.x and dev set generate: false

### DIFF
--- a/app/_data/docs_nav_kuma_2.4.x.yml
+++ b/app/_data/docs_nav_kuma_2.4.x.yml
@@ -24,7 +24,7 @@ items:
       - text: Release notes
         url: /docs/changelog/
         absolute_url: true
-        generate: true
+        generate: false
   - title: Kuma in Production
     group: true
     items:

--- a/app/_data/docs_nav_kuma_dev.yml
+++ b/app/_data/docs_nav_kuma_dev.yml
@@ -24,7 +24,7 @@ items:
       - text: Release notes
         url: /docs/changelog/
         absolute_url: true
-        generate: true
+        generate: false
   - title: Kuma in Production
     group: true
     items:


### PR DESCRIPTION
The previous setup was causing docs.konghq.com to fail
