### PR TITLE
ci(installer): run tests on ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           - amazonlinux:2022
           - debian:bookworm
           - redhat/ubi8:8.6
-          - ubuntu:22.10
+          - ubuntu:22.04
           - archlinux:latest
           - fedora:latest
     container:


### PR DESCRIPTION
ubuntu 22.10 started failing https://github.com/kumahq/kuma-website/actions/runs/6169639158/job/16781025677?pr=1460#step:3:10 not sure if worth investigating 

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
