### PR TITLE
chore(links): exclude anchors for all github links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             ${URL} \
             --buffer-size 8192 \
             --exclude 'https://github.com/(/)?kumahq/kuma/pull/.*' \
-            --exclude 'https://github.com/(/)?kumahq/kuma/blob/.*#.*' \
+            --exclude 'https://github.com/.*/.*/blob/.*#.*' \
             --exclude 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md.*' \
             --exclude ${URL}/docs/1. \
             --exclude 127.0.0.1 \
@@ -66,7 +66,7 @@ jobs:
             ${URL}/docs/dev \
             --buffer-size 8192 \
             --exclude 'https://github.com/(/)?kumahq/kuma/pull/.*' \
-            --exclude 'https://github.com/(/)?kumahq/kuma/blob/.*#.*' \
+            --exclude 'https://github.com/.*/.*/blob/.*#.*' \
             --exclude 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md.*' \
             --exclude 127.0.0.1 \
             --exclude https://cloudsmith.io/~kong/repos \


### PR DESCRIPTION
exclude anchors for all github links since they are not server side rendered

continuation of https://github.com/kumahq/kuma-website/pull/1697 but for all GH links

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
