### PR TITLE
docs(policies): name has to be defined with a bunch of kinds

### DIFF
--- a/app/_src/policies/targetref.md
+++ b/app/_src/policies/targetref.md
@@ -139,7 +139,7 @@ It looks like:
 ```yaml
 targetRef:
   kind: Mesh | MeshSubset | MeshService | MeshServiceSubset | MeshGatewayRoute
-  name: "my-name" # For kinds MeshService, MeshServiceSubset and MeshGatewayRoute a name can be defined
+  name: "my-name" # For kinds MeshService, MeshServiceSubset and MeshGatewayRoute a name has to be defined
   tags:
     key: value # For kinds MeshServiceSubset and MeshSubset a list of matching tags can be used
 ```


### PR DESCRIPTION
The name has to be there for MeshService, MeshServiceSubset and MeshGatewayRoute