### PR TITLE
chore(docs): improve openTelemetry installation command

### DIFF
--- a/app/_src/guides/otel-metrics.md
+++ b/app/_src/guides/otel-metrics.md
@@ -72,7 +72,7 @@ image:
 
 This is the Helm chart configuration we will be using. This will configure OpenTelemetry collector to listen on grpc port `4317` for metrics 
 pushed by dataplane proxy, process and expose collected metrics in Prometheus format on port `8889`. In the next step we 
-will configure Prometheus to scrape these metrics. Our configuration relies on [the contrib distribution](https://github.com/open-telemetry/opentelemetry-collector-contrib?tab=readme-ov-file#opentelemetry-collector-contrib) of opentelemetry-collector so we set this in the values.
+will configure Prometheus to scrape these metrics. Our configuration relies on [the contrib distribution](https://github.com/open-telemetry/opentelemetry-collector-contrib#opentelemetry-collector-contrib) of opentelemetry-collector so we set this in the values.
 
 Most important in this configuration is `pipelines` section:
 

--- a/app/_src/guides/otel-metrics.md
+++ b/app/_src/guides/otel-metrics.md
@@ -65,12 +65,15 @@ ports:
     containerPort: 8889
     servicePort: 8889
     protocol: TCP
+image:
+  repository: 'otel/opentelemetry-collector-contrib'
 " > values-otel.yaml
 ```
 
 This is the Helm chart configuration we will be using. This will configure OpenTelemetry collector to listen on grpc port `4317` for metrics 
 pushed by dataplane proxy, process and expose collected metrics in Prometheus format on port `8889`. In the next step we 
-will configure Prometheus to scrape these metrics.
+will configure Prometheus to scrape these metrics. Refer to openTelemetry-collector helm installation [UPGRADING](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/UPGRADING.md#0880-to-0890),
+it requires the parameter `image.repository` must be set and our current configurations rely on `Contrib distribution` image repository.
 
 Most important in this configuration is `pipelines` section:
 

--- a/app/_src/guides/otel-metrics.md
+++ b/app/_src/guides/otel-metrics.md
@@ -72,8 +72,7 @@ image:
 
 This is the Helm chart configuration we will be using. This will configure OpenTelemetry collector to listen on grpc port `4317` for metrics 
 pushed by dataplane proxy, process and expose collected metrics in Prometheus format on port `8889`. In the next step we 
-will configure Prometheus to scrape these metrics. Refer to openTelemetry-collector helm installation [UPGRADING](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/UPGRADING.md#0880-to-0890),
-it requires the parameter `image.repository` must be set and our current configurations rely on `Contrib distribution` image repository.
+will configure Prometheus to scrape these metrics. Our configuration relies on [the contrib distribution](https://github.com/open-telemetry/opentelemetry-collector-contrib?tab=readme-ov-file#opentelemetry-collector-contrib) of opentelemetry-collector so we set this in the values.
 
 Most important in this configuration is `pipelines` section:
 

--- a/app/_src/guides/otel-metrics.md
+++ b/app/_src/guides/otel-metrics.md
@@ -72,7 +72,7 @@ image:
 
 This is the Helm chart configuration we will be using. This will configure OpenTelemetry collector to listen on grpc port `4317` for metrics 
 pushed by dataplane proxy, process and expose collected metrics in Prometheus format on port `8889`. In the next step we 
-will configure Prometheus to scrape these metrics. Our configuration relies on [the contrib distribution](https://github.com/open-telemetry/opentelemetry-collector-contrib#opentelemetry-collector-contrib) of opentelemetry-collector so we set this in the values.
+will configure Prometheus to scrape these metrics. Our configuration relies on [the contrib distribution](https://github.com/open-telemetry/opentelemetry-collector-contrib) of opentelemetry-collector so we set this in the values.
 
 Most important in this configuration is `pipelines` section:
 


### PR DESCRIPTION
Refer to openTelemetry helm installation [UPGRADING](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/UPGRADING.md#0880-to-0890),  the openTelemetry helm requires the parameter `image.repository` must be set.

Notice: There are 2 options for this parameter, and `OpenTelemetry Collector Kubernetes Distro` will be the default image used for the chart(And we also need to update our [OpenTelemetry collector configuration](https://kuma.io/docs/2.7.x/guides/otel-metrics/#install-opentelemetry-collector)). Currently, we use `Contrib distribution` for transitions.

OpenTelemetry Collector Kubernetes Distro
```text
image:
  repository: "otel/opentelemetry-collector-k8s"
```

Contrib distribution
```text
image:
  repository: "otel/opentelemetry-collector-contrib"
```


close #1796 

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
