### PR TITLE
Fix {% tip %} in doc

### DIFF
--- a/app/_src/production/upgrades-tuning/upgrade-notes.md
+++ b/app/_src/production/upgrades-tuning/upgrade-notes.md
@@ -3,8 +3,8 @@ title: Version specific upgrade notes
 content_type: reference
 ---
 
-{{% tip %}}
+{% tip %}
 Make sure to also check the general [upgrade notes](/docs/{{ page.version }}/production/upgrades-tuning/upgrades).
-{{% endtip %}}
+{% endtip %}
 
 {% embed UPGRADE.md %}


### PR DESCRIPTION
Fix a `{% tip %}` in doc.
There was a warning logged while building the site.
Liquid tags should be `{% tag %}`, `{{ ... }}` is used for interpolating values.

<img width="1375" alt="Screenshot 2024-05-16 at 08 53 56" src="https://github.com/kumahq/kuma-website/assets/715229/94256810-4bba-473e-a030-389f96df0447">


Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
