### PR TITLE
docs(rbac): add info about default rbac type for each product

### DIFF
--- a/app/_src/production/secure-deployment/api-access-control.md
+++ b/app/_src/production/secure-deployment/api-access-control.md
@@ -3,6 +3,13 @@ title: Kuma API access control
 content_type: reference
 ---
 
+{% if site.mesh_product_name != "Kuma" %}
+{% warning %}
+{{site.mesh_product_name}} uses RBAC access control by default. See [Role-Based Access Control documentation](/docs/{{ page.version }}/features/rbac/) for details.
+If you heave a strong reason to use static access control you need to set `KUMA_ACCESS_TYPE=static` to use the variables described in this page.
+{% endwarning %}
+{% endif %}
+
 {{site.mesh_product_name}} provide a simple access control to administrative actions executed on {{site.mesh_product_name}} API Server (port 5681 by default).
 
 ## Manage admin resources


### PR DESCRIPTION
People are confused that in the parent project https://docs.konghq.com/mesh/latest/production/secure-deployment/api-access-control/ the variables mentioned don't work.

Wait for the slack poll to merge this.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
