### PR TITLE
fix: fix policy_yaml rendeing

### DIFF
--- a/app/_src/policies/meshtimeout.md
+++ b/app/_src/policies/meshtimeout.md
@@ -173,7 +173,8 @@ mesh: default
 spec:
   targetRef:
     kind: MeshService
-    name: frontend
+    name_uni: frontend
+    name_kube: frontend_kuma-demo_svc_8080
   from:
     - targetRef:
         kind: Mesh
@@ -188,7 +189,8 @@ spec:
   to:
     - targetRef:
         kind: MeshService
-        name: backend
+        name_uni: backend
+        name_kube: backend_kuma-demo_svc_3001
       default:
         idleTimeout: 60s
         connectionTimeout: 1s
@@ -217,7 +219,8 @@ mesh: default
 spec:
   targetRef:
     kind: MeshService
-    name: frontend_kuma-demo_svc_8080
+    name_uni: frontend
+    name_kube: frontend_kuma-demo_svc_8080
   to:
     - targetRef:
         kind: MeshService
@@ -230,7 +233,8 @@ spec:
           default:
             backendRef:
               - kind: MeshServiceSubset
-                name: backend_kuma-demo_svc_3001
+                name_uni: backend
+                name_kube: backend_kuma-demo_svc_3001
                 tags:
                   version: v2
 ---

--- a/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/cpinstall.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/cpinstall.rb
@@ -1,12 +1,11 @@
 # This plugins lets us add a set of key values to add to install and it will generate 2 tabs for helm and kumactl install
 # It removes duplication of examples for both universal and kubernetes environments.
-# The expected format is universal. It only works for policies V2 with a `spec` blocks.
 require 'yaml'
 module Jekyll
   module KumaPlugins
     module Liquid
       module Tags
-        class PolicyYaml < ::Liquid::Block
+        class InstallCp < ::Liquid::Block
           def initialize(tag_name, tabs_name, options)
              super
              @tabs_name = tabs_name
@@ -55,4 +54,4 @@ helm install --create-namespace \\
   end
 end
 
-Liquid::Template.register_tag('cpinstall', Jekyll::KumaPlugins::Liquid::Tags::PolicyYaml)
+Liquid::Template.register_tag('cpinstall', Jekyll::KumaPlugins::Liquid::Tags::InstallCp)

--- a/jekyll-kuma-plugins/spec/jekyll/kuma-plugins/liquid/tags/cpinstall_spec copy.rb
+++ b/jekyll-kuma-plugins/spec/jekyll/kuma-plugins/liquid/tags/cpinstall_spec copy.rb
@@ -1,0 +1,16 @@
+RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::InstallCp do
+  subject { described_class.parse('cpinstall', "", Liquid::Tokenizer.new(entry + '{%endcpinstall%}'), Liquid::ParseContext.new).render(Liquid::Context.new({
+    registers: {
+        :site => {
+            config: {}
+        }
+    }
+  }))}
+
+  context "with nothing" do
+    let(:entry) {''}
+    it "is empty" do
+      expect(subject).to eq('')
+    end
+  end
+end


### PR DESCRIPTION
After introducing `cpinstall` plugin, `policy_yaml` plugin stopped working

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
