### PR TITLE
fix(installer): set VERSION to commit hash for previews

### DIFF
--- a/app/installer.sh
+++ b/app/installer.sh
@@ -212,6 +212,7 @@ EOF
 
   if echo "$FILENAME_VERSION" | grep -qs -E 'preview|0.0.0'; then
     URL_REPO="${REPO_REPO}-binaries-preview"
+    VERSION="${FILENAME_VERSION#*0.0.0-preview.v}"
   else
 
     # 2.1.x or lower


### PR DESCRIPTION
When running a command:
```
curl https://kuma.io/installer.sh | VERSION=0.0.0-preview.v97af5da5e sh -
```
it attempts to use the URL (and fails):
```
https://packages.konghq.com/public/kuma-binaries-preview/raw/names/kuma-darwin-arm64/versions/0.0.0-preview.v97af5da5e/kuma-0.0.0-preview.v97af5da5e-darwin-arm64.tar.gz
```
the correct URL is (difference after the `/versions/`):
```
https://packages.konghq.com/public/kuma-binaries-preview/raw/names/kuma-darwin-arm64/versions/97af5da5e/kuma-0.0.0-preview.v97af5da5e-darwin-arm64.tar.gz
```