### PR TITLE
fix: typos in doc (proxies and slashes)

### DIFF
--- a/app/_src/policies/general-notes-about-kuma-policies.md
+++ b/app/_src/policies/general-notes-about-kuma-policies.md
@@ -32,9 +32,9 @@ conf:
 
 * The wildcard character (*) is supported only as the selector value to match all traffic.
 * Tag values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), and underscores (`_`).
-* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`_`).
+* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`/`).
 
-Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`_`).
+Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`/`).
 
 All policies support arbitrary tags for the `sources` selector, but there are tag limitations for the `destinations` selector. For example, policies that are applied on the client side of a connection between two dataplane objects do not support arbitrary tags in the `destinations` selector. Only the `kuma.io/service` tag is supported in this case. This includes TrafficRoute, TrafficLog, and HealthCheck.
 

--- a/app/_src/production/deployment/stand-alone.md
+++ b/app/_src/production/deployment/stand-alone.md
@@ -49,7 +49,7 @@ A standalone deployment includes:
 
 #### Control plane offline
 
-* New data planes proxis won't be able to join the mesh.
+* New data plane proxies won't be able to join the mesh.
 * Data-plane proxy configuration will not be updated.
 * Communication between data planes proxies will still work.
 

--- a/app/docs/1.3.x/policies/general-notes-about-kuma-policies.md
+++ b/app/docs/1.3.x/policies/general-notes-about-kuma-policies.md
@@ -27,9 +27,9 @@ Kuma assumes that every dataplane object represents a service, even if it's a cr
 
 * The wildcard character (*) is supported only as the selector value to match all traffic.
 * Tag values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), and underscores (`_`).
-* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`_`).
+* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`/`).
 
-Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`_`).
+Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`/`).
 
 All policies support arbitrary tags for the `sources` selector, but there are tag limitations for the `destinations` selector. For example, policies that are applied on the client side of a connection between two dataplane objects do not support arbitrary tags in the `destinations` selector. Only the `kuma.io/service` tag is supported in this case. This includes TrafficRoute, TrafficLog, and HealthCheck.
 

--- a/app/docs/1.4.x/deployments/stand-alone.md
+++ b/app/docs/1.4.x/deployments/stand-alone.md
@@ -55,7 +55,7 @@ When the mode is not specified, Kuma will always start in `standalone` mode by d
 
 #### Control plane offline
 
-* New data planes proxis won't be able to join the mesh.
+* New data plane proxies won't be able to join the mesh.
 * Data-plane proxy configuration will not be updated.
 * Communication between data planes proxies will still work.
 

--- a/app/docs/1.4.x/policies/general-notes-about-kuma-policies.md
+++ b/app/docs/1.4.x/policies/general-notes-about-kuma-policies.md
@@ -27,9 +27,9 @@ Kuma assumes that every dataplane object represents a service, even if it's a cr
 
 * The wildcard character (*) is supported only as the selector value to match all traffic.
 * Tag values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), and underscores (`_`).
-* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`_`).
+* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`/`).
 
-Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`_`).
+Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`/`).
 
 All policies support arbitrary tags for the `sources` selector, but there are tag limitations for the `destinations` selector. For example, policies that are applied on the client side of a connection between two dataplane objects do not support arbitrary tags in the `destinations` selector. Only the `kuma.io/service` tag is supported in this case. This includes TrafficRoute, TrafficLog, and HealthCheck.
 

--- a/app/docs/1.5.x/deployments/stand-alone.md
+++ b/app/docs/1.5.x/deployments/stand-alone.md
@@ -67,7 +67,7 @@ When the mode is not specified, Kuma will always start in `standalone` mode by d
 
 #### Control plane offline
 
-* New data planes proxis won't be able to join the mesh.
+* New data plane proxies won't be able to join the mesh.
 * Data-plane proxy configuration will not be updated.
 * Communication between data planes proxies will still work.
 

--- a/app/docs/1.5.x/policies/general-notes-about-kuma-policies.md
+++ b/app/docs/1.5.x/policies/general-notes-about-kuma-policies.md
@@ -27,9 +27,9 @@ Kuma assumes that every dataplane object represents a service, even if it's a cr
 
 * The wildcard character (*) is supported only as the selector value to match all traffic.
 * Tag values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), and underscores (`_`).
-* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`_`).
+* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`/`).
 
-Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`_`).
+Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`/`).
 
 All policies support arbitrary tags for the `sources` selector, but there are tag limitations for the `destinations` selector. For example, policies that are applied on the client side of a connection between two dataplane objects do not support arbitrary tags in the `destinations` selector. Only the `kuma.io/service` tag is supported in this case. This includes TrafficRoute, TrafficLog, and HealthCheck.
 

--- a/app/docs/1.6.x/deployments/stand-alone.md
+++ b/app/docs/1.6.x/deployments/stand-alone.md
@@ -67,7 +67,7 @@ When the mode is not specified, Kuma will always start in `standalone` mode by d
 
 #### Control plane offline
 
-* New data planes proxis won't be able to join the mesh.
+* New data plane proxies won't be able to join the mesh.
 * Data-plane proxy configuration will not be updated.
 * Communication between data planes proxies will still work.
 

--- a/app/docs/1.6.x/policies/general-notes-about-kuma-policies.md
+++ b/app/docs/1.6.x/policies/general-notes-about-kuma-policies.md
@@ -27,9 +27,9 @@ Kuma assumes that every dataplane object represents a service, even if it's a cr
 
 * The wildcard character (*) is supported only as the selector value to match all traffic.
 * Tag values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), and underscores (`_`).
-* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`_`).
+* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`/`).
 
-Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`_`).
+Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`/`).
 
 All policies support arbitrary tags for the `sources` selector, but there are tag limitations for the `destinations` selector. For example, policies that are applied on the client side of a connection between two dataplane objects do not support arbitrary tags in the `destinations` selector. Only the `kuma.io/service` tag is supported in this case. This includes TrafficRoute, TrafficLog, and HealthCheck.
 

--- a/app/docs/1.7.x/deployments/stand-alone.md
+++ b/app/docs/1.7.x/deployments/stand-alone.md
@@ -68,7 +68,7 @@ When the mode is not specified, Kuma will always start in `standalone` mode by d
 
 #### Control plane offline
 
-* New data planes proxis won't be able to join the mesh.
+* New data plane proxies won't be able to join the mesh.
 * Data-plane proxy configuration will not be updated.
 * Communication between data planes proxies will still work.
 

--- a/app/docs/1.7.x/policies/general-notes-about-kuma-policies.md
+++ b/app/docs/1.7.x/policies/general-notes-about-kuma-policies.md
@@ -27,9 +27,9 @@ Kuma assumes that every dataplane object represents a service, even if it's a cr
 
 * The wildcard character (*) is supported only as the selector value to match all traffic.
 * Tag values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), and underscores (`_`).
-* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`_`).
+* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`/`).
 
-Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`_`).
+Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`/`).
 
 All policies support arbitrary tags for the `sources` selector, but there are tag limitations for the `destinations` selector. For example, policies that are applied on the client side of a connection between two dataplane objects do not support arbitrary tags in the `destinations` selector. Only the `kuma.io/service` tag is supported in this case. This includes TrafficRoute, TrafficLog, and HealthCheck.
 

--- a/app/docs/1.8.x/deployments/stand-alone.md
+++ b/app/docs/1.8.x/deployments/stand-alone.md
@@ -65,7 +65,7 @@ When the mode is not specified, Kuma will always start in `standalone` mode by d
 
 #### Control plane offline
 
-* New data planes proxis won't be able to join the mesh.
+* New data plane proxies won't be able to join the mesh.
 * Data-plane proxy configuration will not be updated.
 * Communication between data planes proxies will still work.
 

--- a/app/docs/1.8.x/policies/general-notes-about-kuma-policies.md
+++ b/app/docs/1.8.x/policies/general-notes-about-kuma-policies.md
@@ -27,9 +27,9 @@ Kuma assumes that every dataplane object represents a service, even if it's a cr
 
 * The wildcard character (*) is supported only as the selector value to match all traffic.
 * Tag values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), and underscores (`_`).
-* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`_`).
+* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`/`).
 
-Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`_`).
+Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`/`).
 
 All policies support arbitrary tags for the `sources` selector, but there are tag limitations for the `destinations` selector. For example, policies that are applied on the client side of a connection between two dataplane objects do not support arbitrary tags in the `destinations` selector. Only the `kuma.io/service` tag is supported in this case. This includes TrafficRoute, TrafficLog, and HealthCheck.
 

--- a/app/docs/2.0.x/deployments/stand-alone.md
+++ b/app/docs/2.0.x/deployments/stand-alone.md
@@ -67,7 +67,7 @@ When the mode is not specified, {{site.mesh_product_name}} will always start in 
 
 #### Control plane offline
 
-* New data planes proxis won't be able to join the mesh.
+* New data plane proxies won't be able to join the mesh.
 * Data-plane proxy configuration will not be updated.
 * Communication between data planes proxies will still work.
 

--- a/app/docs/2.0.x/policies/general-notes-about-kuma-policies.md
+++ b/app/docs/2.0.x/policies/general-notes-about-kuma-policies.md
@@ -32,9 +32,9 @@ conf:
 
 * The wildcard character (*) is supported only as the selector value to match all traffic.
 * Tag values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), and underscores (`_`).
-* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`_`).
+* Selector values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`). slashes (`/`).
 
-Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`_`).
+Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`/`).
 
 All policies support arbitrary tags for the `sources` selector, but there are tag limitations for the `destinations` selector. For example, policies that are applied on the client side of a connection between two dataplane objects do not support arbitrary tags in the `destinations` selector. Only the `kuma.io/service` tag is supported in this case. This includes TrafficRoute, TrafficLog, and HealthCheck.
 


### PR DESCRIPTION
There are a few minor typos on the Kuma website. 
This PR is to fix those I found when I was reading through the docs.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)
Yes.

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
Yes.