### PR TITLE
chore(links): fix 404'd redis links

### DIFF
--- a/app/_src/quickstart/universal.md
+++ b/app/_src/quickstart/universal.md
@@ -15,7 +15,7 @@ The zone key is purely static and arbitrary. Different zone values for different
 
 ## Prerequisites
 
-- [Redis installed](https://redis.io/docs/getting-started/)
+- [Redis installed](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack)
 - [{{site.mesh_product_name}} installed](/install)
 - [Demo app downloaded from GitHub](https://github.com/kumahq/kuma-counter-demo):
 

--- a/app/docs/1.2.x/quickstart/universal.md
+++ b/app/docs/1.2.x/quickstart/universal.md
@@ -15,7 +15,7 @@ The zone key is purely static and arbitrary. Different zone values for different
 
 ## Prerequisites
 
-- [Redis installed](https://redis.io/docs/quickstart)
+- [Redis installed](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack)
 - [Kuma installed](/install)
 - [Demo app downloaded from GitHub](https://github.com/kumahq/kuma-counter-demo):
 

--- a/app/docs/1.3.x/quickstart/universal.md
+++ b/app/docs/1.3.x/quickstart/universal.md
@@ -15,7 +15,7 @@ The zone key is purely static and arbitrary. Different zone values for different
 
 ## Prerequisites
 
-- [Redis installed](https://redis.io/docs/quickstart)
+- [Redis installed](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack)
 - [Kuma installed](/install)
 - [Demo app downloaded from GitHub](https://github.com/kumahq/kuma-counter-demo):
 

--- a/app/docs/1.4.x/quickstart/universal.md
+++ b/app/docs/1.4.x/quickstart/universal.md
@@ -15,7 +15,7 @@ The zone key is purely static and arbitrary. Different zone values for different
 
 ## Prerequisites
 
-- [Redis installed](https://redis.io/docs/quickstart)
+- [Redis installed](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack)
 - [Kuma installed](/install)
 - [Demo app downloaded from GitHub](https://github.com/kumahq/kuma-counter-demo):
 

--- a/app/docs/1.5.x/quickstart/universal.md
+++ b/app/docs/1.5.x/quickstart/universal.md
@@ -15,7 +15,7 @@ The zone key is purely static and arbitrary. Different zone values for different
 
 ## Prerequisites
 
-- [Redis installed](https://redis.io/docs/quickstart)
+- [Redis installed](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack)
 - [Kuma installed](/install)
 - [Demo app downloaded from GitHub](https://github.com/kumahq/kuma-counter-demo):
 

--- a/app/docs/1.6.x/quickstart/universal.md
+++ b/app/docs/1.6.x/quickstart/universal.md
@@ -15,7 +15,7 @@ The zone key is purely static and arbitrary. Different zone values for different
 
 ## Prerequisites
 
-- [Redis installed](https://redis.io/docs/getting-started/)
+- [Redis installed](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack)
 - [Kuma installed](/install)
 - [Demo app downloaded from GitHub](https://github.com/kumahq/kuma-counter-demo):
 

--- a/app/docs/1.7.x/quickstart/universal.md
+++ b/app/docs/1.7.x/quickstart/universal.md
@@ -15,7 +15,7 @@ The zone key is purely static and arbitrary. Different zone values for different
 
 ## Prerequisites
 
-- [Redis installed](https://redis.io/docs/getting-started/)
+- [Redis installed](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack)
 - [Kuma installed](/install)
 - [Demo app downloaded from GitHub](https://github.com/kumahq/kuma-counter-demo):
 

--- a/app/docs/1.8.x/quickstart/universal.md
+++ b/app/docs/1.8.x/quickstart/universal.md
@@ -15,7 +15,7 @@ The zone key is purely static and arbitrary. Different zone values for different
 
 ## Prerequisites
 
-- [Redis installed](https://redis.io/docs/getting-started/)
+- [Redis installed](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack)
 - [Kuma installed](/install)
 - [Demo app downloaded from GitHub](https://github.com/kumahq/kuma-counter-demo):
 

--- a/app/docs/2.0.x/quickstart/universal.md
+++ b/app/docs/2.0.x/quickstart/universal.md
@@ -15,7 +15,7 @@ The zone key is purely static and arbitrary. Different zone values for different
 
 ## Prerequisites
 
-- [Redis installed](https://redis.io/docs/getting-started/)
+- [Redis installed](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack)
 - [{{site.mesh_product_name}} installed](/install)
 - [Demo app downloaded from GitHub](https://github.com/kumahq/kuma-counter-demo):
 


### PR DESCRIPTION
The old redis ones are 404ing, probably they broke their docs.