### PR TITLE
fix(virtualOutbound): use k8s.kuma.io/service-port in examples

### DIFF
--- a/app/_src/policies/virtual-outbound.md
+++ b/app/_src/policies/virtual-outbound.md
@@ -61,7 +61,7 @@ spec:
       - name: service
         tagKey: "kuma.io/service"
       - name: port
-        tagKey: port
+        tagKey: "k8s.kuma.io/service-port
       - name: v
         tagKey: version
 ```


### PR DESCRIPTION
It was confusing to users that we're not using a label that exists.

<Explain your change!>

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
