### PR TITLE
docs(tproxy): improve tproxy instructions

### DIFF
--- a/.github/styles/Vocab/Base/accept.txt
+++ b/.github/styles/Vocab/Base/accept.txt
@@ -49,6 +49,7 @@ endunless
 endwarning
 etcd
 Fargate
+firewalld
 GAMMA
 Gateway API
 GitHub

--- a/app/_src/production/dp-config/transparent-proxying.md
+++ b/app/_src/production/dp-config/transparent-proxying.md
@@ -38,7 +38,7 @@ The host that will run the `kuma-dp` process in transparent proxying mode needs 
 
 1. Use proper version of iptables
     
-    {{site.mesh_product_name}} [is not yet compatible](https://github.com/kumahq/kuma/issues/8293) with `nf_tables`. You can check the version of iptables with the following command
+    {{site.mesh_product_name}} [isn't yet compatible](https://github.com/kumahq/kuma/issues/8293) with `nf_tables`. You can check the version of iptables with the following command
     ```sh
     $ iptables --version
     iptables v1.8.7 (nf_tables)
@@ -71,10 +71,10 @@ The host that will run the `kuma-dp` process in transparent proxying mode needs 
 {% warning %}
 Please note that this command **will change** the host `iptables` rules.
 
-We exclude port 22, so we can SSH to the machine without `kuma-dp` running.
+The command excludes port 22, so you can SSH to the machine without `kuma-dp` running.
 {% endwarning %}
 
-The changes will not persist over restarts. You need to either add this command to your start scripts or use firewalld.
+The changes won't persist over restarts. You need to either add this command to your start scripts or use firewalld.
 
 ### Data plane proxy resource
 
@@ -142,7 +142,7 @@ ip6tables -t nat -X
 ip6tables -t raw -F
 ip6tables -t raw -X
 ```
-Be aware that the command above with remove all iptables rules, not only created by {{site.mesh_product_name}}. 
+Be aware that this command removes all iptables rules, not only created by {{site.mesh_product_name}}. 
 
 In the future release, `kumactl` [will ship](https://github.com/kumahq/kuma/issues/8071) with `uninstall` command.
 

--- a/app/_src/production/dp-config/transparent-proxying.md
+++ b/app/_src/production/dp-config/transparent-proxying.md
@@ -40,18 +40,18 @@ The host that will run the `kuma-dp` process in transparent proxying mode needs 
     
     {{site.mesh_product_name}} [isn't yet compatible](https://github.com/kumahq/kuma/issues/8293) with `nf_tables`. You can check the version of iptables with the following command
     ```sh
-    $ iptables --version
-    iptables v1.8.7 (nf_tables)
+    iptables --version
+    # iptables v1.8.7 (nf_tables)
     ```
     
     On the recent versions of Ubuntu, you need to change default `iptables`.
     
     ```sh
-    $ update-alternatives --set iptables /usr/sbin/iptables-legacy
-    $ update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-    $ iptables --version
-    iptables v1.8.7 (legacy)
-```
+    update-alternatives --set iptables /usr/sbin/iptables-legacy
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+    iptables --version
+    # iptables v1.8.7 (legacy)
+    ```
 
 2. Create a new dedicated user on the machine.
 
@@ -132,17 +132,20 @@ If you run `firewalld` to manage firewalls and wrap iptables, add the `--store-f
 Before upgrading to the next version of {{site.mesh_product_name}}, it's best to clean existing `iptables` rules and only then replace the `kumactl` binary.
 
 You can clean the rules either by restarting the host or by running following commands
+
+{% warning %}
+Executing these commands will remove all iptables rules, including those created by {{site.mesh_product_name}} and any other applications or services.
+{% endwarning %}
+
 ```sh
-iptables -t nat -F
-iptables -t nat -X
-iptables -t raw -F
-iptables -t raw -X
-ip6tables -t nat -F
-ip6tables -t nat -X
-ip6tables -t raw -F
-ip6tables -t raw -X
-```
-Be aware that this command removes all iptables rules, not only created by {{site.mesh_product_name}}. 
+iptables --table nat --flush
+iptables --table raw --flush
+ip6tables --table nat --flush
+ip6tables --table raw --flush
+iptables --table nat --delete-chain
+iptables --table raw --delete-chain
+ip6tables --table nat --delete-chain
+ip6tables --table raw --delete-chain
 
 In the future release, `kumactl` [will ship](https://github.com/kumahq/kuma/issues/8071) with `uninstall` command.
 


### PR DESCRIPTION
A bunch of improvements to docs to be able to actually run this on Ubuntu.
* How to replace `iptables` with supported version
* Drop `--skip-resolve-conf`, it says it's deprecated
* Add port `22` to exclude by default. Users will use this doc as a guide. I was locked out from the VM
* `iptables` are not preserved on the machine by default
* `uninstall` command does not exist. There is no point in referencing it until we get this done.
* Template of DPP was broken
* Added clarification that the service itself has to be run as any other user (a user was recently confused about this)

Additionally, I had problems with installation that I had to provide `--wait=0`. This should be fixed by https://github.com/kumahq/kuma/pull/8364

Fix #1528