### PR TITLE
fix(installer.sh): make VERSION=preview more reliable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           - debian:bookworm
           - fedora:latest
           - redhat/ubi8:8.6
-          - ubuntu:22.04
+          - ubuntu:23.10 # to have newer gh version, update to 24.04 LTS when released
     container:
       image: ${{ matrix.os }}
     steps:

--- a/app/installer.sh
+++ b/app/installer.sh
@@ -110,7 +110,7 @@ main() {
     fi
 
     log "Fetching latest preview commit.."
-    commit=$(gh run list --repo "${REPO}" --branch "${BRANCH}" --workflow build-test-distribute -e push -s success --json headSha --jq '. | first | .headSha[0:9]')
+    commit=$(gh run list --repo "${REPO}" --branch "${BRANCH}" --workflow build-test-distribute -L 200 --json event,headSha,conclusion --jq '[.[] | select(.conclusion == "success" and .event == "push")] | first | .headSha[0:9]')
     if ! echo "$commit" | grep -qs -E '[a-z0-9]{9,}'; then
       err "Failed to find suitable preview commit (${count} commits checked)."
     fi


### PR DESCRIPTION
Before we were using some graphQL black magic.
Now we use `gh run list` which enables to very strictly filter on successful workflow run

This should avoid failures in CI due to build-test-distribute waiting to be run
