### PR TITLE
fix: sidebar being too tall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 
 # Installs npm packages and gems.
 install: ruby-version-check
-	npm install -g netlify-cli
+	npm install -g netlify-cli@16.5.1
 	yarn install
 	bundle install
 
@@ -35,3 +35,7 @@ serve:
 clean:
 	-rm -rf dist
 	-rm -rf app/.jekyll-cache
+
+kill-ports:
+	@JEKYLL_PROCESS=$$(lsof -ti:4000) && kill -9 $$JEKYLL_PROCESS || true
+	@VITE_PROCESS=$$(lsof -ti:3036) && kill -9 $$VITE_PROCESS || true

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ serve:
 clean:
 	-rm -rf dist
 	-rm -rf app/.jekyll-cache
+	-rm -rf app/.jekyll-metadata
+	-rm -rf .jekyll-cache/vite
 
 kill-ports:
 	@JEKYLL_PROCESS=$$(lsof -ti:4000) && kill -9 $$JEKYLL_PROCESS || true

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /usr/bin/env bash
+
 define newline
 
 

--- a/app/_assets/styles/custom/components/_sidebar.scss
+++ b/app/_assets/styles/custom/components/_sidebar.scss
@@ -1,6 +1,6 @@
-// 
+//
 // Sidebarm, sidebar button
-// 
+//
 
 $sidebar-width: $sidebarWidth; // comes from VuePress core styles
 $sidebar-top-spacing: $navbar-height-large;
@@ -13,36 +13,20 @@ $sidebar-button-left-spacing: 1.5rem;
 
 // Sidebar
 
-.sidebar-wrapper {
-  position: relative;
-
-  &:after {
-    position: absolute;
-    top: 0; right: 0; bottom: 0;
-    z-index: 0;
-    display: block;
-    height: 100%;
-    width: 100vw;
-    content: "";
-    background-color: $gray-1;
-  }
-}
-
 .sidebar {
   position: fixed;
   top: 0;
+  bottom: 0;
+  overflow-y: auto;
   left: auto;
-  overflow-x: visible !important;
   background: none;
-  // background-color: #fff;
   font-size: $base-font-size;
   width: $sidebar-width;
-  padding-top: $sidebar-top-spacing;
 
   .nav-item {
     margin: 0;
-    
-    > a {
+
+    >a {
       padding: 1rem;
     }
   }
@@ -61,10 +45,6 @@ $sidebar-button-left-spacing: 1.5rem;
   }
 }
 
-.sidebar-links {
-  
-}
-
 a.sidebar-link {
 
   &:hover {
@@ -80,7 +60,7 @@ a.sidebar-link {
 // Sidebar button
 
 .sidebar-button {
-  top: calc( (#{$navbarHeight} / 2) - (#{$sidebar-button-size} / 2) );
+  top: calc((#{$navbarHeight} / 2) - (#{$sidebar-button-size} / 2));
   left: $sidebar-button-left-spacing;
   display: none;
   padding: 0;
@@ -105,14 +85,9 @@ a.sidebar-link {
 @media (min-width: $MQNarrowMid + 1) {
   .sidebar {
     position: sticky;
-    // top: $navbarHeight;
-    left: auto;
-    bottom: auto;
-    // padding-top: $navbarHeight;
-  }
-
-  .page {
-    // padding-left: 15rem;
+    top: $navbarHeight;
+    bottom: 0;
+    height: calc(100vh - #{$navbarHeight});
   }
 
   .theme-container.no-sidebar .sidebar {

--- a/app/_assets/styles/vuepress-core/sidebar.scss
+++ b/app/_assets/styles/vuepress-core/sidebar.scss
@@ -23,8 +23,6 @@
   }
   & > .sidebar-links {
     padding: 1.5rem 0;
-    overflow-y: scroll;
-    height: 100vh;
 
     & > li > a.sidebar-link {
       font-size: 1.1em;

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -74,6 +74,13 @@ mesh_product_name_path: kuma
 mesh_namespace: kuma-system
 mesh_cp_name: kuma-control-plane
 mesh_base_url: https://kuma.io
+# Prefix for the values of "--set" flag for "kumactl install [...]" or
+# "helm install [...]" commands.
+# It's useful for projects based on Kuma, which expects Kuma options
+# to be prefixed with for example "kuma."
+# kumactl install control-plane \
+#   --set "{{site.set_flag_values_prefix}}experimental.ebpf.enabled=true"
+set_flag_values_prefix: ""
 
 # Helm commands
 mesh_helm_repo: kuma/kuma

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -72,11 +72,11 @@ include:
   - installer.sh
   - robots.txt
 
+# Product name variables
 mesh_product_name: Kuma
 mesh_product_name_path: kuma
 mesh_namespace: kuma-system
 mesh_cp_name: kuma-control-plane
-# Product name variables
 # Prefix for the values of "--set" flag for "kumactl install [...]" or
 # "helm install [...]" commands.
 # It's useful for projects based on Kuma, which expects Kuma options


### PR DESCRIPTION
## Changes

Fixes the sidebar being too tall which messes up the scrolling behavior: one currently often needs to scroll all the way to the bottom of the page to see the bottom items of the sidebar. This PR changes the sidebar behavior so that the sidebar can always be scrolled individually regardless of the main content height.

Resolves #1321.

## Notes

I made some development setup-related changes that I ran into while working on this.

One note on the development setup using `make run`: I had trouble getting things working and ultimately, with the help of @fabianrbz, got a working development server working by removing `netlify: sleep 50 && netlify dev` from the `Procfile`. I haven’t committed this change here because I’m not entirely sure what it implies.