### PR TITLE
fix(installer): fix installer for kong mesh

### DIFF
--- a/app/installer.sh
+++ b/app/installer.sh
@@ -110,9 +110,9 @@ main() {
     fi
 
     log "Fetching latest preview commit.."
-    commit=$(curl -s --request GET --url "https://api.cloudsmith.io/v1/packages/kong/""$(echo ${PRODUCT_NAME} | tr '[:upper:]' '[:lower:]')""-binaries-preview/?page=1&page_size=1&query=filename%3A0.0.0-preview&sort=-date" --header 'accept: application/json' | jq -r '.[0].version')
+    commit=$(curl -s --request GET --url "https://api.cloudsmith.io/v1/packages/kong/""$(echo ${PRODUCT_NAME} | tr '[:upper:]' '[:lower:]' | tr ' ' '-')""-binaries-preview/?page=1&page_size=1&query=filename%3A0.0.0-preview&sort=-date" --header 'accept: application/json' | jq -r '.[0].version')
     if ! echo "$commit" | grep -qs -E '[a-z0-9]{9,}'; then
-      err "Failed to find suitable preview commit (${count} commits checked)."
+      err "Failed to find suitable preview commit."
     fi
     log "Found preview commit: https://github.com/${REPO}/commit/${commit}"
 


### PR DESCRIPTION
There was an unsued variable from the graphql version and `kong mesh` needs to be `kong-mesh`

```
$ PRODUCT_NAME='Kong Mesh' VERSION=preview app/installer.sh --print-version

INFO    Welcome to the Kong Mesh automated download!
INFO    Fetching latest preview commit..
INFO    Found preview commit: https://github.com/kumahq/kuma/commit/7bf655a7a
0.0.0-preview.v7bf655a7a
```

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
