### PR TITLE
Fix rack dep

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,9 +20,7 @@ GEM
     ffi (1.15.5)
     foreman (0.87.2)
     forwardable-extended (2.6.0)
-    google-protobuf (3.23.3-arm64-darwin)
-    google-protobuf (3.23.3-x86_64-darwin)
-    google-protobuf (3.23.3-x86_64-linux)
+    google-protobuf (3.23.3)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -101,12 +99,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
-  arm64-darwin-21
-  arm64-darwin-22
-  arm64-darwin-23
-  x86_64-darwin-21
-  x86_64-darwin-22
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
       forwardable-extended (~> 2.6)
     posix-spawn (0.3.15)
     public_suffix (5.0.1)
-    rack (3.0.8)
+    rack (3.0.10)
     rack-proxy (0.7.6)
       rack
     rackup (0.2.3)


### PR DESCRIPTION
Clean up the [platforms](https://bundler.io/v2.5/man/gemfile.5.html#PLATFORMS) section of the Gemfile.lock
We don't need to specify specific platforms, we can just list `ruby` and let bundler figure out if it needs to install platform-specific versions of the gems.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
