### PR TITLE
fix(guide): fix not being able to link to migration steps heading because of duplication

### DIFF
--- a/app/_src/guides/migration-to-the-new-policies.md
+++ b/app/_src/guides/migration-to-the-new-policies.md
@@ -211,7 +211,7 @@ It's possible to migrate all policies at once, but small portions are preferable
 
 The generalized migration process roughly consists of 4 steps:
 
-1. Create a new [targetRef](/docs/{{ page.version }}/policies/targetref) policy as a replacement for exising [source/destination](/docs/{{ page.version }}/policies/general-notes-about-kuma-policies/) policy.
+1. Create a new [targetRef](/docs/{{ page.version }}/policies/targetref) policy as a replacement for exising [source/destination](/docs/{{ page.version }}/policies/general-notes-about-kuma-policies/) policy (do not forget about default policies that might not be stored in your source control).
 The corresponding new policy type can be found in [the table](/docs/{{ page.version }}/policies/introduction).
 Deploy the policy in [shadow mode](/docs/{{ page.version }}/policies/applying-policies/#applying-policies-in-shadow-mode) to avoid any traffic disruptions.
 2. Using Inspect API review the list of changes that are going to be created by the new policy.

--- a/app/_src/guides/migration-to-the-new-policies.md
+++ b/app/_src/guides/migration-to-the-new-policies.md
@@ -201,7 +201,7 @@ spec:
         threshold: 36' | kubectl apply -f-
 ```
 
-## Migration to the new policies
+## Migration steps
 
 It's time to migrate the demo app to the new policies.
 


### PR DESCRIPTION
otherwise we can't link to steps, it always goes to top of the page https://kuma.io/docs/2.8.x/guides/migration-to-the-new-policies/#migration-to-the-new-policies :(


Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
