### PR TITLE
fix(install): change install link to the new webpage

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -5,7 +5,7 @@
 /docs/:version/overview/ /docs/:version/overview/what-is-kuma 301
 /docs/:version/production/init-containers/ /docs/:version/production/dp-config/dpp-on-kubernetes/#init-containers 301
 /latest_version.html /latest_version 301
-/install /install/LATEST_RELEASE/ 302
+/install /docs/LATEST_RELEASE/production/install-kumactl 302
 /install/latest/* /install/LATEST_RELEASE/:splat 302
 /install/kong-gateway /docs/LATEST_RELEASE/explore/gateway 302
 /docs/latest/* /docs/LATEST_RELEASE/:splat 302


### PR DESCRIPTION
the install button was leading to the old install site

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
