### PR TITLE
docs(routing): make the examples work for marketplace demos

### DIFF
--- a/app/_posts/2023-02-01-kuma-2-1-0.md
+++ b/app/_posts/2023-02-01-kuma-2-1-0.md
@@ -64,18 +64,18 @@ spec:
        - matches:
            - path:
                type: Prefix
-               value: /api
+               value: /
          default:
            backendRefs:
              - kind: MeshServiceSubset
                name: backend_kuma-demo_svc_3001
                tags:
-                 version: "1.0"
+                 version: "v0"
                weight: 90
              - kind: MeshServiceSubset
                name: backend_kuma-demo_svc_3001
                tags:
-                 version: "2.0"
+                 version: "v1"
                weight: 10
 ```
 

--- a/app/_posts/2023-06-23-kuma-2-3-0.md
+++ b/app/_posts/2023-06-23-kuma-2-3-0.md
@@ -54,12 +54,12 @@ spec:
               - kind: MeshServiceSubset
                 name: backend_kuma-demo_svc_3001
                 tags:
-                  version: "1.0"
+                  version: "v0"
                 weight: 90
               - kind: MeshServiceSubset
                 name: backend_kuma-demo_svc_3001
                 tags:
-                  version: "2.0"
+                  version: "v1"
                 weight: 10
 ```
 

--- a/app/_src/policies/meshhttproute.md
+++ b/app/_src/policies/meshhttproute.md
@@ -182,18 +182,18 @@ spec:
         - matches:
             - path:
                 type: PathPrefix
-                value: /api
+                value: /
           default:
             backendRefs:
               - kind: MeshServiceSubset
                 name: backend_kuma-demo_svc_3001
                 tags:
-                  version: "1.0"
+                  version: "v0"
                 weight: 90
               - kind: MeshServiceSubset
                 name: backend_kuma-demo_svc_3001
                 tags:
-                  version: "2.0"
+                  version: "v1"
                 weight: 10
 ```
 {% endif_version %}
@@ -218,18 +218,18 @@ spec:
         - matches:
             - path:
                 type: Prefix
-                value: /api
+                value: /
           default:
             backendRefs:
               - kind: MeshServiceSubset
                 name: backend_kuma-demo_svc_3001
                 tags:
-                  version: "1.0"
+                  version: "v0"
                 weight: 90
               - kind: MeshServiceSubset
                 name: backend_kuma-demo_svc_3001
                 tags:
-                  version: "2.0"
+                  version: "v1"
                 weight: 10
 ```
 {% endif_version %}
@@ -252,18 +252,18 @@ spec:
         - matches:
             - path:
                 type: PathPrefix
-                value: /api
+                value: /
           default:
             backendRefs:
               - kind: MeshServiceSubset
                 name: backend_kuma-demo_svc_3001
                 tags:
-                  version: "1.0"
+                  version: "v0"
                 weight: 90
               - kind: MeshServiceSubset
                 name: backend_kuma-demo_svc_3001
                 tags:
-                  version: "2.0"
+                  version: "v1"
                 weight: 10
 ```
 {% endif_version %}
@@ -284,18 +284,18 @@ spec:
         - matches:
             - path:
                 type: PathPrefix
-                value: /api
+                value: /
           default:
             backendRefs:
               - kind: MeshServiceSubset
                 name: backend_kuma-demo_svc_3001
                 tags:
-                  version: "1.0"
+                  version: "v0"
                 weight: 90
               - kind: MeshServiceSubset
                 name: backend_kuma-demo_svc_3001
                 tags:
-                  version: "2.0"
+                  version: "v1"
                 weight: 10
 ```
 {% endif_version %}

--- a/app/_src/policies/meshtcproute.md
+++ b/app/_src/policies/meshtcproute.md
@@ -127,12 +127,12 @@ spec:
               - kind: MeshServiceSubset
                 name: backend_kuma-demo_svc_3001
                 tags:
-                  version: "1.0"
+                  version: "v0"
                 weight: 90
               - kind: MeshServiceSubset
                 name: backend_kuma-demo_svc_3001
                 tags:
-                  version: "2.0"
+                  version: "v1"
                 weight: 10
 ```
 
@@ -159,12 +159,12 @@ spec:
               - kind: MeshServiceSubset
                 name: backend_kuma-demo_svc_3001
                 tags:
-                  version: "1.0"
+                  version: "v0"
                 weight: 90
               - kind: MeshServiceSubset
                 name: backend_kuma-demo_svc_3001
                 tags:
-                  version: "2.0"
+                  version: "v1"
                 weight: 10
 ```
 


### PR DESCRIPTION
The examples in the blogpost / httproute / tcproute look like they should work with the marketplace demo but they **actually don't** (`kuma.io/service` is the same, but version tags and prefix is wrong).

This combined with the "catch all" route causes an invalid MeshHTTPRoute to "sort of work" without any warning and can cause confusion down the line.

E.g. if we take the old MeshHTTPRoute with a 90/10 split:

```yaml
          default:
            backendRefs:
              - kind: MeshServiceSubset
                name: backend_kuma-demo_svc_3001
                tags:
                  version: "1.0"
                weight: 90
              - kind: MeshServiceSubset
                name: backend_kuma-demo_svc_3001
                tags:
                  version: "2.0"
                weight: 10
```

this produces the following envoy configuration:

```yaml
      - match:
          path: "/api"
        route:
          weighted_clusters:
            clusters:
            - name: backend_kuma-demo_svc_3001-de1397ec09e96dfb
              weight: 90
            - name: backend_kuma-demo_svc_3001-e0530223b717773a
              weight: 10
      - match:
          prefix: "/api/"
        route:
          weighted_clusters:
            clusters:
            - name: backend_kuma-demo_svc_3001-de1397ec09e96dfb
              weight: 90
            - name: backend_kuma-demo_svc_3001-e0530223b717773a
              weight: 10
          timeout: 15s
      - match:
          prefix: "/"
        route:
          cluster: backend_kuma-demo_svc_3001
```

the first two matches will not match (not matching version/path) and the "catch all" will make the requests work with 50/50 split.

I think this is a bug in "catch all" mechanism. I think we should add the "prefix" to existing split not create a new "catch all" route. So if there is no match you get a 404 and you immediately know that there is something wrong with `MeshHTTPRoute` and not silently ignore the not working policy. WDYT? @bartsmykla (original author of https://github.com/kumahq/kuma/pull/6993) @lobkovilya ( https://github.com/kumahq/kuma/issues/6758 ) and @michaelbeaumont ( this docs ) also @lahabana.

Kuma issue: https://github.com/kumahq/kuma/issues/9885

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
