### PR TITLE
docs(transparent-proxy): fix broken link

### DIFF
--- a/app/_src/production/dp-config/transparent-proxying.md
+++ b/app/_src/production/dp-config/transparent-proxying.md
@@ -12,11 +12,11 @@ Transparent proxying helps with a smoother rollout of a Service Mesh to a curren
 On **Kubernetes** `kuma-dp` leverages transparent proxying automatically via `iptables` installed with `kuma-init` container or CNI.
 All incoming and outgoing traffic is automatically intercepted by `kuma-dp` without having to change the application code.
 
-{{site.mesh_product_name}} integrates with a service naming provided by Kubernetes DNS as well as providing its own [{{site.mesh_product_name}} DNS](/docs/{{ page.version }}/networking/dns) for multizone service naming.
+{{site.mesh_product_name}} integrates with a service naming provided by Kubernetes DNS as well as providing its own [{{site.mesh_product_name}} DNS](/docs/{{ page.version }}/networking/dns) for multi-zone service naming.
 
 ## Universal
 
-On **Universal** `kuma-dp` leverages the [data plane proxy specification]{%if_version lte:2.1.x %}(/docs/{{ page.version }}/explore/dpp-on-universal/){%endif_version%}{%if_version gte:2.2.x %}(/docs/{{ page.version }}/production/dp-config/dpp-on-universal#dataplane-configuration){%endif_version%} associated to it for receiving incoming requests on a pre-defined port.
+On **Universal** `kuma-dp` leverages the {%if_version lte:2.1.x %}[data plane proxy specification](/docs/{{ page.version }}/explore/dpp-on-universal/){%endif_version%}{%if_version gte:2.2.x %}[data plane proxy specification](/docs/{{ page.version }}/production/dp-config/dpp-on-universal#dataplane-configuration){%endif_version%} associated to it for receiving incoming requests on a pre-defined port.
 
 There are several advantages for using transparent proxying in universal mode:
 
@@ -169,7 +169,7 @@ spec:
     metadata:
       ...
       annotations:
-        # all incomming connections on ports 1234 won't be intercepted by Envoy
+        # all incoming connections on ports 1234 won't be intercepted by Envoy
         traffic.kuma.io/exclude-inbound-ports: "1234"
         # all outgoing connections on ports 5678, 8900 won't be intercepted by Envoy
         traffic.kuma.io/exclude-outbound-ports: "5678,8900"
@@ -244,7 +244,7 @@ networking:
 
 ### Transparent Proxy with eBPF (experimental)
 
-Starting from {{site.mesh_product_name}} 2.0 you can setup transparent proxy to use eBPF instead of iptables.
+Starting from {{site.mesh_product_name}} 2.0 you can set up transparent proxy to use eBPF instead of iptables.
 
 {% warning %}
 To use Transparent Proxy with eBPF your environment has to use `Kernel >= 5.7`

--- a/app/_src/production/dp-config/transparent-proxying.md
+++ b/app/_src/production/dp-config/transparent-proxying.md
@@ -37,21 +37,22 @@ Prerequisites:
 The host that will run the `kuma-dp` process in transparent proxying mode needs to be prepared with the following steps executed as `root`:
 
 1. Use proper version of iptables
-    
-    {{site.mesh_product_name}} [isn't yet compatible](https://github.com/kumahq/kuma/issues/8293) with `nf_tables`. You can check the version of iptables with the following command
-    ```sh
-    iptables --version
-    # iptables v1.8.7 (nf_tables)
-    ```
-    
-    On the recent versions of Ubuntu, you need to change default `iptables`.
-    
-    ```sh
-    update-alternatives --set iptables /usr/sbin/iptables-legacy
-    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-    iptables --version
-    # iptables v1.8.7 (legacy)
-    ```
+
+   {{site.mesh_product_name}} [isn't yet compatible](https://github.com/kumahq/kuma/issues/8293) with `nf_tables`. You can check the version of iptables with the following command
+
+   ```sh
+   iptables --version
+   # iptables v1.8.7 (nf_tables)
+   ```
+
+   On the recent versions of Ubuntu, you need to change default `iptables`.
+
+   ```sh
+   update-alternatives --set iptables /usr/sbin/iptables-legacy
+   update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+   iptables --version
+   # iptables v1.8.7 (legacy)
+   ```
 
 2. Create a new dedicated user on the machine.
 
@@ -146,6 +147,7 @@ iptables --table nat --delete-chain
 iptables --table raw --delete-chain
 ip6tables --table nat --delete-chain
 ip6tables --table raw --delete-chain
+```
 
 In the future release, `kumactl` [will ship](https://github.com/kumahq/kuma/issues/8071) with `uninstall` command.
 
@@ -157,6 +159,7 @@ In the future release, `kumactl` [will ship](https://github.com/kumahq/kuma/issu
 {% tab intercepted-traffic Kubernetes %}
 
 By default, all the traffic is intercepted by Envoy. You can exclude which ports are intercepted by Envoy with the following annotations placed on the Pod
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -179,6 +182,7 @@ spec:
 ```  
 
 You can also control this value on whole {{site.mesh_product_name}} deployment with the following {{site.mesh_product_name}} CP [configuration](/docs/{{ page.version }}/documentation/configuration)
+
 ```
 KUMA_RUNTIME_KUBERNETES_SIDECAR_TRAFFIC_EXCLUDE_INBOUND_PORTS=1234
 KUMA_RUNTIME_KUBERNETES_SIDECAR_TRAFFIC_EXCLUDE_OUTBOUND_PORTS=5678,8900


### PR DESCRIPTION
- Fixes broken link in the transparent proxying docs
- Fixes few small spelling mistakes and typo
- Adds missing code block closing <code>```</code>
- Removes additional space before some of the code blocks in one of the lists

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
