### PR TITLE
add plugin to generate helm and kumactl install

### DIFF
--- a/app/_common_redirects
+++ b/app/_common_redirects
@@ -48,4 +48,4 @@
 
 # kuma IA redirects (pages that do exist take precedence on these so it's safe to use `:version` for pages moved in newer versions).
 /docs/:version/policies/proxy-template/ /docs/:version/reference/proxy-template/
-/docs/:version/installation/* /docs/:version/production/install-kumactl/
+/docs/:version/installation/* /docs/:version/production/cp-deployment/stand-alone/

--- a/app/_src/documentation/configuration.md
+++ b/app/_src/documentation/configuration.md
@@ -19,22 +19,12 @@ For example the yaml path: `store.postgres.port` is the environment variable: `K
 {% endtip %}
 
 {% tabs usage useUrlFragment=false %}
-{% tab usage Kubernetes (kumactl) %}
-When using `kumactl`, override the configuration with the `--env-var` flag. For example, to configure the refresh interval for configuration of the data plane proxy, specify:
-```sh
-kumactl install control plane \
-  --env-var KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
-  --env-var KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s | kubectl apply -f -
-```
-{% endtab %}
-{% tab usage Kubernetes (HELM) %}
-When using `helm`, you can override the configuration with the `envVars` field. For example, to configure the refresh interval for configuration with the data plane proxy, specify:
-```sh
-helm install \
-  --set {{site.set_flag_values_prefix}}controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s \
-  --set {{site.set_flag_values_prefix}}controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s \
-  {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }}
-```
+{% tab usage Kubernetes %}
+On Kubernetes, you can override the configuration with the `envVars` field. For example, to configure the refresh interval for configuration with the data plane proxy, specify:
+{% cpinstall envars %}
+controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL=5s
+controlPlane.envVars.KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL=5s
+{% endcpinstall %}
 
 Or you can create a `values.yaml` file with:
 ```yaml

--- a/app/_src/production/cp-deployment/stand-alone.md
+++ b/app/_src/production/cp-deployment/stand-alone.md
@@ -7,20 +7,22 @@ In order to deploy {{site.mesh_product_name}} in a standalone deployment, the `k
 
 {% tabs usage useUrlFragment=false %}
 {% tab usage Kubernetes %}
-This is the standard installation method as described in the [installation page](/install).
-```sh
-kumactl install control-plane | kubectl apply -f -
-```
+This is the standard installation method. 
+{% cpinstall cpstandalone %}
+controlPlane.mode=standalone
+{% endcpinstall %}
 
 **With zone egress**:
 
 It's possible to run {% if_version lte:2.1.x %}[`ZoneEgress`](/docs/{{ page.version }}/explore/zoneegress){% endif_version %}{% if_version gte:2.2.x %}[`ZoneEgress`](/docs/{{ page.version }}/production/cp-deployment/zoneegress/){% endif_version %} for standalone deployment. In order to deploy {{site.mesh_product_name}} with `ZoneEgress` run the install command with an additional parameter.
-```sh
-kumactl install control-plane --egress-enabled | kubectl apply -f -
-```
+{% cpinstall cpstandalone-egress %}
+controlPlane.mode=standalone
+egress.enabled=true
+{% endcpinstall %}
+
 {% endtab %}
 {% tab usage Universal %}
-This is the standard installation method as described in the [installation page](/install).
+This is the standard installation method. 
 ```sh
 kuma-cp run
 ```

--- a/app/_src/production/deployment/multi-zone.md
+++ b/app/_src/production/deployment/multi-zone.md
@@ -16,6 +16,10 @@ Or without the optional zone egress:
 <img src="/assets/images/diagrams/gslides/kuma_multizone_without_egress.svg" alt="Kuma service mesh multi zone deployment with zone egress" style="padding-top: 20px; padding-bottom: 10px;"/>
 </center>
 
+{% if_version gte:2.2.x %}
+To Install with this topology follow the [multi-zone deployment docs](/docs/{{ page.version }}/production/cp-deployment/multi-zone).
+{% endif_version %}
+
 ## How it works
 
 In {{site.mesh_product_name}}, zones are abstracted away, meaning that your data plane proxies will find services wherever they run.

--- a/app/_src/production/deployment/stand-alone.md
+++ b/app/_src/production/deployment/stand-alone.md
@@ -19,6 +19,10 @@ This mode implies that we can deploy {{site.mesh_product_name}} and its data pla
 
 Standalone mode is usually a great choice within the context of one zone (ie: within one Kubernetes cluster or one AWS VPC).
 
+{% if_version gte:2.2.x %}
+To Install with this topology follow the [stand-alone deployment docs](/docs/{{ page.version }}/production/cp-deployment/stand-alone).
+{% endif_version %}
+
 ## Limitations
 
 * All data plane proxies need to be able to communicate with every other dataplane proxy.

--- a/app/_src/production/dp-config/cni.md
+++ b/app/_src/production/dp-config/cni.md
@@ -32,256 +32,101 @@ Below are the details of how to set up {{site.mesh_product_name}} CNI in differe
 
 {% tabs installation useUrlFragment=false %}
 {% tab installation Cilium %}
-{% tabs cilium useUrlFragment=false %}
-{% tab cilium kumactl %}
-
-```shell
-kumactl install control-plane \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=05-cilium.conflist"
-```
-{% endtab %}
-{% tab cilium helm %}
-
-```shell
-helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=05-cilium.conflist" \
-   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
-```
-{% endtab %}
-{% endtabs %}
+{% cpinstall cilium %}
+cni.enabled=true
+cni.chained=true
+cni.netDir=/etc/cni/net.d
+cni.binDir=/opt/cni/bin
+cni.confName=05-cilium.conflist
+{% endcpinstall %}
 
 {% warning %}
 For Cilium versions < 1.14 you should use `{{site.set_flag_values_prefix}}cni.confName=05-cilium.conf` as this has changed
 for version starting from [Cilium 1.14](https://docs.cilium.io/en/stable/operations/upgrade/#id2).
 {% endwarning %}
-
 {% endtab %}
+
 {% tab installation Calico %}
-
-{% tabs calico useUrlFragment=false %}
-{% tab calico kumactl %}
-
-```shell
-kumactl install control-plane \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=10-calico.conflist"
-```
-
-{% endtab %}
-{% tab calico Helm %}
-
-```shell
-helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=10-calico.conflist" \
-   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
-```
-
-{% endtab %}
-{% endtabs %}
+{% cpinstall calico %}
+cni.enabled=true
+cni.chained=true
+cni.netDir=/etc/cni/net.d
+cni.binDir=/opt/cni/bin
+cni.confName=10-calico.conflist
+{% endcpinstall%}
 {% endtab %}
 
 {% tab installation K3D with Flannel %}
-{% tabs k3d useUrlFragment=false %}
-{% tab k3d kumactl %}
-
-```shell
-kumactl install control-plane \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/var/lib/rancher/k3s/agent/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=10-flannel.conflist"
-```
-
-{% endtab %}
-{% tab k3d Helm %}
-
-```shell
-helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/var/lib/rancher/k3s/agent/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=10-flannel.conflist" \
-   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
-```
-
-{% endtab %}
-{% endtabs %}
+{% cpinstall k3d %}
+cni.enabled=true
+cni.chained=true
+cni.netDir=/var/lib/rancher/k3s/agent/etc/cni/net.d
+cni.binDir=/bin
+cni.confName=10-flannel.conflist
+{% endcpinstall %}
 {% endtab %}
 
 {% tab installation Kind %}
-{% tabs kind useUrlFragment=false %}
-{% tab kind kumactl %}
-
-```shell
-kumactl install control-plane \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=10-kindnet.conflist"
-```
-
-{% endtab %}
-{% tab kind Helm %}
-
-```shell
-helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=10-kindnet.conflist" \
-   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
-```
-
-{% endtab %}
-{% endtabs %}
+{% cpinstall kind %}
+cni.enabled=true
+cni.chained=true
+cni.netDir=/etc/cni/net.d
+cni.binDir=/opt/cni/bin
+cni.confName=10-kindnet.conflist
+{% endcpinstall %}
 {% endtab %}
 
 {% tab installation Azure %}
-{% tabs azure useUrlFragment=false %}
-{% tab azure kumactl %}
-
-```shell
-kumactl install control-plane \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=10-azure.conflist"
-```
-
-{% endtab %}
-{% tab azure Helm %}
-
-```shell
-helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=10-azure.conflist" \
-   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
-```
-
-{% endtab %}
-{% endtabs %}
+{% cpinstall azure %}
+cni.enabled=true
+cni.chained=true
+cni.netDir=/etc/cni/net.d
+cni.binDir=/opt/cni/bin
+cni.confName=10-azure.conflist
+{% endcpinstall %}
 {% endtab %}
 
 {% tab installation Azure Overlay %}
-{% tabs azure_overlay useUrlFragment=false %}
-{% tab azure_overlay kumactl %}
-
-```shell
-kumactl install control-plane \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=15-azure-swift-overlay.conflist"
-```
-
-{% endtab %}
-{% tab azure_overlay Helm %}
-
-```shell
-helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=15-azure-swift-overlay.conflist" \
-   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
-```
-
-{% endtab %}
-{% endtabs %}
+{% cpinstall azure_overlay %}
+cni.enabled=true
+cni.chained=true
+cni.netDir=/etc/cni/net.d
+cni.binDir=/opt/cni/bin
+cni.confName=15-azure-swift-overlay.conflist
+{% endcpinstall %}
 {% endtab %}
 
 {% tab installation AWS - EKS %}
-{% tabs aws-eks useUrlFragment=false %}
-{% tab aws-eks kumactl %}
+{% cpinstall aws-eks %}
+cni.enabled=true
+cni.chained=true
+cni.netDir=/etc/cni/net.d
+cni.binDir=/opt/cni/bin
+cni.confName=10-aws.conflist
+runtime.kubernetes.injector.sidecarContainer.redirectPortInboundV6=0
+{% endcpinstall %}
 
-```shell
-kumactl install control-plane \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=10-aws.conflist" \
-  --set "{{site.set_flag_values_prefix}}runtime.kubernetes.injector.sidecarContainer.redirectPortInboundV6=0" # EKS does not have ipv6 enabled by default
-```
-
-{% endtab %}
-{% tab aws-eks Helm %}
-
-```shell
-helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/opt/cni/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=10-aws.conflist" \
-   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
-```
-
-{% endtab %}
-{% endtabs %}
+{% tip %}
+Add `redirectPortInboundV6=0` as EKS has IPv6 disabled by default.
+{% endtip %}
 {% endtab %}
 
 {% tab installation Google - GKE %}
 
 You need to [enable network-policy](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy) in your cluster (for existing clusters this redeploys the nodes).
 
-{% tabs google-gke useUrlFragment=false %}
-{% tab google-gke kumactl %}
+{% cpinstall google-gke %}
+cni.enabled=true
+cni.chained=true
+cni.netDir=/etc/cni/net.d
+cni.binDir=/home/kubernetes/bin
+cni.confName=10-calico.conflist
+{% endcpinstall %}
+{%endtab%}
 
-```shell
-kumactl install control-plane \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/home/kubernetes/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=10-calico.conflist"
-```
+{% tab installation OpenShift 3.11 %}
 
-{% endtab %}
-{% tab google-gke Helm %}
-
-```shell
-helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.chained=true" \
-  --set "{{site.set_flag_values_prefix}}cni.netDir=/etc/cni/net.d" \
-  --set "{{site.set_flag_values_prefix}}cni.binDir=/home/kubernetes/bin" \
-  --set "{{site.set_flag_values_prefix}}cni.confName=10-calico.conflist" \
-   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
-```
-
-{% endtab %}
-{% endtabs %}
-{% endtab %}
-
-{% tab insallation OpenShift 3.11 %}
-
-1. Follow the instructions in [OpenShift 3.11 installation](/docs/{{ page.version }}/installation/openshift/#2-run-kuma)
+1. Follow the instructions in [OpenShift 3.11 installation](/docs/{{ page.version }}/production/cp-deployment/stand-alone)
    to get the `MutatingAdmissionWebhook` and `ValidatingAdmissionWebhook` enabled (this is required for regular {{site.mesh_product_name}} installation).
 
 2. You need to grant privileged permission to kuma-cni service account:
@@ -290,50 +135,17 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \
 oc adm policy add-scc-to-user privileged -z kuma-cni -n kube-system
 ```
 
-{% tabs openshift-3 useUrlFragment=false %}
-{% tab openshift-3 kumactl %}
-
-```shell
-kumactl install control-plane \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.containerSecurityContext.privileged=true"
-```
-
-{% endtab %}
-{% tab openshift-3 Helm %}
-
-```shell
-helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-  --set "{{site.set_flag_values_prefix}}cni.containerSecurityContext.privileged=true" \
-   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
-```
-
-{% endtab %}
-{% endtabs %}
+{% cpinstall openshit-3 %}
+cni.enabled=true
+cni.containerSecurityContext.privileged=true
+{% endcpinstall %}
 {% endtab %}
 
 {% tab installation OpenShift 4 %}
-
-{% tabs openshift-4 useUrlFragment=false %}
-{% tab openshift-4 kumactl %}
-
-```shell
-kumactl install control-plane \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true"
-```
-
-{% endtab %}
-{% tab openshift-4 Helm %}
-
-```shell
-helm install --create-namespace --namespace {{site.mesh_namespace}} \
-  --set "{{site.set_flag_values_prefix}}cni.enabled=true" \
-   {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
-```
-
-{% endtab %}
-{% endtabs %}
+{% cpinstall openshit-4 %}
+cni.enabled=true
+cni.containerSecurityContext.privileged=true
+{% endcpinstall %}
 {% endtab %}
 
 {% endtabs %}
@@ -390,7 +202,7 @@ If you are using the CNI v2 version logs are available via `kubectl logs` instea
 {% endif_version %}
 
 {% if_version gte:2.2.x %}
-Logs are available via `kubectl logs`.
+Logs of the are available via `kubectl logs`.
 
 {% warning %}
 eBPF CNI currently doesn't have support for exposing its logs.

--- a/app/_src/production/secure-deployment/certificates.md
+++ b/app/_src/production/secure-deployment/certificates.md
@@ -58,7 +58,7 @@ cp /tmp/tls.crt /tmp/ca.crt
 2) Configure the control plane with generated certs:
 
 {% tabs control-plane useUrlFragment=false %}
-{% tab control-plane Kubernetes (kumactl) %}
+{% tab control-plane Kubernetes %}
 Create a secret in the namespace where the control plane is installed:
 ```sh
 kubectl create secret generic general-tls-certs -n <namespace> \
@@ -68,31 +68,11 @@ kubectl create secret generic general-tls-certs -n <namespace> \
 ```
 
 Point to this secret when installing {{site.mesh_product_name}}:
-```sh
-kumactl install control-plane \
-  --tls-general-secret=general-tls-certs \
-  --tls-general-ca-bundle=$(cat /tmp/ca.crt | base64)
-```
 
-The data plane proxy Injector in the control plane automatically provides the CA to the {{site.mesh_product_name}} DP sidecar 
-so {{site.mesh_product_name}} DP can confirm the control plane identity.
-
-{% endtab %}
-{% tab control-plane Kubernetes (HELM) %}
-Create a secret in the namespace where the control plane is installed:
-```sh
-kubectl create secret generic general-tls-certs -n <namespace> \
-  --from-file=tls.crt=/tmp/tls.crt \
-  --from-file=tls.key=/tmp/tls.key \
-  --from-file=ca.crt=/tmp/ca.crt
-```
-
-Point to this secret when installing {{site.mesh_product_name}}:
-```sh
-helm install --create-namespace --namespace <namespace> {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}} \
-  --set {{site.set_flag_values_prefix}}controlPlane.tls.general.secretName=general-tls-certs \
-  --set {{site.set_flag_values_prefix}}controlPlane.tls.general.caBundle=$(cat /tmp/ca.crt | base64)
-```
+{% cpinstall certs %}
+controlPlane.tls.general.secretName=general-tls-certs
+controlPlane.tls.general.caBundle=$(cat /tmp/ca.crt | base64)
+{% endcpinstall %}
 
 The data plane proxy Injector in the control plane automatically provides the CA to the {{site.mesh_product_name}} DP sidecar 
 so {{site.mesh_product_name}} DP can confirm the control plane identity.
@@ -142,12 +122,12 @@ kubectl create secret generic general-tls-certs -n <namespace> \
 ```
 
 Point to this secret when installing Kuma:
-```sh
-kumactl install control-plane \
-  --tls-general-secret=general-tls-certs \
-  --tls-general-ca-bundle=$(cat /tmp/ca.crt | base64) \
-  --env-var 'KUMA_MONITORING_ASSIGNMENT_SERVER_TLS_ENABLED=true'
-```
+
+{% cpinstall install-mads %}
+controlPlane.tls.general.secretName=general-tls-certs
+controlPlane.tls.general.caBundle=$(cat /tmp/ca.crt | base64)
+controlPlane.envVars.KUMA_MONITORING_ASSIGNMENT_SERVER_TLS_ENABLED=true
+{% endcpinstall %}
 
 {% endtab %}
 {% tab mads Universal %}
@@ -197,7 +177,7 @@ cp /tmp/tls.crt /tmp/ca.crt
 
 2) Configure the control plane with generated certificates
 {% tabs configure-control-plane useUrlFragment=false %}
-{% tab configure-control-plane Kubernetes (kumactl) %}
+{% tab configure-control-plane Kubernetes %}
 Create a secret in the namespace in which the control plane is installed:
 ```sh
 kubectl create secret tls api-server-tls -n <namespace> \
@@ -206,24 +186,10 @@ kubectl create secret tls api-server-tls -n <namespace> \
 ```
 
 Point to this secret when installing {{site.mesh_product_name}}:
-```sh
-kumactl install control-plane \
-  --tls-api-server-secret=api-server-tls
-```
-{% endtab %}
-{% tab configure-control-plane Kubernetes (HELM) %}
-Create a secret in the namespace in which the control plane is installed:
-```sh
-kubectl create secret tls api-server-tls -n <namespace> \
-  --cert=/tmp/tls.crt \
-  --key=/tmp/tls.key
-```
 
-Point to this secret when installing {{site.mesh_product_name}}:
-```sh
-helm install --create-namespace --namespace <namespace> {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}} \
-  --set {{site.set_flag_values_prefix}}controlPlane.tls.apiServer.secretName=api-server-tls
-```
+{% cpinstall apiserversecret %}
+controlPlane.tls.apiServer.secretName=api-server-tls
+{% endcpinstall %}
 
 {% endtab %}
 {% tab configure-control-plane Universal %}
@@ -284,8 +250,9 @@ cp /tmp/tls.crt /tmp/ca.crt
 ```
 
 2) Configure global control plane
+
 {% tabs global-control-plane useUrlFragment=false %}
-{% tab global-control-plane Kubernetes (kumactl) %}
+{% tab global-control-plane Kubernetes %}
 Create a secret in the namespace where the global control plane is installed:
 ```sh
 kubectl create secret tls kds-server-tls -n <namespace> \
@@ -294,25 +261,10 @@ kubectl create secret tls kds-server-tls -n <namespace> \
 ```
 
 Point to this secret when installing the global control plane:
-```sh
-kumactl install control-plane \
-  --mode=global \
-  --tls-kds-global-server-secret=general-tls-certs
-```
-{% endtab %}
-{% tab global-control-plane Kubernetes (HELM) %}
-Create a secret in the namespace where the global control plane is installed:
-```sh
-kubectl create secret tls kds-server-tls -n <namespace> \
-  --cert=/tmp/tls.crt \
-  --key=/tmp/tls.key
-```
 
-Point to this secret when installing {{site.mesh_product_name}}:
-```sh
-helm install --create-namespace --namespace <namespace> {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}} \
-  --set {{site.set_flag_values_prefix}}controlPlane.tls.kdsGlobalServer.secretName=kds-server-tls
-```
+{% cpinstall kdsglobalsecret %}
+controlPlane.tls.kdsGlobalServer.secretName=kds-server-tls
+{% endcpinstall %}
 
 {% endtab %}
 {% tab global-control-plane Universal %}
@@ -329,7 +281,7 @@ KUMA_MULTIZONE_GLOBAL_KDS_TLS_CERT_FILE=/tmp/tls.crt \
 3) Configure the zone control plane
 
 {% tabs zone-control-plane useUrlFragment=false %}
-{% tab zone-control-plane Kubernetes (kumactl) %}
+{% tab zone-control-plane Kubernetes %}
 Create a secret in the namespace where the zone control plane is installed:
 ```sh
 kubectl create secret generic kds-ca-certs -n <namespace> \
@@ -337,24 +289,10 @@ kubectl create secret generic kds-ca-certs -n <namespace> \
 ```
 
 Point to this secret when installing the zone control plane:
-```sh
-kumactl install control-plane \
-  --mode=zone \
-  --tls-kds-zone-client-secret=kds-ca-certs
-```
-{% endtab %}
-{% tab zone-control-plane Kubernetes (HELM) %}
-Create a secret in the namespace where the zone control plane is installed:
-```sh
-kubectl create secret generic kds-ca-certs -n <namespace> \
-  --from-file=ca.crt.pem=/tmp/ca.crt
-```
 
-Point to this secret when installing {{site.mesh_product_name}}:
-```sh
-helm install --create-namespace --namespace <namespace> {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}} \
-  --set {{site.set_flag_values_prefix}}controlPlane.tls.kdsZoneClient.secretName=kds-ca-certs
-```
+{% cpinstall kdszonesecret %}
+controlPlane.tls.kdsZoneClient.secretName=kds-ca-certs
+{% endcpinstall %}
 
 {% endtab %}
 {% tab zone-control-plane Universal %}

--- a/jekyll-kuma-plugins/lib/jekyll/kuma-plugins.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma-plugins.rb
@@ -4,3 +4,4 @@ require_relative "kuma-plugins/version"
 require_relative 'kuma-plugins/liquid/tags/jsonschema'
 require_relative 'kuma-plugins/liquid/tags/embed'
 require_relative 'kuma-plugins/liquid/tags/policyyaml'
+require_relative 'kuma-plugins/liquid/tags/cpinstall'

--- a/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/cpinstall.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/cpinstall.rb
@@ -1,0 +1,58 @@
+# This plugins lets us add a set of key values to add to install and it will generate 2 tabs for helm and kumactl install
+# It removes duplication of examples for both universal and kubernetes environments.
+# The expected format is universal. It only works for policies V2 with a `spec` blocks.
+require 'yaml'
+module Jekyll
+  module KumaPlugins
+    module Liquid
+      module Tags
+        class PolicyYaml < ::Liquid::Block
+          def initialize(tag_name, tabs_name, options)
+             super
+             @tabs_name = tabs_name
+             name, *params_list = @markup.split(' ')
+             params = {'prefixed' => "true"}
+             params_list.each do |item|
+                 sp = item.split('=')
+                 params[sp[0]] = sp[1] unless sp[1] == ''
+             end
+             @prefixed = params['prefixed'].downcase() == "true"
+          end
+
+          def render(context)
+            content = super
+            return "" unless content != ""
+            site_data = context.registers[:site].config
+
+            opts = content.strip.split("\n").map do |x|
+                x = site_data['set_flag_values_prefix'] + x if @prefixed
+                "--set \"#{x}\""
+            end
+            res = opts.join(" \\\n  ")
+
+            htmlContent = "
+{% tabs #{@tabs_name} useUrlFragment=false %}
+{% tab #{@tabs_name} kumactl %}
+```shell
+kumactl install control-plane \\
+  #{res} \\
+  | kubectl apply -f -
+```
+{% endtab %}
+{% tab #{@tabs_name} helm %}
+```shell
+helm install --create-namespace \\
+  #{res} \\
+  {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
+```
+{% endtab %}
+{% endtabs %}"
+            ::Liquid::Template.parse(htmlContent).render(context)
+          end
+        end
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('cpinstall', Jekyll::KumaPlugins::Liquid::Tags::PolicyYaml)


### PR DESCRIPTION
We now redirect to install standalone instead of install kumactl.
Added a link to how to install in each mode from the topology page

Fix https://github.com/kumahq/kuma-website/issues/1458

Built on top of: #1447 