### PR TITLE
docs(dns): mention DNS standards RFC in dns documentation

### DIFF
--- a/app/_src/networking/dns.md
+++ b/app/_src/networking/dns.md
@@ -119,8 +119,9 @@ Consuming a service handled by {{site.mesh_product_name}} DNS, whether from {{si
 <kuma-enabled-pod>$ curl http://echo-server_echo-example_svc_1010.mesh:80
 <kuma-enabled-pod>$ curl http://echo-server_echo-example_svc_1010.mesh
 ```
+Be aware of DNS standards ([RFC1035](https://www.ietf.org/rfc/rfc1035.txt)) if using underscores in the service name.
 
-A DNS standards compliant name is also available, where the underscores in the service name are replaced with dots. For example:
+A DNS standards-compliant name is also available, where the underscores in the service name are replaced with dots. For example:
 
 ```
 <kuma-enabled-pod>$ curl http://echo-server.echo-example.svc.1010.mesh:80

--- a/app/_src/networking/dns.md
+++ b/app/_src/networking/dns.md
@@ -119,9 +119,8 @@ Consuming a service handled by {{site.mesh_product_name}} DNS, whether from {{si
 <kuma-enabled-pod>$ curl http://echo-server_echo-example_svc_1010.mesh:80
 <kuma-enabled-pod>$ curl http://echo-server_echo-example_svc_1010.mesh
 ```
-Be aware of DNS standards ([RFC1035](https://www.ietf.org/rfc/rfc1035.txt)) if using underscores in the service name.
 
-A DNS standards-compliant name is also available, where the underscores in the service name are replaced with dots. For example:
+A DNS-compliant ([RFC 1035](https://www.ietf.org/rfc/rfc1035.txt) name can also be used, where the underscores in the service name are replaced with dots. For example:
 
 ```
 <kuma-enabled-pod>$ curl http://echo-server.echo-example.svc.1010.mesh:80

--- a/app/_src/networking/dns.md
+++ b/app/_src/networking/dns.md
@@ -120,7 +120,9 @@ Consuming a service handled by {{site.mesh_product_name}} DNS, whether from {{si
 <kuma-enabled-pod>$ curl http://echo-server_echo-example_svc_1010.mesh
 ```
 
+<!-- vale Google.Parens = NO -->
 You can also use a DNS-compliant name (RFC 1035: https://www.ietf.org/rfc/rfc1035.txt) by replacing the underscores in the service name with dots. For example:
+<!-- vale Google.Parens = YES -->
 
 ```
 <kuma-enabled-pod>$ curl http://echo-server.echo-example.svc.1010.mesh:80

--- a/app/_src/networking/dns.md
+++ b/app/_src/networking/dns.md
@@ -120,7 +120,7 @@ Consuming a service handled by {{site.mesh_product_name}} DNS, whether from {{si
 <kuma-enabled-pod>$ curl http://echo-server_echo-example_svc_1010.mesh
 ```
 
-A DNS-compliant ([RFC 1035](https://www.ietf.org/rfc/rfc1035.txt) name can also be used, where the underscores in the service name are replaced with dots. For example:
+You can also use a DNS-compliant name (RFC 1035: https://www.ietf.org/rfc/rfc1035.txt) by replacing the underscores in the service name with dots. For example:
 
 ```
 <kuma-enabled-pod>$ curl http://echo-server.echo-example.svc.1010.mesh:80

--- a/app/_src/networking/dns.md
+++ b/app/_src/networking/dns.md
@@ -120,9 +120,8 @@ Consuming a service handled by {{site.mesh_product_name}} DNS, whether from {{si
 <kuma-enabled-pod>$ curl http://echo-server_echo-example_svc_1010.mesh
 ```
 
-<!-- vale Google.Parens = NO -->
-You can also use a DNS-compliant name (RFC 1035: https://www.ietf.org/rfc/rfc1035.txt) by replacing the underscores in the service name with dots. For example:
-<!-- vale Google.Parens = YES -->
+
+You can also use a [DNS RFC1035 compliant name](https://www.ietf.org/rfc/rfc1035.txt) by replacing the underscores in the service name with dots. For example:
 
 ```
 <kuma-enabled-pod>$ curl http://echo-server.echo-example.svc.1010.mesh:80


### PR DESCRIPTION
Adding reference to DNS standards as per ([RFC1035](https://www.ietf.org/rfc/rfc1035.txt)).
