### PR TITLE
fix(blog): fix blogpost template

### DIFF
--- a/app/_posts/2024-06-25-kuma-2-8-0.md
+++ b/app/_posts/2024-06-25-kuma-2-8-0.md
@@ -41,7 +41,7 @@ spec:
     meshExternalService:
       matchLabels:
         kuma.io/origin: zone
-  template: "{{ .DisplayName }}.svc.meshext.local"
+  template: "{% raw %}{{ .DisplayName }}.svc.meshext.local{% endraw %}"
 ---
 apiVersion: kuma.io/v1alpha1
 kind: MeshExternalService


### PR DESCRIPTION
was not rendering `.DisplayName`

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes

rendered: https://deploy-preview-1894--kuma.netlify.app/blog/2024/kuma-2-8-0/
