### PR TITLE
chore(docs): optimize the local running docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,11 @@ In most cases, you can add this signoff to your commit automatically with the `-
 
 ### Running the site locally
 
-Clone the repository and run `make install`, make sure you have the right ruby version installed (`cat .ruby-version`).
+Clone the repository and run:
+```
+make install
+```
+make sure you have the right ruby version installed (`cat .ruby-version`).
 Jekyll is a static-site generator, so first we need to build the site and compile the assets:
 ```
 make build


### PR DESCRIPTION
The command `make install` is not obvious in the `CONTRIBUTING.md`, and I just make it equal with other commands

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) - yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? - yes
