### PR TITLE
Update multi-zone.md

### DIFF
--- a/app/_src/production/cp-deployment/multi-zone.md
+++ b/app/_src/production/cp-deployment/multi-zone.md
@@ -149,10 +149,23 @@ Before using {{site.mesh_product_name}} with helm, please follow [these steps](/
 
 {% tab global-control-plane Universal %}
 
+{% tip %}
+When running the global control plane in Universal mode, a database must be used to persist state for production deployments.
+Ensure that migrations have been run against the database prior to running the global control plane.
+{% endtip %}
+
 1.  Set up the global control plane, and add the `global` environment variable:
 
     ```sh
-    KUMA_MODE=global kuma-cp run
+    KUMA_MODE=global 
+    KUMA_ENVIRONMENT=universal \
+    KUMA_STORE_TYPE=postgres \
+    KUMA_STORE_POSTGRES_HOST=<postgres-host> \
+    KUMA_STORE_POSTGRES_PORT=<postgres-port> \
+    KUMA_STORE_POSTGRES_USER=<postgres-user> \
+    KUMA_STORE_POSTGRES_PASSWORD=<postgres-password> \
+    KUMA_STORE_POSTGRES_DB_NAME=<postgres-db-name> \
+    kuma-cp run
     ```
 
 {% endtab %}
@@ -200,23 +213,41 @@ For production use a certificate signed by a trusted CA. See [Secure access acro
 {% endtab %}
 {% tab zone-control-planes Universal %}
 
+{% tip %}
+When running the zone control plane in Universal mode, a database must be used to persist state for production deployments.
+Ensure that migrations have been run against the database prior to running the zone control plane.
+{% endtip %}
+
 1. On each zone control plane, run:
 
    {% if_version gte:2.3.x %}
    ```sh
-   KUMA_MODE=zone \
-   KUMA_MULTIZONE_ZONE_NAME=<zone-name> \
-   KUMA_MULTIZONE_ZONE_KDS_TLS_SKIP_VERIFY=true \
-   KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS=grpcs://<global-kds-address>:5685 \
-   ./kuma-cp run
+    KUMA_MODE=zone \
+    KUMA_MULTIZONE_ZONE_NAME=<zone-name> \
+    KUMA_ENVIRONMENT=universal \
+    KUMA_STORE_TYPE=postgres \
+    KUMA_STORE_POSTGRES_HOST=<postgres-host> \
+    KUMA_STORE_POSTGRES_PORT=<postgres-port> \
+    KUMA_STORE_POSTGRES_USER=<postgres-user> \
+    KUMA_STORE_POSTGRES_PASSWORD=<postgres-password> \
+    KUMA_STORE_POSTGRES_DB_NAME=<postgres-db-name> \
+    KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS=grpcs://<global-kds-address>:5685 \
+    kuma-cp run
    ```
    {% endif_version %}
    {% if_version lte:2.2.x %}
    ```sh
-   KUMA_MODE=zone \
-   KUMA_MULTIZONE_ZONE_NAME=<zone-name> \
-   KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS=grpcs://<global-kds-address>:5685 \
-   ./kuma-cp run
+    KUMA_MODE=zone \
+    KUMA_MULTIZONE_ZONE_NAME=<zone-name> \
+    KUMA_ENVIRONMENT=universal \
+    KUMA_STORE_TYPE=postgres \
+    KUMA_STORE_POSTGRES_HOST=<postgres-host> \
+    KUMA_STORE_POSTGRES_PORT=<postgres-port> \
+    KUMA_STORE_POSTGRES_USER=<postgres-user> \
+    KUMA_STORE_POSTGRES_PASSWORD=<postgres-password> \
+    KUMA_STORE_POSTGRES_DB_NAME=<postgres-db-name> \
+    KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS=grpcs://<global-kds-address>:5685 \
+    kuma-cp run
    ```
    {% endif_version %}
 


### PR DESCRIPTION
Updated the multi-zone deployment section to include more detailed steps for connecting the control plane to a database. This addresses the requirement for production deployments to not use an in-memory datastore. 

- [x] Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)
- [x] Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?