### PR TITLE
docs(kuma-requirements): update sidecar container default cpu limit

### DIFF
--- a/app/_src/introduction/kuma-requirements.md
+++ b/app/_src/introduction/kuma-requirements.md
@@ -51,7 +51,7 @@ resources:
         cpu: 50m
         memory: 64Mi
     limits:
-        cpu: 500m
+        cpu: 1000m
         memory: 512Mi
 ```
 


### PR DESCRIPTION
Per [Code](https://github.com/kumahq/kuma/blob/2.5.1/pkg/config/plugins/runtime/k8s/config.go#L54-L61) the default CPU limit for Sidecar Container is 1000m. 

This PR will correct the typo in the documentation.