### PR TITLE
docs(mesh): convert policy references to targetref ones for 2.6

### DIFF
--- a/app/_src/production/mesh.md
+++ b/app/_src/production/mesh.md
@@ -5,7 +5,7 @@ content_type: how-to
 
 This resource describes a very important concept in {{site.mesh_product_name}}, and that is the ability of creating multiple isolated service meshes within the same {{site.mesh_product_name}} cluster which in turn make {{site.mesh_product_name}} a very simple and easy project to operate in environments where more than one mesh is required based on security, segmentation or governance requirements.
 
-Typically we would want to create a `Mesh` per line of business, per team, per application or per environment or for any other reason. Typically multiple meshes are being created so that a service mesh can be adopted by an organization with a gradual roll-out that doesn't require all the teams and their applications to coordinate with each other, or as an extra layer of security and segmentation for our services so that - for example - policies applied to one `Mesh` do not affect another `Mesh`.
+Typically, we would want to create a `Mesh` per line of business, per team, per application or per environment or for any other reason. Typically multiple meshes are being created so that a service mesh can be adopted by an organization with a gradual roll-out that doesn't require all the teams and their applications to coordinate with each other, or as an extra layer of security and segmentation for our services so that - for example - policies applied to one `Mesh` do not affect another `Mesh`.
 
 `Mesh` is the parent resource of every other resource in {{site.mesh_product_name}}, including: 
 
@@ -21,8 +21,8 @@ When starting a new {{site.mesh_product_name}} cluster from scratch a `default` 
 Besides the ability of being able to create virtual service mesh, a `Mesh` resource will also be used for:
 
 * [Mutual TLS](/docs/{{ page.version }}/policies/mutual-tls/), to secure and encrypt our service traffic and assign an identity to the data plane proxies within the Mesh.
-* [Traffic Metrics](/docs/{{ page.version }}/policies/traffic-metrics/), to setup metrics backend that will be used to collect and visualize metrics of our service mesh and service traffic within the Mesh.
-* [Traffic Trace](/docs/{{ page.version }}/policies/traffic-trace/), to setup tracing backends that will be used to collect traces of our service traffic within the Mesh.
+* {% if_version lte:2.5.x inline:true %}[Traffic Metrics](/docs/{{ page.version }}/policies/traffic-metrics/){% endif_version %}{% if_version inline:true gte:2.6.x %}[MeshMetric](/docs/{{ page.version }}/policies/meshmetric){% endif_version %}, to setup metrics backend that will be used to collect and visualize metrics of our service mesh and service traffic within the Mesh.
+* {% if_version lte:2.5.x inline:true %}[Traffic Trace](/docs/{{ page.version }}/policies/traffic-trace/){% endif_version %}{% if_version inline:true gte:2.6.x %}[MeshTrace](/docs/{{ page.version }}/policies/meshtrace){% endif_version %}, to setup tracing backends that will be used to collect traces of our service traffic within the Mesh.
 * {% if_version lte:2.1.x %}[Zone Egress](/docs/{{ page.version }}/explore/zoneegress){% endif_version %}{% if_version gte:2.2.x %}[Zone Egress](/docs/{{ page.version }}/production/cp-deployment/zoneegress/){% endif_version %}, to setup if `ZoneEgress` should be used for cross zone and external service communication.
 * [Non-mesh traffic](/docs/{{ page.version }}/networking/non-mesh-traffic), to setup if `passthrough` mode should be used for the non-mesh traffic.
 
@@ -100,14 +100,15 @@ kuma-dp run \
 {% endtab %}
 {% endtabs %}
 
-You can control which data plane proxies are allowed to join the mesh using [mesh constraints]{% if_version gte:2.2.x %}(/docs/{{ page.version }}/production/secure-deployment/dp-membership/){% endif_version %}{% if_version lte:2.1.x %}(/docs/{{ page.version }}/security/dp-membership/){% endif_version %}.
+You can control which data plane proxies are allowed to join the mesh using [mesh constraints]{% if_version gte:2.2.x inline:true %}(/docs/{{ page.version }}/production/secure-deployment/dp-membership/){% endif_version %}{% if_version lte:2.1.x inline:true %}(/docs/{{ page.version }}/security/dp-membership/){% endif_version %}.
 
 #### Policies
 
 When creating new [Policies](/policies) we also must specify to what `Mesh` they belong. This can be done in the following way:
 
 {% tabs policies useUrlFragment=false %}
-{% tab policies Kubernetes %}
+{% if_version lte:2.5.x %}
+{% tab policies Kubernetes (Old policies) %}
 By using the `mesh` property, like:
 
 ```yaml
@@ -122,7 +123,8 @@ spec:
 
 {{site.mesh_product_name}} consumes all [Policies](/policies) on the cluster and joins each to an individual `Mesh`, identified by this property.
 {% endtab %}
-{% tab policies Kubernetes (New policies) %}
+{% endif_version %}
+{% tab policies Kubernetes %}
 By using the `kuma.io/mesh` label, like:
 
 ```yaml


### PR DESCRIPTION
convert policy references to targetref ones for 2.6 release

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
