### PR TITLE
fix(jsonschema): remove new lines from description

### DIFF
--- a/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/jsonschema.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/jsonschema.rb
@@ -30,11 +30,23 @@ module Jekyll
                   <script type="text/javascript">
                   const data = #{JSON.dump(data)};
                   document.addEventListener("DOMContentLoaded", function() {
+                    function removeNewlinesFromDescriptions(obj) {
+                      for (const key in obj) {
+                        if (typeof obj[key] === 'object') {
+                          // Recursively process nested objects
+                          removeNewlinesFromDescriptions(obj[key]);
+                        } else if (key === 'description' && typeof obj[key] === 'string') {
+                          // Replace newlines in description values
+                          obj[key] = obj[key].replace(\/\\n/g, '');
+                        }
+                      }
+                    }
                     // create an instance of JSONSchemaMarkdown
                     const Doccer = new JSONSchemaMarkdown();
-
                     // don't include the path of the field in the output
                     Doccer.writePath = function() {};
+                    // remove new lines in description
+                    removeNewlinesFromDescriptions(data)
 
                     Doccer.load(data);
                     Doccer.generate();


### PR DESCRIPTION
Kubebuilder 0.14 has introduced a change in how it handles new lines in field descriptions. Now, if there is a new line, it adds it to the object, causing rendering issues for the objects. I attempted to address this by utilizing the library option, but unfortunately, it is not supported (refer to https://github.com/showdownjs/showdown/issues/801).

As a workaround, I implemented a function that iterates over the object and removes new lines from the description field.

https://kuma.io/docs/2.6.x/policies/meshgatewayinstance/#schema
https://deploy-preview-1632--kuma.netlify.app/docs/2.6.x/policies/meshgatewayinstance/#schema

