### PR TITLE
docs(meshservice): modify targetref

### DIFF
--- a/app/_src/guides/federate.md
+++ b/app/_src/guides/federate.md
@@ -114,6 +114,7 @@ You should eventually see
 
 We can check policy synchronization from global control plane to zone control plane by applying a policy on global control plane:
 
+{% if_version lte:2.8.x %}
 ```
 echo "apiVersion: kuma.io/v1alpha1
 kind: MeshCircuitBreaker
@@ -137,6 +138,33 @@ spec:
         maxRetries: 2
         maxRequests: 2" | kubectl --context=kind-mesh-global apply -f -
 ```
+{% endif_version %}
+{% if_version gte:2.9.x %}
+```
+echo "apiVersion: kuma.io/v1alpha1
+kind: MeshCircuitBreaker
+metadata:
+  name: demo-app-to-redis
+  namespace: {{site.mesh_namespace}}
+  labels:
+    kuma.io/mesh: default
+spec:
+  targetRef:
+    kind: MeshService
+    name: demo-app
+    namespace: kuma-demo
+  to:
+  - targetRef:
+      kind: MeshService
+      name: redis_kuma-demo_svc_6379
+    default:
+      connectionLimits:
+        maxConnections: 2
+        maxPendingRequests: 8
+        maxRetries: 2
+        maxRequests: 2" | kubectl --context=kind-mesh-global apply -f -
+```
+{% endif_version %}
 
 If we execute the following command:
 ```sh


### PR DESCRIPTION
I'm struggling a bit, maybe @michaelbeaumont can tell me what else needs to be changed and how he envisioned this.

Should I go through every policy and change MeshService to be compatible with the new form ([basically adding namespace and modifying the name](https://github.com/kumahq/kuma/blob/e3b1dc7ae89ee5272a561c7fd03737684ea039c1/docs/madr/decisions/046-meshservice-policy-matching.md#meshservice) - or should I always use `labels`?)? Or should I add deprecation notice and an example showing the new way?

I started changing federation guide but waiting for some feedback first.

closes https://github.com/kumahq/kuma-website/issues/1892

rendered: https://deploy-preview-1909--kuma.netlify.app/docs/dev/policies/targetref/

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
