### PR TITLE
docs(policy): fixed docs of meshpassthrough and meshexternalservice

### DIFF
--- a/app/_src/networking/meshexternalservice.md
+++ b/app/_src/networking/meshexternalservice.md
@@ -7,7 +7,13 @@ This resource is experimental!
 {% endwarning %}
 
 This resource allows services running inside the mesh to consume services that are not part of the mesh.
-The `MeshExternalService` resource allows you to declare external resources instead of relying on [MeshPassthrough](/docs/{{ page.version }}/policies/meshpassthrough) or [passthrough mode](/docs/{{ page.version }}/networking/non-mesh-traffic#outgoing).
+The `MeshExternalService` resource allows you to declare external resources instead of relying on [MeshPassthrough](/docs/{{ page.version }}/policies/meshpassthrough) or [passthrough mode](/docs/{{ page.version }}/networking/non-mesh-traffic#outgoing). 
+
+{% tip %}
+What is the difference between `MeshPassthrough` and `MeshExternalService`?
+
+The main difference is that `MeshExternalService` is assigned a custom domain and can be targeted by policies. `MeshPassthrough`, on the other hand, does not alter the address of the original host and cannot be targeted by policies.
+{% endtip %}
 
 {% warning %}
 Currently `MeshExternalService` resource only supports targeting by [MeshTrafficPermission](/docs/{{ page.version }}/policies/meshtrafficpermission) with [Zone Egress](/docs/{{ page.version }}/production/cp-deployment/zoneegress).

--- a/app/_src/policies/meshpassthrough.md
+++ b/app/_src/policies/meshpassthrough.md
@@ -29,8 +29,11 @@ This policy doesn't work with sidecars without [transparent-proxy](/docs/{{ page
 
 The following describes the default configuration settings of the `MeshPassthrough` policy:
 
-- **`passthroughMode`**: (Optional) Defines behaviour for handling traffic. Allowed values: `All`, `None` and `Matched`. Default: `None`. `All` enables all traffic to pass through, `Matched` allows only the traffic defined in `appendMatch` and `None` disallows all traffic.
-- **`appendMatch`**: List of destinations that are allowed to pass through. When `enabled` is `true` this list is not used. It only takes effect when `enabled` is `false`.
+- **`passthroughMode`**: (Optional) Defines behaviour for handling traffic. Allowed values: `All`, `None` and `Matched`. Default: `None`
+  - **`All`** enables all traffic to pass through.
+  - **`Matched`** allows only the traffic defined in `appendMatch`.
+  - **`None`** disallows all traffic.
+- **`appendMatch`**: List of destinations that are allowed to pass through. When `passthroughMode` is `All` or `None` this list is not used. It only takes effect when `passthroughMode` is `Matched`.
   - **`type`**: Defines what type of destination is allowed. Either `Domain`, `IP` or `CIDR`.
   - **`value`**: Destination address based on the defined `type`.
   - **`port`**: Port at which external destination is available. When not defined it caches all traffic to the address.


### PR DESCRIPTION
Fix: https://github.com/kumahq/kuma-website/issues/1830

`proxyTypes` doesn't need clarification because it's part of a `targetRef` and not specific to any particular policy. The documentation in that context already explains it.