### PR TITLE
docs(gateway/builtin): update gateway docs after service tag deprecation in MeshGatewayInstance

### DIFF
--- a/app/_includes/snippets/warning_meshgatewayinstance_service_tag.md
+++ b/app/_includes/snippets/warning_meshgatewayinstance_service_tag.md
@@ -1,0 +1,11 @@
+[//]: # (This is change in behavior, let's assume that users will get used to it, so we won't have to show this warning after 2.9.x)
+{% if_version gte:2.7.x lte:2.9.x %}
+
+{% warning %}
+**Heads up!**
+In previous versions of {{site.mesh_product_name}}, setting the `kuma.io/service` tag directly within a `MeshGatewayInstance` resource was used to identify the service. However, this practice is deprecated and no longer recommended for security reasons since {{site.mesh_product_name}} version 2.7.0.
+
+We've automatically switched to generating the service name for you based on your `MeshGatewayInstance` resource name and namespace (format: `{name}_{namespace}_svc`).
+{% endwarning %}
+
+{% endif_version %}

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-k8s.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-k8s.md
@@ -59,8 +59,15 @@ spec:
 ```
 {% endif_version %}
 
-Once a `MeshGateway` exists with {% if_version lte:2.6.x inline:true %}`kuma.io/service: edge-gateway`{% endif_version %}{% if_version gte:2.7.x inline:true %}`kuma.io/service: edge-gateway_default_svc`{% endif_version %}, the control plane creates a new `Deployment` in the `default` namespace.
-This `Deployment` deploys 2 replicas of `kuma-dp` and corresponding builtin gateway `Dataplane` running with {% if_version lte:2.6.x inline:true %}`kuma.io/service: edge-gateway`{% endif_version %}{% if_version gte:2.7.x inline:true %}`kuma.io/service: edge-gateway_default_svc`{% endif_version %}.
+{% if_version lte:2.6.x %}
+Once a `MeshGateway` exists with `kuma.io/service: edge-gateway`, the control plane creates a new `Deployment` in the `default` namespace.
+This `Deployment` deploys 2 replicas of `kuma-dp` and corresponding builtin gateway `Dataplane` running with `kuma.io/service: edge-gateway`.
+{% endif_version %}
+{% if_version gte:2.7.x %}
+Once a `MeshGateway` exists with `kuma.io/service: edge-gateway_default_svc`, the control plane creates a new `Deployment` in the `default` namespace.
+This `Deployment` deploys 2 replicas of `kuma-dp` and corresponding builtin gateway `Dataplane` running with `kuma.io/service: edge-gateway_default_svc`.
+{% endif_version %}
+
 The control plane also creates a new `Service` to send network traffic to the builtin `Dataplane` pods.
 The `Service` is of type `LoadBalancer`, and its ports are automatically adjusted to match the listeners on the corresponding `MeshGateway`.
 

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-k8s.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-k8s.md
@@ -11,6 +11,8 @@ instances that listen and serve traffic.
 Kuma offers `MeshGatewayInstance` to manage a Kubernetes `Deployment` and `Service`
 that together provide service capacity for the `MeshGateway`{% if_version lte:2.6.x inline:true %} with the matching `kuma.io/service` tag{% endif_version %}.
 
+{% include snippets/warning_meshgatewayinstance_service_tag.md %}
+
 {% tip %}
 If you're not using the `default` `Mesh`, you'll need to _label_ the
 `MeshGatewayInstance` using `kuma.io/mesh`.
@@ -35,16 +37,7 @@ spec:
 ```
 {% endif_version %}
 {% if_version gte:2.7.x %}
-{% if_version lte:2.9.x %}
-[//]: # (This is change in behavior, let's assume that users will get used to it, so we won't have to show this warning after 2.9.x)
-{% warning %}
-**Heads up!**
-In previous versions of {{site.mesh_product_name}}, setting the `kuma.io/service` tag directly within a `MeshGatewayInstance` resource was used to identify the service. However, this practice is deprecated and no longer recommended for security reasons since {{site.mesh_product_name}} version 2.7.0.
 
-We've automatically switched to generating the service name for you based on your `MeshGatewayInstance` resource name and namespace (format: `{name}_{namespace}_svc`).
-{% endwarning %}
-
-{% endif_version %}
 ```yaml
 apiVersion: kuma.io/v1alpha1
 kind: MeshGatewayInstance

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-k8s.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-k8s.md
@@ -67,71 +67,79 @@ The `Service` is of type `LoadBalancer`, and its ports are automatically adjuste
 ## Customization
 
 Additional customization of the generated `Service` or `Pods` is possible via `spec.serviceTemplate` and `spec.podTemplate`.
+
 For example, you can add annotations and/or labels to the generated objects:
 
 {% if_version lte:2.6.x %}
 ```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshGatewayInstance
+metadata:
+  name: edge-gateway
+  namespace: default
 spec:
   replicas: 1
   serviceType: LoadBalancer
   tags:
     kuma.io/service: edge-gateway
-  resources:
-    limits: ...
-    requests: ...
   serviceTemplate:
     metadata:
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-    spec:
-      loadBalancerIP: ...
   podTemplate:
     metadata:
       labels:
         app-name: my-app
-        ...
 ```
 {% endif_version %}
 {% if_version gte:2.7.x %}
 ```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshGatewayInstance
+metadata:
+  name: edge-gateway
+  namespace: default
 spec:
   replicas: 1
   serviceType: LoadBalancer
-  resources:
-    limits: ...
-    requests: ...
   serviceTemplate:
     metadata:
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-    spec:
-      loadBalancerIP: ...
   podTemplate:
     metadata:
       labels:
         app-name: my-app
-        ...
 ```
 {% endif_version %}
 
-You can also modify several security-related parameters for the generated `Pods` or specify a `loadBalancerIP` for the `Service`:
+You can also modify several resource limits or security-related parameters for the generated `Pods` or specify a `loadBalancerIP` for the `Service`:
 
 {% if_version lte:2.6.x %}
 ```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshGatewayInstance
+metadata:
+  name: edge-gateway
+  namespace: default
 spec:
   replicas: 1
   serviceType: LoadBalancer
   tags:
     kuma.io/service: edge-gateway
   resources:
-    limits: ...
-    requests: ...
+    requests:
+      memory: 64Mi
+      cpu: 250m
+    limits:
+      memory: 128Mi
+      cpu: 500m
   serviceTemplate:
     metadata:
       labels:
         svc-id: "19-001"
     spec:
-      loadBalancerIP: ...
+      loadBalancerIP: 172.17.0.1
   podTemplate:
     metadata:
       annotations:
@@ -139,7 +147,7 @@ spec:
     spec:
       serviceAccountName: my-sa
       securityContext:
-        fsGroup: ...
+        fsGroup: 2000
       container:
         securityContext:
           readOnlyRootFilesystem: true
@@ -147,18 +155,27 @@ spec:
 {% endif_version %}
 {% if_version gte:2.7.x %}
 ```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshGatewayInstance
+metadata:
+  name: edge-gateway
+  namespace: default
 spec:
   replicas: 1
   serviceType: LoadBalancer
   resources:
-    limits: ...
-    requests: ...
+    requests:
+      memory: 64Mi
+      cpu: 250m
+    limits:
+      memory: 128Mi
+      cpu: 500m
   serviceTemplate:
     metadata:
       labels:
         svc-id: "19-001"
     spec:
-      loadBalancerIP: ...
+      loadBalancerIP: 172.17.0.1
   podTemplate:
     metadata:
       annotations:
@@ -166,7 +183,7 @@ spec:
     spec:
       serviceAccountName: my-sa
       securityContext:
-        fsGroup: ...
+        fsGroup: 2000
       container:
         securityContext:
           readOnlyRootFilesystem: true

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-k8s.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-k8s.md
@@ -9,7 +9,7 @@ listener and route configuration but don't handle deploying `kuma-dp`
 instances that listen and serve traffic.
 
 Kuma offers `MeshGatewayInstance` to manage a Kubernetes `Deployment` and `Service`
-that together provide service capacity for the `MeshGateway` with the matching `kuma.io/service` tag.
+that together provide service capacity for the `MeshGateway`{% if_version lte:2.6.x inline:true %} with the matching `kuma.io/service` tag{% endif_version %}.
 
 {% tip %}
 If you're not using the `default` `Mesh`, you'll need to _label_ the
@@ -18,6 +18,7 @@ If you're not using the `default` `Mesh`, you'll need to _label_ the
 
 Consider the following example:
 
+{% if_version lte:2.6.x %}
 ```yaml
 apiVersion: kuma.io/v1alpha1
 kind: MeshGatewayInstance
@@ -32,9 +33,34 @@ spec:
   tags:
     kuma.io/service: edge-gateway
 ```
+{% endif_version %}
+{% if_version gte:2.7.x %}
+{% if_version lte:2.9.x %}
+[//]: # (This is change in behavior, let's assume that users will get used to it, so we won't have to show this warning after 2.9.x)
+{% warning %}
+**Heads up!**
+In previous versions of {{site.mesh_product_name}}, setting the `kuma.io/service` tag directly within a `MeshGatewayInstance` resource was used to identify the service. However, this practice is deprecated and no longer recommended for security reasons since {{site.mesh_product_name}} version 2.7.0.
 
-Once a `MeshGateway` exists with `kuma.io/service: edge-gateway`, the control plane creates a new `Deployment` in the `default` namespace.
-This `Deployment` deploys 2 replicas of `kuma-dp` and corresponding builtin gateway `Dataplane` running with `kuma.io/service: edge-gateway`.
+We've automatically switched to generating the service name for you based on your `MeshGatewayInstance` resource name and namespace (format: `{name}_{namespace}_svc`).
+{% endwarning %}
+
+{% endif_version %}
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshGatewayInstance
+metadata:
+  name: edge-gateway
+  namespace: default
+  labels:
+    kuma.io/mesh: default # only necessary if not using default Mesh
+spec:
+  replicas: 2
+  serviceType: LoadBalancer
+```
+{% endif_version %}
+
+Once a `MeshGateway` exists with {% if_version lte:2.6.x inline:true %}`kuma.io/service: edge-gateway`{% endif_version %}{% if_version gte:2.7.x inline:true %}`kuma.io/service: edge-gateway_default_svc`{% endif_version %}, the control plane creates a new `Deployment` in the `default` namespace.
+This `Deployment` deploys 2 replicas of `kuma-dp` and corresponding builtin gateway `Dataplane` running with {% if_version lte:2.6.x inline:true %}`kuma.io/service: edge-gateway`{% endif_version %}{% if_version gte:2.7.x inline:true %}`kuma.io/service: edge-gateway_default_svc`{% endif_version %}.
 The control plane also creates a new `Service` to send network traffic to the builtin `Dataplane` pods.
 The `Service` is of type `LoadBalancer`, and its ports are automatically adjusted to match the listeners on the corresponding `MeshGateway`.
 
@@ -43,6 +69,7 @@ The `Service` is of type `LoadBalancer`, and its ports are automatically adjuste
 Additional customization of the generated `Service` or `Pods` is possible via `spec.serviceTemplate` and `spec.podTemplate`.
 For example, you can add annotations and/or labels to the generated objects:
 
+{% if_version lte:2.6.x %}
 ```yaml
 spec:
   replicas: 1
@@ -64,9 +91,32 @@ spec:
         app-name: my-app
         ...
 ```
+{% endif_version %}
+{% if_version gte:2.7.x %}
+```yaml
+spec:
+  replicas: 1
+  serviceType: LoadBalancer
+  resources:
+    limits: ...
+    requests: ...
+  serviceTemplate:
+    metadata:
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    spec:
+      loadBalancerIP: ...
+  podTemplate:
+    metadata:
+      labels:
+        app-name: my-app
+        ...
+```
+{% endif_version %}
 
 You can also modify several security-related parameters for the generated `Pods` or specify a `loadBalancerIP` for the `Service`:
 
+{% if_version lte:2.6.x %}
 ```yaml
 spec:
   replicas: 1
@@ -94,6 +144,34 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
 ```
+{% endif_version %}
+{% if_version gte:2.7.x %}
+```yaml
+spec:
+  replicas: 1
+  serviceType: LoadBalancer
+  resources:
+    limits: ...
+    requests: ...
+  serviceTemplate:
+    metadata:
+      labels:
+        svc-id: "19-001"
+    spec:
+      loadBalancerIP: ...
+  podTemplate:
+    metadata:
+      annotations:
+        app-monitor: "false"
+    spec:
+      serviceAccountName: my-sa
+      securityContext:
+        fsGroup: ...
+      container:
+        securityContext:
+          readOnlyRootFilesystem: true
+```
+{% endif_version %}
 
 ## Schema
 

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
@@ -204,7 +204,7 @@ metadata:
 spec:
   selectors:
     - match:
-    kuma.io/service: edge-gateway
+        kuma.io/service: edge-gateway
   conf:
     listeners:
     - port: 8443

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
@@ -16,15 +16,7 @@ The `MeshGateway` resource specifies what network ports the gateway should liste
 A builtin gateway Dataplane can have exactly one `MeshGateway` resource bound to it.
 This binding uses standard, tag-based {{site.mesh_product_name}} matching semantics:
 
-{% if_version gte:2.7.x lte:2.9.x %}
-[//]: # (This is change in behavior, let's assume that users will get used to it, so we won't have to show this warning after 2.9.x)
-{% warning %}
-**Heads up!**
-In previous versions of {{site.mesh_product_name}}, setting the `kuma.io/service` tag directly within a `MeshGatewayInstance` resource was used to identify the service. However, this practice is deprecated and no longer recommended for security reasons since {{site.mesh_product_name}} version 2.7.0.
-
-We've automatically switched to generating the service name for you based on your `MeshGatewayInstance` resource name and namespace (format: `{name}_{namespace}_svc`).
-{% endwarning %}
-{% endif_version %}
+{% include snippets/warning_meshgatewayinstance_service_tag.md %}
 
 {% tabs binding useUrlFragment=false %}
 {% tab binding Kubernetes %}

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
@@ -45,7 +45,7 @@ selectors:
 {% endtabs %}
 
 A `MeshGateway` can have any number of listeners, where each listener represents an endpoint that can accept network traffic.
-Note that the `MeshGateway` doesn’t specify which IP addresses are listened on; the `Dataplane` resource specifies that.
+Note that the `MeshGateway` doesn't specify which IP addresses are listened on; the `Dataplane` resource specifies that.
 
 To configure a listener, you need to specify at least the port number and network protocol.
 Each listener may also have its own set of {{site.mesh_product_name}} tags so that {{site.mesh_product_name}} policy configuration can be targeted to specific listeners.
@@ -118,7 +118,7 @@ conf:
 {% endtab %}
 {% endtabs %}
 
-In this example, the gateway proxy listens for HTTP protocol connections on TCP port 8080 but restricts the `Host` header to `foo.example.com`.
+In the above example, the gateway proxy listens for HTTP protocol connections on TCP port 8080 but restricts the `Host` header to `foo.example.com`.
 
 {% tabs selectors useUrlFragment=false %}
 {% tab selectors Kubernetes %}
@@ -290,7 +290,7 @@ data: $(kumactl generate tls-certificate --type=server --hostname=foo.example.co
 
 The `Mesh` abstraction allows users
 to encapsulate and isolate services
-inside a kind of submesh with its own CA.
+inside a kind of sub-mesh with its own CA.
 With a cross-mesh `MeshGateway`,
 you can expose the services of one `Mesh`
 to other `Mesh`es by defining an API with `MeshGatewayRoute`s.

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
@@ -54,8 +54,15 @@ Each listener may also have its own set of {{site.mesh_product_name}} tags so th
 {% tab listener Kubernetes %}
 
 ```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshGateway
+mesh: default
+metadata:
+  name: edge-gateway
 spec:
-  ...
+  selectors:
+    - match:
+        kuma.io/service: edge-gateway
   conf:
     listeners:
       - port: 8080
@@ -68,6 +75,12 @@ spec:
 {% tab listener Universal %}
 
 ```yaml
+type: MeshGateway
+mesh: default
+name: edge-gateway
+selectors:
+  - match:
+      kuma.io/service: edge-gateway
 conf:
   listeners:
     - port: 8080
@@ -91,8 +104,15 @@ the port/protocol with other routes attached to other hostnames.
 {% tab usage Kubernetes %}
 
 ```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshGateway
+mesh: default
+metadata:
+  name: edge-gateway
 spec:
-  ...
+  selectors:
+    - match:
+        kuma.io/service: edge-gateway
   conf:
     listeners:
       - port: 8080
@@ -106,6 +126,12 @@ spec:
 {% tab usage Universal %}
 
 ```yaml
+type: MeshGateway
+mesh: default
+name: edge-gateway
+selectors:
+  - match:
+      kuma.io/service: edge-gateway
 conf:
   listeners:
     - port: 8080
@@ -300,9 +326,18 @@ All meshes involved in cross-mesh communication must have mTLS enabled.
 To enable cross-mesh functionality for a `MeshGateway` listener,
 set the `crossMesh` property.
 
-```
-  ...
-  mesh: default
+{% tabs cross-mesh useUrlFragment=false %}
+{% tab cross-mesh Kubernetes %}
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshGateway
+mesh: default
+metadata:
+  name: cross-mesh-gateway
+  labels:
+    kuma.io/mesh: default
+spec:
   selectors:
     - match:
         kuma.io/service: cross-mesh-gateway
@@ -313,6 +348,27 @@ set the `crossMesh` property.
         crossMesh: true
         hostname: default.mesh
 ```
+
+{% endtab %}
+{% tab cross-mesh Universal %}
+
+```yaml
+type: MeshGateway
+mesh: default
+name: cross-mesh-gateway
+selectors:
+  - match:
+      kuma.io/service: cross-mesh-gateway
+conf:
+  listeners:
+    - port: 8080
+      protocol: HTTP
+      crossMesh: true
+      hostname: default.mesh
+```
+
+{% endtab %}
+{% endtabs %}
 
 #### Hostname
 

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
@@ -319,7 +319,7 @@ to encapsulate and isolate services
 inside a kind of sub-mesh with its own CA.
 With a cross-mesh `MeshGateway`,
 you can expose the services of one `Mesh`
-to other `Mesh`es by defining an API with `MeshGatewayRoute`s.
+to other `Mesh`es by defining an API with {% if_version gte:2.6.x inline:true %}`MeshHTTPRoute`s{% endif_version %}{% if_version lte:2.5.x inline:true %}`MeshGatewayRoute`s{% endif_version %}.
 All traffic remains inside the {{site.mesh_product_name}} data plane protected by mTLS.
 
 All meshes involved in cross-mesh communication must have mTLS enabled.

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
@@ -2,6 +2,8 @@
 title: Configuring built-in listeners
 ---
 
+{% capture k8s_service_selector_suffix %}{% if_version gte:2.7.x inline:true %}_default_svc{% endif_version %}{% endcapture %}
+
 For configuring built-in gateway listeners, use the [`MeshGateway`](/docs/{{ page.version }}/using-mesh/managing-ingress-traffic/builtin-listeners) resource.
 
 {% tip %}
@@ -13,6 +15,16 @@ multi-zone.
 The `MeshGateway` resource specifies what network ports the gateway should listen on and how network traffic should be accepted.
 A builtin gateway Dataplane can have exactly one `MeshGateway` resource bound to it.
 This binding uses standard, tag-based {{site.mesh_product_name}} matching semantics:
+
+{% if_version gte:2.7.x lte:2.9.x %}
+[//]: # (This is change in behavior, let's assume that users will get used to it, so we won't have to show this warning after 2.9.x)
+{% warning %}
+**Heads up!**
+In previous versions of {{site.mesh_product_name}}, setting the `kuma.io/service` tag directly within a `MeshGatewayInstance` resource was used to identify the service. However, this practice is deprecated and no longer recommended for security reasons since {{site.mesh_product_name}} version 2.7.0.
+
+We've automatically switched to generating the service name for you based on your `MeshGatewayInstance` resource name and namespace (format: `{name}_{namespace}_svc`).
+{% endwarning %}
+{% endif_version %}
 
 {% tabs binding useUrlFragment=false %}
 {% tab binding Kubernetes %}
@@ -26,7 +38,7 @@ metadata:
 spec:
   selectors:
     - match:
-        kuma.io/service: edge-gateway
+        kuma.io/service: edge-gateway{{ k8s_service_selector_suffix }}
 ```
 
 {% endtab %}
@@ -62,7 +74,7 @@ metadata:
 spec:
   selectors:
     - match:
-        kuma.io/service: edge-gateway
+        kuma.io/service: edge-gateway{{ k8s_service_selector_suffix }}
   conf:
     listeners:
       - port: 8080
@@ -112,7 +124,7 @@ metadata:
 spec:
   selectors:
     - match:
-        kuma.io/service: edge-gateway
+        kuma.io/service: edge-gateway{{ k8s_service_selector_suffix }}
   conf:
     listeners:
       - port: 8080
@@ -158,7 +170,7 @@ metadata:
 spec:
   selectors:
     - match:
-        kuma.io/service: edge-gateway
+        kuma.io/service: edge-gateway{{ k8s_service_selector_suffix }}
   conf:
     listeners:
       - port: 8080
@@ -207,11 +219,12 @@ Note that because each listener entry has its own {{site.mesh_product_name}} tag
 {{site.mesh_product_name}} generates a set of tags for each listener by combining the tags from the listener, the `MeshGateway` and the `Dataplane`.
 {{ site.mesh_product_name}} matches policies against this set of combined tags.
 
-| `Dataplane` tags                 | Listener tags                                 | Final Tags                                         |
-| -------------------------------- | --------------------------------------------- | -------------------------------------------------- |
-| kuma.io/service=edge-gateway     | vhost=foo.example.com                         | kuma.io/service=edge-gateway,vhost=foo.example.com |
-| kuma.io/service=edge-gateway     | kuma.io/service=example,domain=example.com    | kuma.io/service=example,domain=example.com         |
-| kuma.io/service=edge,location=us | version=2                                     | kuma.io/service=edge,location=us,version=2         |
+| `Dataplane` tags                                                  | Listener tags                                 | Final Tags                                                                         |
+|-------------------------------------------------------------------| --------------------------------------------- |------------------------------------------------------------------------------------|
+| kuma.io/service=edge-gateway{{ k8s_service_selector_suffix }}     | vhost=foo.example.com                         | kuma.io/service=edge-gateway{{ k8s_service_selector_suffix }},vhost=foo.example.com |
+| kuma.io/service=edge-gateway{{ k8s_service_selector_suffix }}     | kuma.io/service=example,domain=example.com    | kuma.io/service=example,domain=example.com                                         |
+| kuma.io/service=edge{{ k8s_service_selector_suffix }},location=us | version=2                                     | kuma.io/service=edge{{ k8s_service_selector_suffix }},location=us,version=2        |
+
 
 ## TLS Termination
 
@@ -230,7 +243,7 @@ metadata:
 spec:
   selectors:
     - match:
-        kuma.io/service: edge-gateway
+        kuma.io/service: edge-gateway{{ k8s_service_selector_suffix }}
   conf:
     listeners:
       - port: 8443
@@ -340,7 +353,7 @@ metadata:
 spec:
   selectors:
     - match:
-        kuma.io/service: cross-mesh-gateway
+        kuma.io/service: cross-mesh-gateway{{ k8s_service_selector_suffix }}
   conf:
     listeners:
       - port: 8080

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
@@ -385,13 +385,13 @@ Otherwise it will be reachable at the host:
 If transparent proxy isn't set up, you'll have to add the listener explicitly as
 an outbound to your `Dataplane` objects if you want to access it:
 
-```
-  ...
-  outbound
-  - port: 8080
-    tags:
-      kuma.io/service: cross-mesh-gateway
-      kuma.io/mesh: default
+```yaml
+...
+  outbound:
+    - port: 8080
+      tags:
+        kuma.io/service: cross-mesh-gateway
+        kuma.io/mesh: default
 ```
 
 #### Limitations

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
@@ -233,15 +233,15 @@ spec:
         kuma.io/service: edge-gateway
   conf:
     listeners:
-    - port: 8443
-      protocol: HTTPS
-      hostname: foo.example.com
-      tls:
-        mode: TERMINATE
-        certificates:
-          - secret: foo-example-com-certificate
-      tags:
-        name: foo.example.com
+      - port: 8443
+        protocol: HTTPS
+        hostname: foo.example.com
+        tls:
+          mode: TERMINATE
+          certificates:
+            - secret: foo-example-com-certificate
+        tags:
+          name: foo.example.com
 ```
 
 {% endtab %}

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin.md
@@ -50,15 +50,9 @@ spec:
 ```
 {% endif_version %}
 {% if_version gte:2.7.x %}
-{% if_version lte:2.9.x %}
-[//]: # (This is change in behavior, let's assume that users will get used to it, so we won't have to show this warning after 2.9.x)
-{% warning %}
-**Heads up!**
-In previous versions of {{site.mesh_product_name}}, setting the `kuma.io/service` tag directly within a `MeshGatewayInstance` resource was used to identify the service. However, this practice is deprecated and no longer recommended for security reasons since {{site.mesh_product_name}} version 2.7.0.
 
-We've automatically switched to generating the service name for you based on your `MeshGatewayInstance` resource name and namespace (format: `{name}_{namespace}_svc`).
+{% include snippets/warning_meshgatewayinstance_service_tag.md %}
 
-{% endwarning %}
 {% endif_version %}
 ```yaml
 apiVersion: kuma.io/v1alpha1

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin.md
@@ -53,7 +53,6 @@ spec:
 
 {% include snippets/warning_meshgatewayinstance_service_tag.md %}
 
-{% endif_version %}
 ```yaml
 apiVersion: kuma.io/v1alpha1
 kind: MeshGatewayInstance

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin.md
@@ -8,7 +8,7 @@ gateways. {{ site.mesh_product_name }} policies are then used to configure
 built-in gateways.
 
 {% tip %}
-**New to Kuma?**
+**New to {{site.mesh_product_name}}?**
 Checkout our [guide](/docs/{{ page.version }}/guides/gateway-builtin/) to get quickly started with builtin gateways!
 {% endtip %}
 
@@ -31,8 +31,9 @@ multi-zone.
 {% endtip %}
 
 This resource manages a Kubernetes `Deployment` and `Service`
-suitable for providing service capacity for the `MeshGateway` with the matching `kuma.io/service` tag.
+suitable for providing service capacity for the `MeshGateway`{% if_version lte:2.6.x inline:true %} with the matching `kuma.io/service` tag{% endif_version %}.
 
+{% if_version lte:2.6.x %}
 The `kuma.io/service` value you select will be used in `MeshGateway` to [configure listeners](/docs/{{ page.version }}/using-mesh/managing-ingress-traffic/builtin-listeners).
 
 ```yaml
@@ -47,6 +48,29 @@ spec:
   tags:
     kuma.io/service: edge-gateway
 ```
+{% endif_version %}
+{% if_version gte:2.7.x %}
+{% if_version lte:2.9.x %}
+[//]: # (This is change in behavior, let's assume that users will get used to it, so we won't have to show this warning after 2.9.x)
+{% warning %}
+**Heads up!**
+In previous versions of {{site.mesh_product_name}}, setting the `kuma.io/service` tag directly within a `MeshGatewayInstance` resource was used to identify the service. However, this practice is deprecated and no longer recommended for security reasons since {{site.mesh_product_name}} version 2.7.0.
+
+We've automatically switched to generating the service name for you based on your `MeshGatewayInstance` resource name and namespace (format: `{name}_{namespace}_svc`).
+
+{% endwarning %}
+{% endif_version %}
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshGatewayInstance
+metadata:
+  name: edge-gateway
+  namespace: default
+spec:
+  replicas: 1
+  serviceType: LoadBalancer
+```
+{% endif_version %}
 
 See [the `MeshGatewayInstance` docs](/docs/{{ page.version }}//using-mesh/managing-ingress-traffic/builtin-k8s) for more options.
 {% endtab %}


### PR DESCRIPTION
Update builtin gateway docs after deprecation of specifying `kuma.io/service` tag in `MeshGatewayInstance`

Closes https://github.com/kumahq/kuma-website/issues/1745

Rendered modified pages:
- https://deploy-preview-1748--kuma.netlify.app/docs/2.7.x/using-mesh/managing-ingress-traffic/builtin/
- https://deploy-preview-1748--kuma.netlify.app/docs/2.7.x/using-mesh/managing-ingress-traffic/builtin-k8s/
- https://deploy-preview-1748--kuma.netlify.app/docs/2.7.x/using-mesh/managing-ingress-traffic/builtin-listeners/

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
