### PR TITLE
docs: fix IPv6 DNS record typo

### DIFF
--- a/app/_src/networking/dns.md
+++ b/app/_src/networking/dns.md
@@ -8,7 +8,7 @@ The usage of {{site.mesh_product_name}} DNS is only relevant when {% if_version 
 
 ## How it works
 
-{{site.mesh_product_name}} DNS server responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAAA` records, for example `redis.mesh. 60 IN A 240.0.0.100` or `redis.mesh. 60 IN AAAAA fd00:fd00::100`.
+{{site.mesh_product_name}} DNS server responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAA` records, for example `redis.mesh. 60 IN A 240.0.0.100` or `redis.mesh. 60 IN AAAA fd00:fd00::100`.
 
 The virtual IPs are allocated by the control plane from the configured CIDR (by default `240.0.0.0/4`) , by constantly scanning the services available in all {{site.mesh_product_name}} meshes.
 When a service is removed, its VIP is also freed, and {{site.mesh_product_name}} DNS does not respond for it with `A` and `AAAA` DNS record.

--- a/app/docs/1.2.x/networking/dns.md
+++ b/app/docs/1.2.x/networking/dns.md
@@ -133,7 +133,7 @@ Kuma DNS includes these components:
 - The VIPs allocator
 - Cross-replica persistence
 
-The DNS server listens on port `5653`, responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAAA` records, for example ```<service>.mesh. 60 IN A  240.0.0.100``` or ```<service>.mesh. 60 IN AAAAA  fd00:fd00::100```. The default TTL is 60 seconds, to ensure the client synchronizes with Kuma DNS and to account for any intervening changes.
+The DNS server listens on port `5653`, responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAA` records, for example ```<service>.mesh. 60 IN A  240.0.0.100``` or ```<service>.mesh. 60 IN AAAA  fd00:fd00::100```. The default TTL is 60 seconds, to ensure the client synchronizes with Kuma DNS and to account for any intervening changes.
 
 The virtual IPs are allocated from the configured CIDR, by constantly scanning the services available in all Kuma meshes. When a service is removed, its VIP is also freed, and Kuma DNS does not respond for it with `A` DNS record.
 

--- a/app/docs/1.3.x/networking/dns.md
+++ b/app/docs/1.3.x/networking/dns.md
@@ -151,7 +151,7 @@ Kuma DNS includes these components:
 - The VIPs allocator
 - Cross-replica persistence
 
-The DNS server listens on port `5653`, responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAAA` records, for example ```<service>.mesh. 60 IN A  240.0.0.100``` or ```<service>.mesh. 60 IN AAAAA  fd00:fd00::100```. The default TTL is 60 seconds, to ensure the client synchronizes with Kuma DNS and to account for any intervening changes.
+The DNS server listens on port `5653`, responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAA` records, for example ```<service>.mesh. 60 IN A  240.0.0.100``` or ```<service>.mesh. 60 IN AAAA  fd00:fd00::100```. The default TTL is 60 seconds, to ensure the client synchronizes with Kuma DNS and to account for any intervening changes.
 
 The virtual IPs are allocated from the configured CIDR, by constantly scanning the services available in all Kuma meshes. When a service is removed, its VIP is also freed, and Kuma DNS does not respond for it with `A` DNS record.
 

--- a/app/docs/1.4.x/networking/dns.md
+++ b/app/docs/1.4.x/networking/dns.md
@@ -155,7 +155,7 @@ Kuma DNS includes these components:
 - The VIPs allocator
 - Cross-replica persistence
 
-The DNS server listens on port `5653`, responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAAA` records, for example ```<service>.mesh. 60 IN A  240.0.0.100``` or ```<service>.mesh. 60 IN AAAAA  fd00:fd00::100```. The default TTL is 60 seconds, to ensure the client synchronizes with Kuma DNS and to account for any intervening changes.
+The DNS server listens on port `5653`, responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAA` records, for example ```<service>.mesh. 60 IN A  240.0.0.100``` or ```<service>.mesh. 60 IN AAAA  fd00:fd00::100```. The default TTL is 60 seconds, to ensure the client synchronizes with Kuma DNS and to account for any intervening changes.
 
 The virtual IPs are allocated from the configured CIDR, by constantly scanning the services available in all Kuma meshes. When a service is removed, its VIP is also freed, and Kuma DNS does not respond for it with `A` DNS record.
 

--- a/app/docs/1.5.x/networking/dns.md
+++ b/app/docs/1.5.x/networking/dns.md
@@ -8,7 +8,7 @@ The usage of Kuma DNS is only relevant when [transparent proxying](/docs/{{ page
 
 ## How it works
 
-Kuma DNS server responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAAA` records, for example ```redis.mesh. 60 IN A  240.0.0.100``` or ```redis.mesh. 60 IN AAAAA  fd00:fd00::100```.
+Kuma DNS server responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAA` records, for example ```redis.mesh. 60 IN A  240.0.0.100``` or ```redis.mesh. 60 IN AAAA  fd00:fd00::100```.
 
 The virtual IPs are allocated by the control plane from the configured CIDR (by default `240.0.0.0/4`) , by constantly scanning the services available in all Kuma meshes.
 When a service is removed, its VIP is also freed, and Kuma DNS does not respond for it with `A` and `AAAA` DNS record.

--- a/app/docs/1.6.x/networking/dns.md
+++ b/app/docs/1.6.x/networking/dns.md
@@ -8,7 +8,7 @@ The usage of Kuma DNS is only relevant when [transparent proxying](/docs/{{ page
 
 ## How it works
 
-Kuma DNS server responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAAA` records, for example ```redis.mesh. 60 IN A  240.0.0.100``` or ```redis.mesh. 60 IN AAAAA  fd00:fd00::100```.
+Kuma DNS server responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAA` records, for example ```redis.mesh. 60 IN A  240.0.0.100``` or ```redis.mesh. 60 IN AAAA  fd00:fd00::100```.
 
 The virtual IPs are allocated by the control plane from the configured CIDR (by default `240.0.0.0/4`) , by constantly scanning the services available in all Kuma meshes.
 When a service is removed, its VIP is also freed, and Kuma DNS does not respond for it with `A` and `AAAA` DNS record.

--- a/app/docs/1.7.x/networking/dns.md
+++ b/app/docs/1.7.x/networking/dns.md
@@ -8,7 +8,7 @@ The usage of Kuma DNS is only relevant when [transparent proxying](/docs/{{ page
 
 ## How it works
 
-Kuma DNS server responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAAA` records, for example `redis.mesh. 60 IN A 240.0.0.100` or `redis.mesh. 60 IN AAAAA fd00:fd00::100`.
+Kuma DNS server responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAA` records, for example `redis.mesh. 60 IN A 240.0.0.100` or `redis.mesh. 60 IN AAAA fd00:fd00::100`.
 
 The virtual IPs are allocated by the control plane from the configured CIDR (by default `240.0.0.0/4`) , by constantly scanning the services available in all Kuma meshes.
 When a service is removed, its VIP is also freed, and Kuma DNS does not respond for it with `A` and `AAAA` DNS record.

--- a/app/docs/1.8.x/networking/dns.md
+++ b/app/docs/1.8.x/networking/dns.md
@@ -8,7 +8,7 @@ The usage of Kuma DNS is only relevant when [transparent proxying](/docs/{{ page
 
 ## How it works
 
-Kuma DNS server responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAAA` records, for example `redis.mesh. 60 IN A 240.0.0.100` or `redis.mesh. 60 IN AAAAA fd00:fd00::100`.
+Kuma DNS server responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAA` records, for example `redis.mesh. 60 IN A 240.0.0.100` or `redis.mesh. 60 IN AAAA fd00:fd00::100`.
 
 The virtual IPs are allocated by the control plane from the configured CIDR (by default `240.0.0.0/4`) , by constantly scanning the services available in all Kuma meshes.
 When a service is removed, its VIP is also freed, and Kuma DNS does not respond for it with `A` and `AAAA` DNS record.

--- a/app/docs/2.0.x/networking/dns.md
+++ b/app/docs/2.0.x/networking/dns.md
@@ -8,7 +8,7 @@ The usage of {{site.mesh_product_name}} DNS is only relevant when [transparent p
 
 ## How it works
 
-{{site.mesh_product_name}} DNS server responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAAA` records, for example `redis.mesh. 60 IN A 240.0.0.100` or `redis.mesh. 60 IN AAAAA fd00:fd00::100`.
+{{site.mesh_product_name}} DNS server responds to type `A` and `AAAA` DNS requests, and answers with `A` or `AAAA` records, for example `redis.mesh. 60 IN A 240.0.0.100` or `redis.mesh. 60 IN AAAA fd00:fd00::100`.
 
 The virtual IPs are allocated by the control plane from the configured CIDR (by default `240.0.0.0/4`) , by constantly scanning the services available in all {{site.mesh_product_name}} meshes.
 When a service is removed, its VIP is also freed, and {{site.mesh_product_name}} DNS does not respond for it with `A` and `AAAA` DNS record.


### PR DESCRIPTION
DNS `AAAA` records match a domain name to an IPv6 address, not `AAAAA`

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) - yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? - yes
