### PR TITLE
fix(cni): update install command for AWS EKS with CNI

### DIFF
--- a/app/_src/production/dp-config/cni.md
+++ b/app/_src/production/dp-config/cni.md
@@ -114,11 +114,11 @@ cni.chained=true
 cni.netDir=/etc/cni/net.d
 cni.binDir=/opt/cni/bin
 cni.confName=10-aws.conflist
-runtime.kubernetes.injector.sidecarContainer.redirectPortInboundV6=0
+controlPlane.envVars.KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_IP_FAMILY_MODE=ipv4
 {% endcpinstall %}
 
 {% tip %}
-Add `redirectPortInboundV6=0` as EKS has IPv6 disabled by default.
+Add `KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_IP_FAMILY_MODE=ipv4` as EKS has IPv6 disabled by default.
 {% endtip %}
 {% endtab %}
 


### PR DESCRIPTION
After https://github.com/kumahq/kuma/pull/10906 there won't be `redirectPortInboundV6` and this form basically have never worked

![image](https://github.com/user-attachments/assets/86cf70ea-254f-4dd5-92d5-fe5a928a271a)

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
