### PR TITLE
chore(guides): drop deprecated kuma.io/service in gateway

### DIFF
--- a/app/_src/guides/gateway-builtin.md
+++ b/app/_src/guides/gateway-builtin.md
@@ -45,8 +45,6 @@ metadata:
 spec:
   replicas: 1
   serviceType: LoadBalancer
-  tags:
-    kuma.io/service: edge-gateway
 " | kubectl apply -f -
 ```
 
@@ -71,7 +69,7 @@ metadata:
 spec:
   selectors:
     - match:
-        kuma.io/service: edge-gateway
+        kuma.io/service: edge-gateway_kuma-demo_svc
   conf:
     listeners:
       - port: 8080
@@ -205,7 +203,7 @@ spec:
   from:
     - targetRef:
         kind: MeshService
-        name: edge-gateway 
+        name: edge-gateway_kuma-demo_svc 
       default:
         action: Allow
 " | kubectl apply -f -
@@ -278,7 +276,7 @@ metadata:
 spec:
   selectors:
     - match:
-        kuma.io/service: edge-gateway
+        kuma.io/service: edge-gateway_kuma-demo_svc
   conf:
     listeners:
       - port: 8080


### PR DESCRIPTION
Using `kuma.io/service` is deprecated