### PR TITLE
fix(installer): set VERSION to the commit hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,6 @@ jobs:
           - ubuntu:22.04
     container:
       image: ${{ matrix.os }}
-    env:
-      VERBOSE: ${{ runner.debug }}
     steps:
       - name: Prepare OS
         run: |
@@ -102,12 +100,15 @@ jobs:
           yum install file tar gzip -y || true
       - uses: actions/checkout@v3
       - name: Run installer.sh
+        env:
+          VERBOSE: ${{ runner.debug }}
         run: |
           sh app/installer.sh
           file ./kuma-*/bin/kumactl | grep x86-64 &> /dev/null
           rm -rf ./kuma-*/
       - name: Run installer.sh with VERSION=preview
         env:
+          VERBOSE: ${{ runner.debug }}
           VERSION: preview
         run: |
           sh app/installer.sh
@@ -115,6 +116,7 @@ jobs:
           rm -rf ./kuma-*/
       - name: Run installer.sh with legacy version
         env:
+          VERBOSE: ${{ runner.debug }}
           VERSION: 2.2.0
         run: |
           sh app/installer.sh
@@ -122,6 +124,7 @@ jobs:
           rm -rf ./kuma-*/
       - name: Run installer.sh with preview version
         env:
+          VERBOSE: ${{ runner.debug }}
           VERSION: 0.0.0-preview.v76e03eb68
         run: |
           sh app/installer.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
           - ubuntu:22.04
     container:
       image: ${{ matrix.os }}
+    env:
+      VERBOSE: ${{ runner.debug }}
     steps:
       - name: Prepare OS
         run: |
@@ -100,11 +102,32 @@ jobs:
           yum install file tar gzip -y || true
       - uses: actions/checkout@v3
       - name: Run installer.sh
+        run: |
+          sh app/installer.sh
+          file ./kuma-*/bin/kumactl | grep x86-64 &> /dev/null
+          rm -rf ./kuma-*/
+      - name: Run installer.sh with VERSION=preview
         env:
-          VERBOSE: ${{ runner.debug }}
-        run: sh app/installer.sh
-      - name: Check kumactl architecture
-        run: file ./kuma-*/bin/kumactl | grep x86-64 &> /dev/null
+          VERSION: preview
+        run: |
+          sh app/installer.sh
+          file ./kuma-0.0.0-preview.v/bin/kumactl | grep x86-64 &> /dev/null
+          rm -rf ./kuma-*/
+      - name: Run installer.sh with legacy version
+        env:
+          VERSION: 2.2.0
+        run: |
+          sh app/installer.sh
+          file ./kuma-2.2.0/bin/kumactl | grep x86-64 &> /dev/null
+          rm -rf ./kuma-*/
+      - name: Run installer.sh with preview version
+        env:
+          VERSION: 0.0.0-preview.v76e03eb68
+        run: |
+          sh app/installer.sh
+          file ./kuma-2.2.0/bin/kumactl | grep x86-64 &> /dev/null
+          rm -rf ./kuma-*/ 
+
 
   installer-sh-arm64:
     runs-on: ubuntu-latest

--- a/app/installer.sh
+++ b/app/installer.sh
@@ -212,6 +212,7 @@ EOF
 
   if echo "$FILENAME_VERSION" | grep -qs -E 'preview|0.0.0'; then
     URL_REPO="${REPO_REPO}-binaries-preview"
+    VERSION="${FILENAME_VERSION#*0.0.0-preview.v}"
   else
 
     # 2.1.x or lower


### PR DESCRIPTION
When running a command:
```
curl https://kuma.io/installer.sh | VERSION=0.0.0-preview.v97af5da5e sh -
```
it attempts to use the URL (and fails):
```
https://packages.konghq.com/public/kuma-binaries-preview/raw/names/kuma-darwin-arm64/versions/0.0.0-preview.v97af5da5e/kuma-0.0.0-preview.v97af5da5e-darwin-arm64.tar.gz
```
the correct URL is (difference after the `/versions/`):
```
https://packages.konghq.com/public/kuma-binaries-preview/raw/names/kuma-darwin-arm64/versions/97af5da5e/kuma-0.0.0-preview.v97af5da5e-darwin-arm64.tar.gz
```
