### PR TITLE
fix(observability): delete service label in prometheus scrape

### DIFF
--- a/app/_src/explore/observability.md
+++ b/app/_src/explore/observability.md
@@ -111,10 +111,6 @@ scrape_configs:
         - __meta_kuma_dataplane
         regex: "(.*)"
         target_label: dataplane
-      - source_labels:
-        - __meta_kuma_service
-        regex: "(.*)"
-        target_label: service
       - action: labelmap
         regex: __meta_kuma_label_(.+)
       kuma_sd_configs:


### PR DESCRIPTION
Service can be used by a lot of things and cause label collision kuma_service is a better alternative.

Dashboards currently don't use this label which makes it better.

part of kong/kong-mesh#4576