### PR TITLE
chore(vale): add word "RFC" to allowed in vale vocabulary

### DIFF
--- a/.github/styles/Vocab/Base/accept.txt
+++ b/.github/styles/Vocab/Base/accept.txt
@@ -114,6 +114,7 @@ proxying
 redis
 referenceable
 repo
+RFC
 routable
 runtimes?
 sandboxing


### PR DESCRIPTION
Add word `RFC` to allowed in vale dictionary

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
