### PR TITLE
feat(installer): use cloudsmith instead of gh to fetch preview version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,9 @@ jobs:
     steps:
       - name: Prepare OS
         run: |
-          (apt-get update && apt-get install file curl gh -y) || true
-          (yum install yum-utils -y && yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && yum install file tar gzip gh -y) || true
-          pacman --noconfirm -Sy github-cli file curl || true
+          (apt-get update && apt-get install file curl jq -y) || true
+          (yum install yum-utils -y && yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && yum install file tar gzip jq -y) || true
+          pacman --noconfirm -Sy jq file curl || true
       - uses: actions/checkout@v3
       - name: Run installer.sh
         env:

--- a/app/installer.sh
+++ b/app/installer.sh
@@ -105,12 +105,12 @@ main() {
 
   if [ "$VERSION" = 'preview' ]; then
 
-    if ! command -v gh >/dev/null 2>&1; then
-      err "Must have github's gh CLI installed to install a preview version."
+    if ! command -v jq >/dev/null 2>&1; then
+      err "Must have jq installed to install a preview version."
     fi
 
     log "Fetching latest preview commit.."
-    commit=$(gh run list --repo "${REPO}" --branch "${BRANCH}" --workflow build-test-distribute -L 200 --json event,headSha,conclusion --jq '[.[] | select(.conclusion == "success" and .event == "push")] | first | .headSha[0:9]')
+    commit=$(curl -s --request GET --url 'https://api.cloudsmith.io/v1/packages/kong/kong-mesh-binaries-preview/?page=1&page_size=1&query=filename%3A0.0.0-preview&sort=-date' --header 'accept: application/json' | jq -r '.[0].version')
     if ! echo "$commit" | grep -qs -E '[a-z0-9]{9,}'; then
       err "Failed to find suitable preview commit (${count} commits checked)."
     fi

--- a/app/installer.sh
+++ b/app/installer.sh
@@ -110,7 +110,7 @@ main() {
     fi
 
     log "Fetching latest preview commit.."
-    commit=$(curl -s --request GET --url "https://api.cloudsmith.io/v1/packages/kong/${PRODUCT_NAME}-binaries-preview/?page=1&page_size=1&query=filename%3A0.0.0-preview&sort=-date" --header 'accept: application/json' | jq -r '.[0].version')
+    commit=$(curl -s --request GET --url "https://api.cloudsmith.io/v1/packages/kong/""$(echo ${PRODUCT_NAME} | tr '[:upper:]' '[:lower:]')""-binaries-preview/?page=1&page_size=1&query=filename%3A0.0.0-preview&sort=-date" --header 'accept: application/json' | jq -r '.[0].version')
     if ! echo "$commit" | grep -qs -E '[a-z0-9]{9,}'; then
       err "Failed to find suitable preview commit (${count} commits checked)."
     fi

--- a/app/installer.sh
+++ b/app/installer.sh
@@ -110,7 +110,7 @@ main() {
     fi
 
     log "Fetching latest preview commit.."
-    commit=$(curl -s --request GET --url 'https://api.cloudsmith.io/v1/packages/kong/kong-mesh-binaries-preview/?page=1&page_size=1&query=filename%3A0.0.0-preview&sort=-date' --header 'accept: application/json' | jq -r '.[0].version')
+    commit=$(curl -s --request GET --url "https://api.cloudsmith.io/v1/packages/kong/${PRODUCT_NAME}-binaries-preview/?page=1&page_size=1&query=filename%3A0.0.0-preview&sort=-date" --header 'accept: application/json' | jq -r '.[0].version')
     if ! echo "$commit" | grep -qs -E '[a-z0-9]{9,}'; then
       err "Failed to find suitable preview commit (${count} commits checked)."
     fi


### PR DESCRIPTION
`gh` requires a valid token - in this PR I exchange it for cloudsmith which does not and now people who don't have a valid token can try out the preview version

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
