### PR TITLE
feat: Source Packages from Cloudsmith

### DIFF
--- a/app/_includes/snippets/install_kumactl.md
+++ b/app/_includes/snippets/install_kumactl.md
@@ -15,11 +15,11 @@ You can omit the `VERSION` variable to install the latest version.
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access Kubernetes:
 
-* <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
-* <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
-* <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
-* <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
-* <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
+* <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
+* <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
+* <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
+* <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
+* <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
 
 and extract the archive with `tar xvzf kuma-{{ page.latest_version }}.tar.gz`
 {% endtab %}

--- a/app/_includes/snippets/install_os.md
+++ b/app/_includes/snippets/install_os.md
@@ -14,7 +14,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-{{ page.os }}-{{ page.arch }}.tar.gz">download</a> the distribution manually.
+or you can <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-{{ page.os }}-{{ page.arch }}/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-{{ page.os }}-{{ page.arch }}.tar.gz">download</a> the distribution manually.
 
 Then extract the archive with: `tar xvzf kuma-{{ page.latest_version }}`.
 

--- a/app/_src/community/contribute-to-kuma.md
+++ b/app/_src/community/contribute-to-kuma.md
@@ -44,10 +44,10 @@ It outputs:
 Getting release
 
 INFO	Welcome to the Kuma automated download!
-INFO	Kuma version: 0.0.0-preview.4d3a9fd03
+INFO	Kuma version: 0.0.0-preview.vbda3bc4bd
 INFO	Kuma architecture: amd64
-INFO	Operating system: Darwin
-INFO	Downloading Kuma from: https://download.konghq.com/mesh-alpine/kuma-0.0.0-preview.4d3a9fd03-darwin-amd64.tar.gz
+INFO	Operating system: darwin
+INFO	Downloading Kuma from: https://packages.konghq.com/public/kuma-binaries-preview/raw/names/kuma-darwin-amd64/versions/bda3bc4bd/kuma-0.0.0-preview.vbda3bc4bd-darwin-amd64.tar.gz
 ```
 
 You then run kumactl with:

--- a/app/_src/installation/docker.md
+++ b/app/_src/installation/docker.md
@@ -119,11 +119,11 @@ You can run the following script to automatically detect the operating system an
 
 or you can download the distribution manually:
 
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.2.x/installation/amazonlinux.md
+++ b/app/docs/1.2.x/installation/amazonlinux.md
@@ -23,7 +23,7 @@ Run the following script to automatically detect the operating system and downlo
 curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.2.3-centos-amd64.tar.gz) the distribution manually.
+or you can [download]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.2.3/kuma-1.2.3-centos-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.2.x/installation/centos.md
+++ b/app/docs/1.2.x/installation/centos.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.2.3-centos-amd64.tar.gz) the distribution manually.
+or you can [download]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.2.3/kuma-1.2.3-centos-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.2.x/installation/debian.md
+++ b/app/docs/1.2.x/installation/debian.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.2.3-debian-amd64.tar.gz) the distribution manually.
+or you can [download]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/1.2.3/kuma-1.2.3-debian-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.2.x/installation/docker.md
+++ b/app/docs/1.2.x/installation/docker.md
@@ -143,11 +143,11 @@ You can run the following script to automatically detect the operating system an
 
 or you can download the distribution manually:
 
-- [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-centos-amd64.tar.gz)
-- [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.2.3-rhel-amd64.tar.gz)
-- [Debian](https://download.konghq.com/mesh-alpine/kuma-1.2.3-debian-amd64.tar.gz)
-- [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.2.3-ubuntu-amd64.tar.gz)
-- [macOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-darwin-amd64.tar.gz)
+- [CentOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.2.3/kuma-1.2.3-centos-amd64.tar.gz)
+- [RedHat]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/1.2.3/kuma-1.2.3-rhel-amd64.tar.gz)
+- [Debian]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/1.2.3/kuma-1.2.3-debian-amd64.tar.gz)
+- [Ubuntu]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/1.2.3/kuma-1.2.3-ubuntu-amd64.tar.gz)
+- [macOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/1.2.3/kuma-1.2.3-darwin-amd64.tar.gz)
 
 and extract the archive with:
 

--- a/app/docs/1.2.x/installation/eks.md
+++ b/app/docs/1.2.x/installation/eks.md
@@ -32,11 +32,11 @@ You can run the following script to automatically detect the operating system an
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access Kubernetes:
 
-- [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-centos-amd64.tar.gz)
-- [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.2.3-rhel-amd64.tar.gz)
-- [Debian](https://download.konghq.com/mesh-alpine/kuma-1.2.3-debian-amd64.tar.gz)
-- [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.2.3-ubuntu-amd64.tar.gz)
-- [macOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-darwin-amd64.tar.gz) or run `brew install kumactl`
+- [CentOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.2.3/kuma-1.2.3-centos-amd64.tar.gz)
+- [RedHat]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/1.2.3/kuma-1.2.3-rhel-amd64.tar.gz)
+- [Debian]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/1.2.3/kuma-1.2.3-debian-amd64.tar.gz)
+- [Ubuntu]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/1.2.3/kuma-1.2.3-ubuntu-amd64.tar.gz)
+- [macOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/1.2.3/kuma-1.2.3-darwin-amd64.tar.gz) or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.2.x/installation/kubernetes.md
+++ b/app/docs/1.2.x/installation/kubernetes.md
@@ -32,11 +32,11 @@ You can run the following script to automatically detect the operating system an
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access Kubernetes:
 
-- [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-centos-amd64.tar.gz)
-- [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.2.3-rhel-amd64.tar.gz)
-- [Debian](https://download.konghq.com/mesh-alpine/kuma-1.2.3-debian-amd64.tar.gz)
-- [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.2.3-ubuntu-amd64.tar.gz)
-- [macOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-darwin-amd64.tar.gz) or run `brew install kumactl`
+- [CentOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.2.3/kuma-1.2.3-centos-amd64.tar.gz)
+- [RedHat]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/1.2.3/kuma-1.2.3-rhel-amd64.tar.gz)
+- [Debian]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/1.2.3/kuma-1.2.3-debian-amd64.tar.gz)
+- [Ubuntu]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/1.2.3/kuma-1.2.3-ubuntu-amd64.tar.gz)
+- [macOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/1.2.3/kuma-1.2.3-darwin-amd64.tar.gz) or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.2.x/installation/macos.md
+++ b/app/docs/1.2.x/installation/macos.md
@@ -28,7 +28,7 @@ Run the following script to automatically detect the operating system and downlo
 
 You can also download the distribution manually:
 
-- [Download Kuma](https://download.konghq.com/mesh-alpine/kuma-1.2.3-darwin-amd64.tar.gz)
+- [Download Kuma]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/1.2.3/kuma-1.2.3-darwin-amd64.tar.gz)
 
 Then extract the archive with:
 

--- a/app/docs/1.2.x/installation/openshift.md
+++ b/app/docs/1.2.x/installation/openshift.md
@@ -28,11 +28,11 @@ You can run the following script to automatically detect the operating system an
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access OpenShift:
 
-- [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-centos-amd64.tar.gz)
-- [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.2.3-rhel-amd64.tar.gz)
-- [Debian](https://download.konghq.com/mesh-alpine/kuma-1.2.3-debian-amd64.tar.gz)
-- [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.2.3-ubuntu-amd64.tar.gz)
-- [macOS](https://download.konghq.com/mesh-alpine/kuma-1.2.3-darwin-amd64.tar.gz) or `brew install kumactl`
+- [CentOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.2.3/kuma-1.2.3-centos-amd64.tar.gz)
+- [RedHat]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/1.2.3/kuma-1.2.3-rhel-amd64.tar.gz)
+- [Debian]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/1.2.3/kuma-1.2.3-debian-amd64.tar.gz)
+- [Ubuntu]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/1.2.3/kuma-1.2.3-ubuntu-amd64.tar.gz)
+- [macOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/1.2.3/kuma-1.2.3-darwin-amd64.tar.gz) or `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.2.x/installation/redhat.md
+++ b/app/docs/1.2.x/installation/redhat.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.2.3-rhel-amd64.tar.gz) the distribution manually.
+or you can [download]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/1.2.3/kuma-1.2.3-rhel-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.2.x/installation/ubuntu.md
+++ b/app/docs/1.2.x/installation/ubuntu.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.2.3-ubuntu-amd64.tar.gz) the distribution manually.
+or you can [download]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/1.2.3/kuma-1.2.3-ubuntu-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.3.x/installation/amazonlinux.md
+++ b/app/docs/1.3.x/installation/amazonlinux.md
@@ -23,7 +23,7 @@ Run the following script to automatically detect the operating system and downlo
 curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.3.1-centos-amd64.tar.gz) the distribution manually.
+or you can [download]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.3.1/kuma-1.3.1-centos-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.3.x/installation/centos.md
+++ b/app/docs/1.3.x/installation/centos.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.3.1-centos-amd64.tar.gz) the distribution manually.
+or you can [download]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.3.1/kuma-1.3.1-centos-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.3.x/installation/debian.md
+++ b/app/docs/1.3.x/installation/debian.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.3.1-debian-amd64.tar.gz) the distribution manually.
+or you can [download]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/1.3.1/kuma-1.3.1-debian-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.3.x/installation/docker.md
+++ b/app/docs/1.3.x/installation/docker.md
@@ -143,11 +143,11 @@ You can run the following script to automatically detect the operating system an
 
 or you can download the distribution manually:
 
-- [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.3.1-centos-amd64.tar.gz)
-- [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.3.1-rhel-amd64.tar.gz)
-- [Debian](https://download.konghq.com/mesh-alpine/kuma-1.3.1-debian-amd64.tar.gz)
-- [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.3.1-ubuntu-amd64.tar.gz)
-- [macOS](https://download.konghq.com/mesh-alpine/kuma-1.3.1-darwin-amd64.tar.gz)
+- [CentOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.3.1/kuma-1.3.1-centos-amd64.tar.gz)
+- [RedHat]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/1.3.1/kuma-1.3.1-rhel-amd64.tar.gz)
+- [Debian]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/1.3.1/kuma-1.3.1-debian-amd64.tar.gz)
+- [Ubuntu]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/1.3.1/kuma-1.3.1-ubuntu-amd64.tar.gz)
+- [macOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/1.3.1/kuma-1.3.1-darwin-amd64.tar.gz)
 
 and extract the archive with:
 

--- a/app/docs/1.3.x/installation/eks.md
+++ b/app/docs/1.3.x/installation/eks.md
@@ -32,11 +32,11 @@ You can run the following script to automatically detect the operating system an
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access Kubernetes:
 
-- [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.3.1-centos-amd64.tar.gz)
-- [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.3.1-rhel-amd64.tar.gz)
-- [Debian](https://download.konghq.com/mesh-alpine/kuma-1.3.1-debian-amd64.tar.gz)
-- [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.3.1-ubuntu-amd64.tar.gz)
-- [macOS](https://download.konghq.com/mesh-alpine/kuma-1.3.1-darwin-amd64.tar.gz) or run `brew install kumactl`
+- [CentOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.3.1/kuma-1.3.1-centos-amd64.tar.gz)
+- [RedHat]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/1.3.1/kuma-1.3.1-rhel-amd64.tar.gz)
+- [Debian]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/1.3.1/kuma-1.3.1-debian-amd64.tar.gz)
+- [Ubuntu]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/1.3.1/kuma-1.3.1-ubuntu-amd64.tar.gz)
+- [macOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/1.3.1/kuma-1.3.1-darwin-amd64.tar.gz) or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.3.x/installation/kubernetes.md
+++ b/app/docs/1.3.x/installation/kubernetes.md
@@ -32,11 +32,11 @@ You can run the following script to automatically detect the operating system an
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access Kubernetes:
 
-- [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.3.1-centos-amd64.tar.gz)
-- [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.3.1-rhel-amd64.tar.gz)
-- [Debian](https://download.konghq.com/mesh-alpine/kuma-1.3.1-debian-amd64.tar.gz)
-- [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.3.1-ubuntu-amd64.tar.gz)
-- [macOS](https://download.konghq.com/mesh-alpine/kuma-1.3.1-darwin-amd64.tar.gz) or run `brew install kumactl`
+- [CentOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.3.1/kuma-1.3.1-centos-amd64.tar.gz)
+- [RedHat]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/1.3.1/kuma-1.3.1-rhel-amd64.tar.gz)
+- [Debian]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/1.3.1/kuma-1.3.1-debian-amd64.tar.gz)
+- [Ubuntu]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/1.3.1/kuma-1.3.1-ubuntu-amd64.tar.gz)
+- [macOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/1.3.1/kuma-1.3.1-darwin-amd64.tar.gz) or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.3.x/installation/macos.md
+++ b/app/docs/1.3.x/installation/macos.md
@@ -28,7 +28,7 @@ Run the following script to automatically detect the operating system and downlo
 
 You can also download the distribution manually:
 
-- [Download Kuma](https://download.konghq.com/mesh-alpine/kuma-1.3.1-darwin-amd64.tar.gz)
+- [Download Kuma]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/1.3.1/kuma-1.3.1-darwin-amd64.tar.gz)
 
 Then extract the archive with:
 

--- a/app/docs/1.3.x/installation/openshift.md
+++ b/app/docs/1.3.x/installation/openshift.md
@@ -28,11 +28,11 @@ You can run the following script to automatically detect the operating system an
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access OpenShift:
 
-- [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.3.1-centos-amd64.tar.gz)
-- [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.3.1-rhel-amd64.tar.gz)
-- [Debian](https://download.konghq.com/mesh-alpine/kuma-1.3.1-debian-amd64.tar.gz)
-- [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.3.1-ubuntu-amd64.tar.gz)
-- [macOS](https://download.konghq.com/mesh-alpine/kuma-1.3.1-darwin-amd64.tar.gz) or `brew install kumactl`
+- [CentOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.3.1/kuma-1.3.1-centos-amd64.tar.gz)
+- [RedHat]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/1.3.1/kuma-1.3.1-rhel-amd64.tar.gz)
+- [Debian]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/1.3.1/kuma-1.3.1-debian-amd64.tar.gz)
+- [Ubuntu]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/1.3.1/kuma-1.3.1-ubuntu-amd64.tar.gz)
+- [macOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/1.3.1/kuma-1.3.1-darwin-amd64.tar.gz) or `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.3.x/installation/redhat.md
+++ b/app/docs/1.3.x/installation/redhat.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.3.1-rhel-amd64.tar.gz) the distribution manually.
+or you can [download]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/1.3.1/kuma-1.3.1-rhel-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.3.x/installation/ubuntu.md
+++ b/app/docs/1.3.x/installation/ubuntu.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.3.1-ubuntu-amd64.tar.gz) the distribution manually.
+or you can [download]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/1.3.1/kuma-1.3.1-ubuntu-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.4.x/installation/amazonlinux.md
+++ b/app/docs/1.4.x/installation/amazonlinux.md
@@ -23,7 +23,7 @@ Run the following script to automatically detect the operating system and downlo
 curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.4.1-centos-amd64.tar.gz) the distribution manually.
+or you can [download]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.4.1/kuma-1.4.1-centos-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.4.x/installation/centos.md
+++ b/app/docs/1.4.x/installation/centos.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.4.1-centos-amd64.tar.gz) the distribution manually.
+or you can [download]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.4.1/kuma-1.4.1-centos-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.4.x/installation/debian.md
+++ b/app/docs/1.4.x/installation/debian.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.4.1-debian-amd64.tar.gz) the distribution manually.
+or you can [download]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/1.4.1/kuma-1.4.1-debian-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.4.x/installation/docker.md
+++ b/app/docs/1.4.x/installation/docker.md
@@ -143,11 +143,11 @@ You can run the following script to automatically detect the operating system an
 
 or you can download the distribution manually:
 
-- [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.4.1-centos-amd64.tar.gz)
-- [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.4.1-rhel-amd64.tar.gz)
-- [Debian](https://download.konghq.com/mesh-alpine/kuma-1.4.1-debian-amd64.tar.gz)
-- [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.4.1-ubuntu-amd64.tar.gz)
-- [macOS](https://download.konghq.com/mesh-alpine/kuma-1.4.1-darwin-amd64.tar.gz)
+- [CentOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.4.1/kuma-1.4.1-centos-amd64.tar.gz)
+- [RedHat]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/1.4.1/kuma-1.4.1-rhel-amd64.tar.gz)
+- [Debian]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/1.4.1/kuma-1.4.1-debian-amd64.tar.gz)
+- [Ubuntu]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/1.4.1/kuma-1.4.1-ubuntu-amd64.tar.gz)
+- [macOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/1.4.1/kuma-1.4.1-darwin-amd64.tar.gz)
 
 and extract the archive with:
 

--- a/app/docs/1.4.x/installation/eks.md
+++ b/app/docs/1.4.x/installation/eks.md
@@ -32,11 +32,11 @@ You can run the following script to automatically detect the operating system an
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access Kubernetes:
 
-- [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.4.1-centos-amd64.tar.gz)
-- [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.4.1-rhel-amd64.tar.gz)
-- [Debian](https://download.konghq.com/mesh-alpine/kuma-1.4.1-debian-amd64.tar.gz)
-- [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.4.1-ubuntu-amd64.tar.gz)
-- [macOS](https://download.konghq.com/mesh-alpine/kuma-1.4.1-darwin-amd64.tar.gz) or run `brew install kumactl`
+- [CentOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.4.1/kuma-1.4.1-centos-amd64.tar.gz)
+- [RedHat]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/1.4.1/kuma-1.4.1-rhel-amd64.tar.gz)
+- [Debian]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/1.4.1/kuma-1.4.1-debian-amd64.tar.gz)
+- [Ubuntu]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/1.4.1/kuma-1.4.1-ubuntu-amd64.tar.gz)
+- [macOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/1.4.1/kuma-1.4.1-darwin-amd64.tar.gz) or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.4.x/installation/kubernetes.md
+++ b/app/docs/1.4.x/installation/kubernetes.md
@@ -32,11 +32,11 @@ You can run the following script to automatically detect the operating system an
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access Kubernetes:
 
-- [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.4.1-centos-amd64.tar.gz)
-- [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.4.1-rhel-amd64.tar.gz)
-- [Debian](https://download.konghq.com/mesh-alpine/kuma-1.4.1-debian-amd64.tar.gz)
-- [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.4.1-ubuntu-amd64.tar.gz)
-- [macOS](https://download.konghq.com/mesh-alpine/kuma-1.4.1-darwin-amd64.tar.gz) or run `brew install kumactl`
+- [CentOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.4.1/kuma-1.4.1-centos-amd64.tar.gz)
+- [RedHat]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/1.4.1/kuma-1.4.1-rhel-amd64.tar.gz)
+- [Debian]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/1.4.1/kuma-1.4.1-debian-amd64.tar.gz)
+- [Ubuntu]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/1.4.1/kuma-1.4.1-ubuntu-amd64.tar.gz)
+- [macOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/1.4.1/kuma-1.4.1-darwin-amd64.tar.gz) or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.4.x/installation/macos.md
+++ b/app/docs/1.4.x/installation/macos.md
@@ -28,7 +28,7 @@ Run the following script to automatically detect the operating system and downlo
 
 You can also download the distribution manually:
 
-- [Download Kuma](https://download.konghq.com/mesh-alpine/kuma-1.4.1-darwin-amd64.tar.gz)
+- [Download Kuma]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/1.4.1/kuma-1.4.1-darwin-amd64.tar.gz)
 
 Then extract the archive with:
 

--- a/app/docs/1.4.x/installation/openshift.md
+++ b/app/docs/1.4.x/installation/openshift.md
@@ -28,11 +28,11 @@ You can run the following script to automatically detect the operating system an
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access OpenShift:
 
-- [CentOS](https://download.konghq.com/mesh-alpine/kuma-1.4.1-centos-amd64.tar.gz)
-- [RedHat](https://download.konghq.com/mesh-alpine/kuma-1.4.1-rhel-amd64.tar.gz)
-- [Debian](https://download.konghq.com/mesh-alpine/kuma-1.4.1-debian-amd64.tar.gz)
-- [Ubuntu](https://download.konghq.com/mesh-alpine/kuma-1.4.1-ubuntu-amd64.tar.gz)
-- [macOS](https://download.konghq.com/mesh-alpine/kuma-1.4.1-darwin-amd64.tar.gz) or `brew install kumactl`
+- [CentOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/1.4.1/kuma-1.4.1-centos-amd64.tar.gz)
+- [RedHat]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/1.4.1/kuma-1.4.1-rhel-amd64.tar.gz)
+- [Debian]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/1.4.1/kuma-1.4.1-debian-amd64.tar.gz)
+- [Ubuntu]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/1.4.1/kuma-1.4.1-ubuntu-amd64.tar.gz)
+- [macOS]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/1.4.1/kuma-1.4.1-darwin-amd64.tar.gz) or `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.4.x/installation/redhat.md
+++ b/app/docs/1.4.x/installation/redhat.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.4.1-rhel-amd64.tar.gz) the distribution manually.
+or you can [download]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/1.4.1/kuma-1.4.1-rhel-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.4.x/installation/ubuntu.md
+++ b/app/docs/1.4.x/installation/ubuntu.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can [download](https://download.konghq.com/mesh-alpine/kuma-1.4.1-ubuntu-amd64.tar.gz) the distribution manually.
+or you can [download]({{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/1.4.1/kuma-1.4.1-ubuntu-amd64.tar.gz) the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.5.x/installation/amazonlinux.md
+++ b/app/docs/1.5.x/installation/amazonlinux.md
@@ -23,7 +23,7 @@ Run the following script to automatically detect the operating system and downlo
 curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">download</a> the distribution manually.
+or you can <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">download</a> the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.5.x/installation/centos.md
+++ b/app/docs/1.5.x/installation/centos.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">download</a> the distribution manually.
+or you can <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">download</a> the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.5.x/installation/debian.md
+++ b/app/docs/1.5.x/installation/debian.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">download</a> the distribution manually.
+or you can <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">download</a> the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.5.x/installation/docker.md
+++ b/app/docs/1.5.x/installation/docker.md
@@ -137,11 +137,11 @@ You can run the following script to automatically detect the operating system an
 
 or you can download the distribution manually:
 
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.5.x/installation/eks.md
+++ b/app/docs/1.5.x/installation/eks.md
@@ -32,11 +32,11 @@ You can run the following script to automatically detect the operating system an
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access Kubernetes:
 
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.5.x/installation/kubernetes.md
+++ b/app/docs/1.5.x/installation/kubernetes.md
@@ -32,11 +32,11 @@ You can run the following script to automatically detect the operating system an
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access Kubernetes:
 
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.5.x/installation/macos.md
+++ b/app/docs/1.5.x/installation/macos.md
@@ -28,7 +28,7 @@ Run the following script to automatically detect the operating system and downlo
 
 You can also download the distribution manually:
 
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">Download Kuma</a> or run `brew install kumactl`
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">Download Kuma</a> or run `brew install kumactl`
 
 Then extract the archive with:
 

--- a/app/docs/1.5.x/installation/openshift.md
+++ b/app/docs/1.5.x/installation/openshift.md
@@ -28,11 +28,11 @@ You can run the following script to automatically detect the operating system an
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access OpenShift:
 
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.5.x/installation/redhat.md
+++ b/app/docs/1.5.x/installation/redhat.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">download</a> the distribution manually.
+or you can <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">download</a> the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.5.x/installation/ubuntu.md
+++ b/app/docs/1.5.x/installation/ubuntu.md
@@ -18,7 +18,7 @@ Run the following script to automatically detect the operating system and downlo
 <pre class="no-line-numbers"><code>curl -L https://kuma.io/installer.sh | VERSION={{ page.latest_version }} sh -</code></pre>
 </div>
 
-or you can <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">download</a> the distribution manually.
+or you can <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">download</a> the distribution manually.
 
 Then extract the archive with:
 

--- a/app/docs/1.6.x/installation/docker.md
+++ b/app/docs/1.6.x/installation/docker.md
@@ -120,11 +120,11 @@ You can run the following script to automatically detect the operating system an
 
 or you can download the distribution manually:
 
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.7.x/installation/docker.md
+++ b/app/docs/1.7.x/installation/docker.md
@@ -120,11 +120,11 @@ You can run the following script to automatically detect the operating system an
 
 or you can download the distribution manually:
 
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/1.8.x/contribute/introduction.md
+++ b/app/docs/1.8.x/contribute/introduction.md
@@ -44,10 +44,10 @@ It outputs:
 Getting release
 
 INFO	Welcome to the Kuma automated download!
-INFO	Kuma version: 0.0.0-preview.4d3a9fd03
+INFO	Kuma version: 0.0.0-preview.vbda3bc4bd
 INFO	Kuma architecture: amd64
-INFO	Operating system: Darwin
-INFO	Downloading Kuma from: https://download.konghq.com/mesh-alpine/kuma-0.0.0-preview.4d3a9fd03-darwin-amd64.tar.gz
+INFO	Operating system: darwin
+INFO	Downloading Kuma from: https://packages.konghq.com/public/kuma-binaries-preview/raw/names/kuma-darwin-amd64/versions/bda3bc4bd/kuma-0.0.0-preview.vbda3bc4bd-darwin-amd64.tar.gz
 ```
 
 You then run kumactl with:

--- a/app/docs/1.8.x/installation/docker.md
+++ b/app/docs/1.8.x/installation/docker.md
@@ -120,11 +120,11 @@ You can run the following script to automatically detect the operating system an
 
 or you can download the distribution manually:
 
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/app/docs/2.0.x/contribute/introduction.md
+++ b/app/docs/2.0.x/contribute/introduction.md
@@ -44,10 +44,10 @@ It outputs:
 Getting release
 
 INFO	Welcome to the Kuma automated download!
-INFO	Kuma version: 0.0.0-preview.4d3a9fd03
+INFO	Kuma version: 0.0.0-preview.vbda3bc4bd
 INFO	Kuma architecture: amd64
-INFO	Operating system: Darwin
-INFO	Downloading Kuma from: https://download.konghq.com/mesh-alpine/kuma-0.0.0-preview.4d3a9fd03-darwin-amd64.tar.gz
+INFO	Operating system: darwin
+INFO	Downloading Kuma from: https://packages.konghq.com/public/kuma-binaries-preview/raw/names/kuma-darwin-amd64/versions/bda3bc4bd/kuma-0.0.0-preview.vbda3bc4bd-darwin-amd64.tar.gz
 ```
 
 You then run kumactl with:

--- a/app/docs/2.0.x/installation/docker.md
+++ b/app/docs/2.0.x/installation/docker.md
@@ -119,11 +119,11 @@ curl -L https://kuma.io/installer.sh | sh -
 
 or you can download the distribution manually:
 
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
-- <a href="https://download.konghq.com/mesh-alpine/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-centos-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-centos-amd64.tar.gz">CentOS</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-rhel-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-rhel-amd64.tar.gz">RedHat</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-debian-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-debian-amd64.tar.gz">Debian</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-ubuntu-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-ubuntu-amd64.tar.gz">Ubuntu</a>
+- <a href="{{ site.links.direct }}/kuma-legacy/raw/names/kuma-darwin-amd64/versions/{{ page.latest_version }}/kuma-{{ page.latest_version }}-darwin-amd64.tar.gz">macOS</a> or run `brew install kumactl`
 
 and extract the archive with:
 

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -17,7 +17,8 @@ title: "Kuma"
 description: "Build, Secure and Observe your modern Service Mesh"
 links:
   web: https://kuma.io
-  download: https://download.konghq.com
+  download: https://cloudsmith.io/~kong/repos
+  direct: https://packages.konghq.com/public
 fb:
   app_id: 682375632267551
 twitter:

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -19,7 +19,8 @@ title: "Kuma"
 description: "Build, Secure and Observe your modern Service Mesh"
 links:
   web: https://kuma.io
-  download: https://download.konghq.com
+  download: https://cloudsmith.io/~kong/repos
+  direct: https://packages.konghq.com/public
 fb:
   app_id: 682375632267551
 twitter:


### PR DESCRIPTION
These changes cause the docs (including historical/legacy docs) to link to Cloudsmith instead of Pulp.

Because the docs feature both links to Pulp's "gui" and for direct downloads, I've repurposed the jekyll templating variable `site.links.download` (for gui-ish links) and added `site.links.direct` (for direct download links).

Did you sign your commit? Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? Yes

[KAG-2257](https://konghq.atlassian.net/browse/KAG-2257)
