### PR TITLE
feat(quickstart): rewrite kubernetes quickstart

### DIFF
--- a/app/_data/docs_nav_kuma_dev.yml
+++ b/app/_data/docs_nav_kuma_dev.yml
@@ -25,6 +25,26 @@ items:
         url: /docs/changelog/
         absolute_url: true
         generate: false
+  - title: Quickstart
+    group: true
+    items:
+      - text: Deploy Kuma on Kubernetes
+        url: /quickstart/kubernetes-demo
+        items:
+          - text: Prerequisites
+            url: "/quickstart/kubernetes-demo/#prerequisites"
+          - text: Start Kubernetes cluster
+            url: "/quickstart/kubernetes-demo/#start-kubernetes-cluster"
+          - text: Install Kuma
+            url: "/quickstart/kubernetes-demo/#install-kuma"
+          - text: Deploy demo application
+            url: "/quickstart/kubernetes-demo/#deploy-demo-application"
+          - text: Explore GUI
+            url: "/quickstart/kubernetes-demo/#explore-gui"
+          - text: Introduce zero-trust security
+            url: "/quickstart/kubernetes-demo/#introduce-zero-trust-security"
+          - text: Next steps
+            url: "/quickstart/kubernetes-demo/#next-steps"
   - title: Kuma in Production
     group: true
     items:
@@ -106,47 +126,6 @@ items:
             url: /production/upgrades-tuning/fine-tuning/
       - text: Init containers
         url: /production/init-containers/
-  - title: Deploy
-    group: true
-    items:
-      - text: Explore Kuma with the Kubernetes demo app
-        url: /quickstart/kubernetes/
-        items:
-          - text: Prerequisites
-            url: "/quickstart/kubernetes/#prerequisites"
-          - text: Set up and run
-            url: "/quickstart/kubernetes/#set-up-and-run"
-          - text: Explore the mesh
-            url: "/quickstart/kubernetes/#explore-the-mesh"
-          - text: Enable Mutual TLS and Traffic Permissions
-            url: "/quickstart/kubernetes/#enable-mutual-tls-and-traffic-permissions"
-          - text: Builtin gateways
-            url: "/quickstart/kubernetes/#builtin-gateways"
-          - text: Explore Observability features
-            url: "/quickstart/kubernetes/#explore-observability-features"
-          - text: Next steps
-            url: "/quickstart/kubernetes/#next-steps"
-      - text: Explore Kuma with the Universal demo app
-        url: /quickstart/universal/
-        items:
-          - text: Prerequisites
-            url: "/quickstart/universal/#prerequisites"
-          - text: Set up
-            url: "/quickstart/universal/#set-up"
-          - text: Generate tokens
-            url: "/quickstart/universal/#generate-tokens"
-          - text: Create a data plane proxy for each service
-            url: "/quickstart/universal/#create-a-data-plane-proxy-for-each-service"
-          - text: Run
-            url: "/quickstart/universal/#run"
-          - text: Explore the mesh
-            url: "/quickstart/universal/#explore-the-mesh"
-          - text: Enable Mutual TLS and Traffic Permissions
-            url: "/quickstart/universal/#enable-mutual-tls-and-traffic-permissions"
-          - text: Explore Traffic Metrics
-            url: "/quickstart/universal/#explore-traffic-metrics"
-          - text: Next steps
-            url: "/quickstart/universal/#next-steps"
   - title: Explore
     group: true
     items:

--- a/app/_src/documentation/configuration.md
+++ b/app/_src/documentation/configuration.md
@@ -36,7 +36,7 @@ controlPlane:
 and then specify it in the helm install command:
 
 ```sh
-helm install -f values.yaml {{ site.kuma_install_name }} {{ site.mesh_helm_repo }}
+helm install -f values.yaml {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }}
 ```
 
 If you have a lot of configuration you can just write them all in a YAML file and use:

--- a/app/_src/explore/gateway.md
+++ b/app/_src/explore/gateway.md
@@ -230,7 +230,7 @@ To configure your gateway {{site.mesh_product_name}} has these resources:
 ### Usage
 
 You can create and configure a gateway that listens for traffic from outside of your mesh
-and forwards it to the [demo app frontend](/docs/dev/quickstart/kubernetes{% if_version gte:2.6.x %}-demo{% endif_version %}/).
+and forwards it to the [demo app frontend](/docs/{{ page.version }}/quickstart/kubernetes{% if_version gte:2.6.x %}-demo{% endif_version %}/).
 
 {% tabs setup useUrlFragment=false %}
 {% tab setup Kubernetes %}

--- a/app/_src/explore/gateway.md
+++ b/app/_src/explore/gateway.md
@@ -230,7 +230,7 @@ To configure your gateway {{site.mesh_product_name}} has these resources:
 ### Usage
 
 You can create and configure a gateway that listens for traffic from outside of your mesh
-and forwards it to the [demo app frontend](/docs/{{ page.version }}/quickstart/kubernetes{% if_version gte:2.6.x %}-demo{% endif_version %}/).
+and forwards it to the {% if_version gte:2.6.x %}[demo app frontend](/docs/{{ page.version }}/quickstart/kubernetes-demo/){% endif_version %}{% if_version lte:2.5.x %}[demo app frontend](/docs/{{ page.version }}/quickstart/kubernetes/){% endif_version %}.
 
 {% tabs setup useUrlFragment=false %}
 {% tab setup Kubernetes %}

--- a/app/_src/explore/gateway.md
+++ b/app/_src/explore/gateway.md
@@ -230,7 +230,7 @@ To configure your gateway {{site.mesh_product_name}} has these resources:
 ### Usage
 
 You can create and configure a gateway that listens for traffic from outside of your mesh
-and forwards it to the [demo app frontend](https://kuma.io/docs/dev/quickstart/kubernetes/).
+and forwards it to the [demo app frontend](/docs/dev/quickstart/kubernetes{% if_version gte:2.6.x %}-demo{% endif_version %}/).
 
 {% tabs setup useUrlFragment=false %}
 {% tab setup Kubernetes %}

--- a/app/_src/index.md
+++ b/app/_src/index.md
@@ -21,7 +21,7 @@ The core maintainer of Kuma is **Kong**, the maker of the popular open-source Ko
 
 [Install Kuma](/install/latest/)
 
-[Jump to the quickstart](/docs/{{ page.version }}/quickstart/kubernetes{% if_version gte:2.6.x %}-demo{% endif_version %})
+[Jump to quickstart](/docs/{{ page.version }}/quickstart/kubernetes/)
 
 [Explore the API](/docs/{{ page.version }}/reference/http-api)
 {% endif_version %}
@@ -32,7 +32,7 @@ The core maintainer of Kuma is **Kong**, the maker of the popular open-source Ko
 
 [Install Kuma](/install/latest/)
 
-[Jump to the quickstart](/docs/{{ page.version }}/quickstart/kubernetes{% if_version gte:2.6.x %}-demo{% endif_version %})
+{% if_version gte:2.6.x %}[Jump to quickstart](/docs/{{ page.version }}/quickstart/kubernetes-demo/){% endif_version %}{% if_version lte:2.5.x %}[Jump to quickstart](/docs/{{ page.version }}/quickstart/kubernetes/){% endif_version %}
 
 [Explore the API](/docs/{{ page.version }}/reference/http-api)
 {% endif_version %}

--- a/app/_src/index.md
+++ b/app/_src/index.md
@@ -21,7 +21,7 @@ The core maintainer of Kuma is **Kong**, the maker of the popular open-source Ko
 
 [Install Kuma](/install/latest/)
 
-[Jump to the quickstart](/docs/{{ page.version }}/quickstart/kubernetes)
+[Jump to the quickstart](/docs/{{ page.version }}/quickstart/kubernetes{% if_version gte:2.6.x %}-demo{% endif_version %})
 
 [Explore the API](/docs/{{ page.version }}/reference/http-api)
 {% endif_version %}
@@ -32,7 +32,7 @@ The core maintainer of Kuma is **Kong**, the maker of the popular open-source Ko
 
 [Install Kuma](/install/latest/)
 
-[Jump to the quickstart](/docs/{{ page.version }}/quickstart/kubernetes)
+[Jump to the quickstart](/docs/{{ page.version }}/quickstart/kubernetes{% if_version gte:2.6.x %}-demo{% endif_version %})
 
 [Explore the API](/docs/{{ page.version }}/reference/http-api)
 {% endif_version %}

--- a/app/_src/installation/docker.md
+++ b/app/_src/installation/docker.md
@@ -142,4 +142,4 @@ You will notice that {{site.mesh_product_name}} automatically creates a {% if_ve
 
 Congratulations! You have successfully installed {{site.mesh_product_name}} on Docker 🚀.
 
-In order to start using {{site.mesh_product_name}}, it's time to check out the [quickstart guide for Universal](/docs/{{ page.version }}/quickstart/universal/) deployments. If you are using Docker you may also be interested in checking out the [Kubernetes quickstart](/docs/{{ page.version }}/quickstart/kubernetes/) as well.
+In order to start using {{site.mesh_product_name}}, it's time to check out the [quickstart guide for Universal](/docs/{{ page.version }}/quickstart/universal/) deployments. If you are using Docker you may also be interested in checking out the [Kubernetes quickstart](/docs/{{ page.version }}/quickstart/kubernetes{% if_version gte:2.6.x %}-demo{% endif_version %}/) as well.

--- a/app/_src/installation/docker.md
+++ b/app/_src/installation/docker.md
@@ -142,4 +142,4 @@ You will notice that {{site.mesh_product_name}} automatically creates a {% if_ve
 
 Congratulations! You have successfully installed {{site.mesh_product_name}} on Docker 🚀.
 
-In order to start using {{site.mesh_product_name}}, it's time to check out the [quickstart guide for Universal](/docs/{{ page.version }}/quickstart/universal/) deployments. If you are using Docker you may also be interested in checking out the [Kubernetes quickstart](/docs/{{ page.version }}/quickstart/kubernetes{% if_version gte:2.6.x %}-demo{% endif_version %}/) as well.
+In order to start using {{site.mesh_product_name}}, it's time to check out the [quickstart guide for Universal](/docs/{{ page.version }}/quickstart/universal/) deployments. If you are using Docker you may also be interested in checking out the {% if_version gte:2.6.x %}[Kubernetes quickstart](/docs/{{ page.version }}/quickstart/kubernetes-demo/){% endif_version %}{% if_version lte:2.5.x %}[Kubernetes quickstart](/docs/{{ page.version }}/quickstart/kubernetes/){% endif_version %} as well.

--- a/app/_src/installation/helm.md
+++ b/app/_src/installation/helm.md
@@ -44,7 +44,7 @@ This example will run {{site.mesh_product_name}} in `standalone` mode for a "fla
 
 Congratulations! You have successfully installed {{site.mesh_product_name}} on Kubernetes 🚀. 
 
-In order to start using {{site.mesh_product_name}}, it's time to check out the [quickstart guide for Kubernetes](/docs/{{ page.version }}/quickstart/kubernetes{% if_version gte:2.6.x %}-demo{% endif_version %}/) deployments.
+In order to start using {{site.mesh_product_name}}, it's time to check out the {% if_version gte:2.6.x %}[quickstart guide](/docs/{{ page.version }}/quickstart/kubernetes-demo/){% endif_version %}{% if_version lte:2.5.x %}[quickstart guide](/docs/{{ page.version }}/quickstart/kubernetes/){% endif_version %} deployments.
 
 ## Argo CD
 

--- a/app/_src/installation/helm.md
+++ b/app/_src/installation/helm.md
@@ -44,7 +44,7 @@ This example will run {{site.mesh_product_name}} in `standalone` mode for a "fla
 
 Congratulations! You have successfully installed {{site.mesh_product_name}} on Kubernetes 🚀. 
 
-In order to start using {{site.mesh_product_name}}, it's time to check out the [quickstart guide for Kubernetes](/docs/{{ page.version }}/quickstart/kubernetes/) deployments.
+In order to start using {{site.mesh_product_name}}, it's time to check out the [quickstart guide for Kubernetes](/docs/{{ page.version }}/quickstart/kubernetes{% if_version gte:2.6.x %}-demo{% endif_version %}/) deployments.
 
 ## Argo CD
 

--- a/app/_src/installation/openshift.md
+++ b/app/_src/installation/openshift.md
@@ -171,7 +171,7 @@ If namespace is not configured properly, we will see following error on the `Dep
 
 Congratulations! You have successfully installed {{site.mesh_product_name}} on OpenShift 🚀.
 
-In order to start using {{site.mesh_product_name}}, it's time to check out the [quickstart guide for Kubernetes](/docs/{{ page.version }}/quickstart/kubernetes{% if_version gte:2.6.x %}-demo{% endif_version %}/) deployments.
+In order to start using {{site.mesh_product_name}}, it's time to check out the {% if_version gte:2.6.x %}[quickstart guide](/docs/{{ page.version }}/quickstart/kubernetes-demo/){% endif_version %}{% if_version lte:2.5.x %}[quickstart guide](/docs/{{ page.version }}/quickstart/kubernetes/){% endif_version %} deployments.
 
 {% tip %}
 Before running {{site.mesh_product_name}} Demo in the Quickstart, remember to run the following command

--- a/app/_src/installation/openshift.md
+++ b/app/_src/installation/openshift.md
@@ -171,7 +171,7 @@ If namespace is not configured properly, we will see following error on the `Dep
 
 Congratulations! You have successfully installed {{site.mesh_product_name}} on OpenShift 🚀.
 
-In order to start using {{site.mesh_product_name}}, it's time to check out the [quickstart guide for Kubernetes](/docs/{{ page.version }}/quickstart/kubernetes/) deployments.
+In order to start using {{site.mesh_product_name}}, it's time to check out the [quickstart guide for Kubernetes](/docs/{{ page.version }}/quickstart/kubernetes{% if_version gte:2.6.x %}-demo{% endif_version %}/) deployments.
 
 {% tip %}
 Before running {{site.mesh_product_name}} Demo in the Quickstart, remember to run the following command

--- a/app/_src/quickstart/kubernetes-demo.md
+++ b/app/_src/quickstart/kubernetes-demo.md
@@ -31,7 +31,7 @@ Install Kuma control plane with Helm by executing:
 ```sh
 helm repo add kuma https://kumahq.github.io/charts
 helm repo update
-helm install --create-namespace --namespace {{site.mesh_namespace}} {{ site.kuma_install_name }} {{ site.mesh_helm_repo }}
+helm install --create-namespace --namespace {{site.mesh_namespace}} {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }}
 ```
 
 ## Deploy demo application

--- a/app/_src/quickstart/kubernetes-demo.md
+++ b/app/_src/quickstart/kubernetes-demo.md
@@ -41,13 +41,13 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} {{ site.kuma
     kubectl apply -f https://raw.githubusercontent.com/kumahq/kuma-counter-demo/master/demo.yaml
     ```
 
-2.  Port forward the service to the namespace on port 5000:
+2.  Port-forward the service to the namespace on port 5000:
 
     ```sh
     kubectl port-forward svc/demo-app -n kuma-demo 5000:5000
     ```
 
-3.  In a browser, go to `127.0.0.1:5000` and increment the counter.
+3.  In a browser, go to [127.0.0.1:5000](http://127.0.0.1:5000) and increment the counter.
 
 The demo app includes the `kuma.io/sidecar-injection` label enabled on the `kuma-demo` namespace.
 
@@ -66,7 +66,7 @@ This means that {{site.mesh_product_name}} [already knows](/docs/{{ page.version
 
 You can view the sidecar proxies that are connected to the {{site.mesh_product_name}} control plane.
 
-{{site.mesh_product_name}} ships with a **read-only** GUI that you can use to retrieve {{site.mesh_product_name}} resources. By default, the GUI listens on the API port and defaults to `:5681/gui`.
+{{site.mesh_product_name}} ships with a **read-only** GUI that you can use to retrieve {{site.mesh_product_name}} resources. By default, the GUI listens on the API port which defaults to `5681`.
 
 To access {{site.mesh_product_name}} we need to first port-forward the API service with:
 
@@ -74,7 +74,7 @@ To access {{site.mesh_product_name}} we need to first port-forward the API servi
 kubectl port-forward svc/{{site.mesh_cp_name}} -n {{site.mesh_namespace}} 5681:5681
 ```
 
-And then navigate to [`127.0.0.1:5681/gui`](http://127.0.0.1:5681/gui) to see the GUI.
+And then navigate to [127.0.0.1:5681/gui](http://127.0.0.1:5681/gui) to see the GUI.
 
 ## Introduce zero-trust security
 

--- a/app/_src/quickstart/kubernetes-demo.md
+++ b/app/_src/quickstart/kubernetes-demo.md
@@ -16,7 +16,7 @@ To start learning how {{site.mesh_product_name}} works, you run and secure a sim
 Start a new Kubernetes cluster on your local machine by executing:
 
 ```sh
-kind create cluster --name=kuma
+kind create cluster --name=kuma-zone
 ```
 
 {% tip %}
@@ -39,6 +39,7 @@ helm install --create-namespace --namespace {{site.mesh_namespace}} {{ site.mesh
 1.  Deploy the application
     ```sh
     kubectl apply -f https://raw.githubusercontent.com/kumahq/kuma-counter-demo/master/demo.yaml
+    kubectl wait -n kuma-demo --for=condition=ready pod --selector=app=demo-app --timeout=90s
     ```
 
 2.  Port-forward the service to the namespace on port 5000:
@@ -117,6 +118,7 @@ spec:
 ```
 
 At this point, the demo application should not function, because we blocked the traffic.
+You can verify this by clicking the increment button again and seeing the error message in the browser
 We can allow the traffic from the `demo-app` to `redis` by applying the following MeshTrafficPermission
 
 ```sh
@@ -138,7 +140,8 @@ spec:
         action: Allow" | kubectl apply -f -
 ```
 
-The application should function once again. The traffic to `redis` from any other service than `demo-app` is not allowed.
+You can click the increment button, the application should function once again.
+However, the traffic to `redis` from any other service than `demo-app` is not allowed.
 
 ## Next steps
 

--- a/app/_src/quickstart/kubernetes-demo.md
+++ b/app/_src/quickstart/kubernetes-demo.md
@@ -1,0 +1,147 @@
+---
+title: Deploy Kuma on Kubernetes
+---
+
+To start learning how {{site.mesh_product_name}} works, you run and secure a simple demo application that consists of two services:
+
+- `demo-app`: a web application that lets you increment a numeric counter. It listens on port 5000
+- `redis`: data store for the counter
+
+## Prerequisites
+- [Helm](https://helm.sh/) - a package manager for Kubernetes
+- [Kind](https://kind.sigs.k8s.io/) - a tool for running local Kubernetes clusters
+
+## Start Kubernetes cluster
+
+Start a new Kubernetes cluster on your local machine by executing:
+
+```sh
+kind create cluster --name=kuma
+```
+
+{% tip %}
+You can skip this step if you already have a Kubernetes cluster running.
+It can be a cluster running locally or in a public cloud like AWS EKS, GCP GKE, etc.
+{% endtip %}
+
+## Install Kuma
+
+Install Kuma control plane with Helm by executing:
+
+```sh
+helm repo add kuma https://kumahq.github.io/charts
+helm repo update
+helm install --create-namespace --namespace {{site.mesh_namespace}} {{ site.kuma_install_name }} {{ site.mesh_helm_repo }}
+```
+
+## Deploy demo application
+
+1.  Deploy the application
+    ```sh
+    kubectl apply -f https://raw.githubusercontent.com/kumahq/kuma-counter-demo/master/demo.yaml
+    ```
+
+2.  Port forward the service to the namespace on port 5000:
+
+    ```sh
+    kubectl port-forward svc/demo-app -n kuma-demo 5000:5000
+    ```
+
+3.  In a browser, go to `127.0.0.1:5000` and increment the counter.
+
+The demo app includes the `kuma.io/sidecar-injection` label enabled on the `kuma-demo` namespace.
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuma-demo
+  labels:
+    kuma.io/sidecar-injection: enabled
+```
+
+This means that {{site.mesh_product_name}} [already knows](/docs/{{ page.version }}/production/dp-config/dpp-on-kubernetes/) that it needs to automatically inject a sidecar proxy to every Kubernetes pod in the `kuma-demo` namespace.
+
+## Explore GUI
+
+You can view the sidecar proxies that are connected to the {{site.mesh_product_name}} control plane.
+
+{{site.mesh_product_name}} ships with a **read-only** GUI that you can use to retrieve {{site.mesh_product_name}} resources. By default, the GUI listens on the API port and defaults to `:5681/gui`.
+
+To access {{site.mesh_product_name}} we need to first port-forward the API service with:
+
+```sh
+kubectl port-forward svc/{{site.mesh_cp_name}} -n {{site.mesh_namespace}} 5681:5681
+```
+
+And then navigate to [`127.0.0.1:5681/gui`](http://127.0.0.1:5681/gui) to see the GUI.
+
+## Introduce zero-trust security
+
+By default, the network is insecure and not encrypted. We can change this with {{site.mesh_product_name}} by enabling the [Mutual TLS](/docs/{{ page.version }}/policies/mutual-tls/) policy to provision a Certificate Authority (CA) that will automatically assign TLS certificates to our services (more specifically to the injected data plane proxies running alongside the services).
+
+We can enable Mutual TLS with a `builtin` CA backend by executing:
+
+```sh
+echo "apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: default
+spec:
+  mtls:
+    enabledBackend: ca-1
+    backends:
+    - name: ca-1
+      type: builtin" | kubectl apply -f -
+```
+
+The traffic is now encrypted with mTLS. However, every service can reach any other service.
+
+We can then restrict the traffic by default by executing:
+
+```sh
+echo "
+apiVersion: kuma.io/v1alpha1
+kind: MeshTrafficPermission
+metadata:
+  namespace: {{site.mesh_namespace}}
+  name: deny-all
+spec:
+  targetRef:
+    kind: Mesh
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        action: Deny" | kubectl apply -f -
+```
+
+At this point, the demo application should not function, because we blocked the traffic.
+We can allow the traffic from the `demo-app` to `redis` by applying the following MeshTrafficPermission
+
+```sh
+echo "
+apiVersion: kuma.io/v1alpha1
+kind: MeshTrafficPermission
+metadata:
+  namespace: {{site.mesh_namespace}}
+  name: redis
+spec:
+  targetRef:
+    kind: MeshService
+    name: redis_kuma-demo_svc_6379
+  from:
+    - targetRef:
+        kind: MeshService
+        name: demo-app_kuma-demo_svc_5000
+      default:
+        action: Allow" | kubectl apply -f -
+```
+
+The application should function once again. The traffic to `redis` from any other service than `demo-app` is not allowed.
+
+## Next steps
+
+* Explore the [Features](/features) available to govern and orchestrate your service traffic.
+* Read the [full documentation](/docs/{{ page.version }}/) to learn about all the capabilities of {{site.mesh_product_name}}.
+* Chat with us at the official [Kuma Slack](/community) for questions or feedback.

--- a/app/docs/1.8.x/explore/gateway.md
+++ b/app/docs/1.8.x/explore/gateway.md
@@ -225,7 +225,7 @@ Kuma gateways are configured with the [Envoy best practices for edge proxies](ht
 ### Usage
 
 You can create and configure a gateway that listens for traffic from outside of your mesh
-and forwards it to the [demo app frontend](https://kuma.io/docs/dev/quickstart/kubernetes/).
+and forwards it to the [demo app frontend](/docs/{{ page.version }}/quickstart/kubernetes/).
 
 {% tabs setup useUrlFragment=false %}
 {% tab setup Kubernetes %}

--- a/app/docs/2.0.x/explore/gateway.md
+++ b/app/docs/2.0.x/explore/gateway.md
@@ -225,7 +225,7 @@ To configure your gateway {{site.mesh_product_name}} has these resources:
 ### Usage
 
 You can create and configure a gateway that listens for traffic from outside of your mesh
-and forwards it to the [demo app frontend](https://kuma.io/docs/dev/quickstart/kubernetes/).
+and forwards it to the [demo app frontend](/docs/{{ page.version }}/quickstart/kubernetes/).
 
 {% tabs setup useUrlFragment=false %}
 {% tab setup Kubernetes %}


### PR DESCRIPTION
Rewrite quickstart.

The goal is to have a very opinionated quickstart (kubernetes, helm, kind, mesh traffic permission). So we can then build guides (like federating zone) as a next step after you complete it.

Quickstart for Universal is intentionally gone. I'm not a big fan of this, but it's what we discussed. We want to reintroduce this after the release.