### PR TITLE
docs(Argo CD): Add Kubernetes cp page to 2.2 and 2.3, add redirects for argo cd section

### DIFF
--- a/app/_data/docs_nav_kuma_2.2.x.yml
+++ b/app/_data/docs_nav_kuma_2.2.x.yml
@@ -63,6 +63,8 @@ items:
             generate: false
           - text: Systemd
             url: /production/cp-deployment/systemd/
+          - text: Kubernetes
+            url: /production/cp-deployment/kubernetes/
       - text: Create multiple service meshes in a cluster
         url: /production/mesh/
       - title: Data plane configuration

--- a/app/_data/docs_nav_kuma_2.3.x.yml
+++ b/app/_data/docs_nav_kuma_2.3.x.yml
@@ -61,6 +61,8 @@ items:
             generate: false
           - text: Systemd
             url: /production/cp-deployment/systemd/
+          - text: Kubernetes
+            url: /production/cp-deployment/kubernetes/
       - text: Create multiple service meshes in a cluster
         url: /production/mesh/
       - title: Data plane configuration

--- a/app/_redirects
+++ b/app/_redirects
@@ -39,6 +39,11 @@ https://prometheus.metrics.kuma.io/path /docs/LATEST_RELEASE/reference/kubernete
 https://traffic.kuma.io/exclude-inbound-ports /docs/LATEST_RELEASE/reference/kubernetes-annotations/#traffic-kuma-io-exclude-inbound-ports/ 302
 https://traffic.kuma.io/exclude-outbound-ports /docs/LATEST_RELEASE/reference/kubernetes-annotations/#traffic-kuma-io-exclude-outbound-ports/ 302
 
+# Argo CD section redirects post submodule
+
+/docs/2.3.x/installation/helm/#argo-cd  /docs/2.3.x/production/cp-deployment/kubernetes/#argo-cd    
+/docs/2.2.x/installation/helm/#argo-cd  /docs/2.2.x/production/cp-deployment/kubernetes/#argo-cd
+
 # Community section
 
 /contribute/introduction/*  /docs/LATEST_RELEASE/community/contribute-to-kuma/:splat 302


### PR DESCRIPTION
See #1319 for context. This PR adds the Kubernetes page (along with the Argo CD) section back to the 2.2 and 2.3 docs because they are still an active release. I also added redirects, but those don't seem to be working. Maybe they are overridden by app/_plugins/generator/redirects.rb?

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
