### PR TITLE
Fix cpinstall tag for kong-mesh

### DIFF
--- a/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/cpinstall.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/cpinstall.rb
@@ -22,6 +22,7 @@ module Jekyll
             content = super
             return "" unless content != ""
             site_data = context.registers[:site].config
+            page = context.environments.first['page']
 
             opts = content.strip.split("\n").map do |x|
                 x = site_data['set_flag_values_prefix'] + x if @prefixed
@@ -39,7 +40,7 @@ kumactl install control-plane \\
 ```
 {% endtab %}
 {% tab #{@tabs_name} helm %}
-Before using {{site.mesh_product_name}} with helm, please follow [these steps](/docs/{{ page.version }}/production/cp-deployment/kubernetes/#helm) to configure your local helm repo.
+Before using {{site.mesh_product_name}} with helm, please follow [these steps](/#{product_url_segment(page)}/{{ page.release }}/production/cp-deployment/kubernetes/#helm) to configure your local helm repo.
 ```shell
 helm install --create-namespace --namespace {{site.mesh_namespace}} \\
   #{res} \\
@@ -48,6 +49,10 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} \\
 {% endtab %}
 {% endtabs %}"
             ::Liquid::Template.parse(htmlContent).render(context)
+          end
+
+          def product_url_segment(page)
+            page['dir'].split('/')[1]
           end
         end
       end


### PR DESCRIPTION
There's a slight difference between Kuma and Kong Mesh regarding the base segment of the docs' URL.
For Kuma, all the docs live under `/docs/`. Unfortunately, that's not the case for Kong Mesh. Kong docs renders multiple products, so we namespace the docs with the corresponding product name, i.e. they live under `/mesh/`.

This commit updates the tag's code so that it uses the base path in which the page is generated as the first URL segment. That way we can re-use the code on both platforms.

It also modifies the rendered link, so that it uses `page.release` instead of `page.version` to work for both docs sites.

### Steps to Reproduce
Visit [multi-zone deployments](https://docs.konghq.com/mesh/latest/production/cp-deployment/multi-zone/) and choose `helm`. The `follow these steps` link is broken.

<img width="1356" alt="Screenshot 2023-11-16 at 11 29 09" src="https://github.com/kumahq/kuma-website/assets/715229/225f82f7-1f66-46a2-a9a1-9acf62305958">


Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
