### PR TITLE
docs(meshroutes): adjust tables to new format

### DIFF
--- a/app/_src/policies/meshhttproute.md
+++ b/app/_src/policies/meshhttproute.md
@@ -18,12 +18,34 @@ depending on where the request coming from and where it's going to.
 
 ## TargetRef support matrix
 
+{% if_version gte:2.6.x %}
+{% tabs targetRef useUrlFragment=false %}
+{% tab targetRef Sidecar %}
+| `targetRef`             | Allowed kinds                                            |
+| ----------------------- | -------------------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
+| `to[].targetRef.kind`   | `MeshService`                                                   |
+{% endtab %}
+
+{% tab targetRef Builtin Gateway %}
+| `targetRef`             | Allowed kinds                                            |
+| ----------------------- | -------------------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `MeshGateway`, `MeshGateway` with listener `tags`|
+| `to[].targetRef.kind`   | `Mesh`                                                   |
+{% endtab %}
+{% endtabs %}
+
+{% endif_version %}
+{% if_version lte:2.5.x %}
+
 | TargetRef type    | top level | to  | from |
 | ----------------- | --------- | --- | ---- |
 | Mesh              | ✅        | ❌  | ❌   |
 | MeshSubset        | ✅        | ❌  | ❌   |
 | MeshService       | ✅        | ✅  | ❌   |
 | MeshServiceSubset | ✅        | ❌  | ❌   |
+
+{% endif_version %}
 
 If you don't understand this table you should read [matching docs](/docs/{{ page.version }}/policies/targetref).
 

--- a/app/_src/policies/meshtcproute.md
+++ b/app/_src/policies/meshtcproute.md
@@ -18,12 +18,34 @@ depending on where the request is coming from and where it's going to.
 
 ## TargetRef support matrix
 
+{% if_version gte:2.6.x %}
+{% tabs targetRef useUrlFragment=false %}
+{% tab targetRef Sidecar %}
+| `targetRef`             | Allowed kinds                                            |
+| ----------------------- | -------------------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
+| `to[].targetRef.kind`   | `MeshService`                                                   |
+{% endtab %}
+
+{% tab targetRef Builtin Gateway %}
+| `targetRef`             | Allowed kinds                                            |
+| ----------------------- | -------------------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `MeshGateway`, `MeshGateway` with listener `tags`|
+| `to[].targetRef.kind`   | `Mesh`                                                   |
+{% endtab %}
+{% endtabs %}
+
+{% endif_version %}
+{% if_version lte:2.5.x %}
+
 | TargetRef type    | top level | to | from |
 |-------------------|-----------|----|------|
 | Mesh              | ✅         | ❌  | ❌    |
 | MeshSubset        | ✅         | ❌  | ❌    |
 | MeshService       | ✅         | ✅  | ❌    |
 | MeshServiceSubset | ✅         | ❌  | ❌    |
+
+{% endif_version %}
 
 For more information, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
 


### PR DESCRIPTION
adjust targetref tables to new format

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes

https://deploy-preview-1621--kuma.netlify.app/docs/dev/policies/meshtcproute/#targetref-support-matrix

and

https://deploy-preview-1621--kuma.netlify.app/docs/dev/policies/meshhttproute/#targetref-support-matrix