### PR TITLE
fix(docs): ensure getting started links have a return between them

### DIFF
--- a/app/_src/index.md
+++ b/app/_src/index.md
@@ -28,6 +28,7 @@ The core maintainer of Kuma is **Kong**, the maker of the popular open-source Ko
 {% if_version gte:2.2.x %}
 [Read about service mesh](/docs/{{ page.version }}/introduction/about-service-meshes)
 
+
 [Read about Kuma](/docs/{{ page.version }}/introduction/overview-of-kuma)
 
 [Install Kuma](/install/latest/)

--- a/app/_src/index.md
+++ b/app/_src/index.md
@@ -17,6 +17,7 @@ The core maintainer of Kuma is **Kong**, the maker of the popular open-source Ko
 {% if_version lte:2.1.x %}
 [Read about service mesh](/docs/{{ page.version }}/introduction/what-is-a-service-mesh)
 
+
 [Read about Kuma](/docs/{{ page.version }}/introduction/what-is-kuma)
 
 [Install Kuma](/install/latest/)


### PR DESCRIPTION
Looks like there is some strange markdown behaviour with `if_version`.

This PR just amends one problem, but doesn't solve whatever the issue is. Happy to close if someone has a better solution.

### Before

![Screenshot 2024-04-15 at 16 19 50](https://github.com/kumahq/kuma-website/assets/554604/0627d372-ac09-4db2-b3f6-286201fe3da9)

### After

![Screenshot 2024-04-15 at 16 19 36](https://github.com/kumahq/kuma-website/assets/554604/da44eaf3-dc24-47f7-ae4e-c6f951c2afe6)
