### PR TITLE
chore(links-checker): exclude github anchors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
             ${URL} \
             --buffer-size 8192 \
             --exclude 'https://github.com/(/)?kumahq/kuma/pull/.*' \
+            --exclude 'https://github.com/(/)?kumahq/kuma/blob/.*#.*' \
             --exclude 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md.*' \
             --exclude ${URL}/docs/1. \
             --exclude 127.0.0.1 \


### PR DESCRIPTION
exclude github anchors since they are no longer server side rendered - that causes the link checker to 404 on these https://github.com/kumahq/kuma-website/actions/runs/8399842601/job/23006467632?pr=1694#step:6:23

```
curl 'https://github.com/kumahq/kuma/blob/master/tools/releases/version.sh#L11' | grep "L11"
```

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
