### PR TITLE
fix(quickstart): replace `from.MeshService` with `from.MeshSubset`

### DIFF
--- a/app/_src/policies/meshtimeout.md
+++ b/app/_src/policies/meshtimeout.md
@@ -268,7 +268,7 @@ spec:
                 type: PathPrefix
                 value: /v2
           default:
-            backendRef:
+            backendRefs:
               - kind: MeshServiceSubset
                 name_uni: backend
                 name_kube: backend_kuma-demo_svc_3001

--- a/app/_src/quickstart/kubernetes-demo.md
+++ b/app/_src/quickstart/kubernetes-demo.md
@@ -174,8 +174,9 @@ spec:
     name: redis_kuma-demo_svc_6379
   from:
     - targetRef:
-        kind: MeshService
-        name: demo-app_kuma-demo_svc_5000
+        kind: MeshSubset
+        tags:
+          kuma.io/service: demo-app_kuma-demo_svc_5000
       default:
         action: Allow" | kubectl apply -f -
 ```


### PR DESCRIPTION
* typo in `backendRefs`
* replace `MeshService` with `MeshSubset` as `MeshService` is deprecated in `from`