### PR TITLE
docs(networking): convert non-mesh traffic doc to use targetref policies

### DIFF
--- a/app/_src/networking/non-mesh-traffic.md
+++ b/app/_src/networking/non-mesh-traffic.md
@@ -141,7 +141,7 @@ conf:
 ```yaml
 type: MeshProxyPatch
 mesh: default
-name: custom-template-1
+name: custom-mpp-1
 spec:
   targetRef:
     kind: Mesh
@@ -176,7 +176,7 @@ tcp:
   idleTimeout: 1h
 ```
 
-{% if_version lte:2.5.x inline:true %}Proxy Template{% endif_version %}{% if_version inline:true gte:2.6.x %}MeshProxyPatch{% endif_version %}to change the defaults:
+{% if_version lte:2.5.x inline:true %}Proxy Template{% endif_version %}{% if_version inline:true gte:2.6.x %}MeshProxyPatch{% endif_version %} to change the defaults:
 
 {% if_version lte:2.5.x %}
 {% tabs passthrough-timeouts useUrlFragment=false %}
@@ -251,7 +251,7 @@ conf:
 ```yaml
 type: MeshProxyPatch
 mesh: default
-name: custom-template-1
+name: custom-mpp-1
 spec:
   targetRef:
     kind: Mesh

--- a/app/_src/networking/non-mesh-traffic.md
+++ b/app/_src/networking/non-mesh-traffic.md
@@ -261,8 +261,10 @@ spec:
           operation: Patch
           match:
             name: "outbound:passthrough:ipv4"
-          value: |
-            connect_timeout: "99s"
+          jsonPatches:
+            - op: replace
+              path: /connectTimeout
+              value: 99s
       - networkFilter:
           operation: Patch
           match:

--- a/app/_src/networking/non-mesh-traffic.md
+++ b/app/_src/networking/non-mesh-traffic.md
@@ -55,7 +55,7 @@ Otherwise, you will block the traffic which may cause the instability of the sys
 ### Policies don't apply to non-mesh traffic
 
 If you need to change configuration for non-mesh traffic 
-you can use a [ProxyTemplate](/docs/{{ page.version }}/policies/proxy-template).
+you can use a {% if_version lte:2.5.x inline:true %}[ProxyTemplate](/docs/{{ page.version }}/policies/proxy-template){% endif_version %}{% if_version inline:true gte:2.6.x %}[MeshProxyPatch](/docs/{{ page.version }}/policies/meshproxypatch){% endif_version %}.
 
 #### Circuit Breaker
 
@@ -70,41 +70,8 @@ maxRetries: 3
 
 Proxy Template to change the defaults:
 
-{% tabs passthrough-thresholds useUrlFragment=false %}
-{% tab passthrough-thresholds Kubernetes %}
-```yaml
-apiVersion: kuma.io/v1alpha1
-kind: ProxyTemplate
-mesh: default
-metadata:
-  name: custom-template-1
-spec:
-  selectors:
-    - match:
-        kuma.io/service: "*"
-  conf:
-    imports:
-      - default-proxy
-    modifications:
-      - cluster:
-          operation: patch
-          match:
-            name: "outbound:passthrough:ipv4"
-          value: |
-            circuit_breakers: {
-              thresholds: [
-                {
-                  max_connections: 2048,
-                  max_pending_requests: 2048,
-                  max_requests: 2048,
-                  max_retries: 4
-                }
-              ]
-            }
-```
-{% endtab %}
-
-{% tab passthrough-thresholds Universal %}
+{% if_version lte:2.5.x %}
+{% policy_yaml passthrough-thresholds %}
 ```yaml
 type: ProxyTemplate
 mesh: default
@@ -132,8 +99,38 @@ conf:
             ]
           }
 ```
-{% endtab %}
-{% endtabs %}
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.6.x %}
+{% policy_yaml passthrough-thresholds-mpp %}
+```yaml
+type: MeshProxyPatch
+mesh: default
+name: custom-template-1
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    appendModifications:
+      - cluster:
+          operation: Patch
+          match:
+            name: "outbound:passthrough:ipv4"
+          value: |
+            circuit_breakers: {
+              thresholds: [
+                {
+                  max_connections: 2048,
+                  max_pending_requests: 2048,
+                  max_requests: 2048,
+                  max_retries: 4
+                }
+              ]
+            }
+```
+{% endpolicy_yaml %}
+{% endif_version %}
 
 #### Timeouts
 
@@ -147,42 +144,8 @@ tcp:
 
 Proxy Template to change the defaults:
 
-{% tabs passthrough-timeouts useUrlFragment=false %}
-{% tab passthrough-timeouts Kubernetes %}
-```yaml
-apiVersion: kuma.io/v1alpha1
-kind: ProxyTemplate
-mesh: default
-metadata:
-  name: custom-template-1
-spec:
-  selectors:
-    - match:
-        kuma.io/service: "*"
-  conf:
-    imports:
-      - default-proxy
-    modifications:
-      - cluster:
-          operation: patch
-          match:
-            name: "outbound:passthrough:ipv4"
-          value: |
-            connect_timeout: "99s"
-      - networkFilter:
-          operation: patch
-          match:
-            name: "envoy.filters.network.tcp_proxy"
-            listenerName: "outbound:passthrough:ipv4"
-          value: |
-            name: envoy.filters.network.tcp_proxy
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-              idleTimeout: "3h"
-```
-{% endtab %}
-
-{% tab passthrough-timeouts Universal %}
+{% if_version lte:2.5.x %}
+{% policy_yaml passthrough-timeouts %}
 ```yaml
 type: ProxyTemplate
 mesh: default
@@ -211,5 +174,36 @@ conf:
             '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
             idleTimeout: "3h"
 ```
-{% endtab %}
-{% endtabs %}
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.6.x %}
+{% policy_yaml passthrough-timeouts-mpp %}
+```yaml
+type: MeshProxyPatch
+mesh: default
+name: custom-template-1
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    appendModifications:
+      - cluster:
+          operation: Patch
+          match:
+            name: "outbound:passthrough:ipv4"
+          value: |
+            connect_timeout: "99s"
+      - networkFilter:
+          operation: Patch
+          match:
+            name: "envoy.filters.network.tcp_proxy"
+            listenerName: "outbound:passthrough:ipv4"
+          value: |
+            name: envoy.filters.network.tcp_proxy
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+              idleTimeout: "3h"
+```
+{% endpolicy_yaml %}
+{% endif_version %}

--- a/app/_src/networking/non-mesh-traffic.md
+++ b/app/_src/networking/non-mesh-traffic.md
@@ -55,7 +55,7 @@ Otherwise, you will block the traffic which may cause the instability of the sys
 ### Policies don't apply to non-mesh traffic
 
 If you need to change configuration for non-mesh traffic 
-you can use a {% if_version lte:2.5.x inline:true %}ProxyTemplate{% endif_version %}{% if_version inline:true gte:2.6.x %}MeshProxyPatch{% endif_version %}.
+you can use a {% if_version lte:2.5.x inline:true %}Proxy Template{% endif_version %}{% if_version inline:true gte:2.6.x %}MeshProxyPatch{% endif_version %}.
 
 #### Circuit Breaker
 
@@ -177,7 +177,7 @@ tcp:
   idleTimeout: 1h
 ```
 
-Proxy Template to change the defaults:
+{% if_version lte:2.5.x inline:true %}Proxy Template{% endif_version %}{% if_version inline:true gte:2.6.x %}MeshProxyPatch{% endif_version %}to change the defaults:
 
 {% if_version lte:2.5.x %}
 {% tabs passthrough-timeouts useUrlFragment=false %}

--- a/app/_src/networking/non-mesh-traffic.md
+++ b/app/_src/networking/non-mesh-traffic.md
@@ -55,7 +55,7 @@ Otherwise, you will block the traffic which may cause the instability of the sys
 ### Policies don't apply to non-mesh traffic
 
 If you need to change configuration for non-mesh traffic 
-you can use a {% if_version lte:2.5.x inline:true %}[ProxyTemplate](/docs/{{ page.version }}/policies/proxy-template){% endif_version %}{% if_version inline:true gte:2.6.x %}[MeshProxyPatch](/docs/{{ page.version }}/policies/meshproxypatch){% endif_version %}.
+you can use a {% if_version lte:2.5.x inline:true %}ProxyTemplate{% endif_version %}{% if_version inline:true gte:2.6.x %}MeshProxyPatch{% endif_version %}.
 
 #### Circuit Breaker
 
@@ -68,7 +68,7 @@ maxRequests: 1024
 maxRetries: 3
 ```
 
-Proxy Template to change the defaults:
+{% if_version lte:2.5.x inline:true %}[ProxyTemplate](/docs/{{ page.version }}/policies/proxy-template){% endif_version %}{% if_version inline:true gte:2.6.x %}[MeshProxyPatch](/docs/{{ page.version }}/policies/meshproxypatch){% endif_version %} to change the defaults:
 
 {% if_version lte:2.5.x %}
 {% tabs passthrough-thresholds useUrlFragment=false %}

--- a/app/_src/networking/non-mesh-traffic.md
+++ b/app/_src/networking/non-mesh-traffic.md
@@ -136,7 +136,6 @@ conf:
 {% endtab %}
 {% endtabs %}
 {% endif_version %}
-
 {% if_version gte:2.6.x %}
 {% policy_yaml passthrough-thresholds-mpp %}
 ```yaml
@@ -247,7 +246,6 @@ conf:
 {% endtab %}
 {% endtabs %}
 {% endif_version %}
-
 {% if_version gte:2.6.x %}
 {% policy_yaml passthrough-timeouts-mpp %}
 ```yaml


### PR DESCRIPTION
convert non-mesh traffic doc to use targetref policies since 2.6

xref: https://github.com/kumahq/kuma-website/issues/1599

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes

2.5.0: https://deploy-preview-1615--kuma.netlify.app/docs/2.5.x/networking/non-mesh-traffic/#non-mesh-traffic
dev: https://deploy-preview-1615--kuma.netlify.app/docs/dev/networking/non-mesh-traffic/#non-mesh-traffic
