### PR TITLE
docs(gateway-api): use `--without-gateway` with `install demo`

### DIFF
--- a/app/_src/explore/gateway-api.md
+++ b/app/_src/explore/gateway-api.md
@@ -35,7 +35,7 @@ Gateway API [`Gateways`](https://gateway-api.sigs.k8s.io/api-types/gateway/) are
 1. Install the [counter demo](https://github.com/kumahq/kuma-counter-demo).
 
    ```sh
-   kumactl install demo | kubectl apply -f -
+   kumactl install demo --without-gateway | kubectl apply -f -
    ```
 
 2. Add a [`Gateway`](https://gateway-api.sigs.k8s.io/api-types/gateway/).

--- a/app/_src/using-mesh/managing-ingress-traffic/gateway-api.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/gateway-api.md
@@ -40,7 +40,7 @@ Kubernetes doesn't include Gateway API CRDs, [install them from the standard cha
 1. Install the [counter demo](https://github.com/kumahq/kuma-counter-demo).
 
    ```sh
-   kumactl install demo | kubectl apply -f -
+   kumactl install demo --without-gateway | kubectl apply -f -
    ```
 
 2. Add a [`Gateway`](https://gateway-api.sigs.k8s.io/api-types/gateway/).


### PR DESCRIPTION
No need for these resources when trying out Gateway API. Closes https://github.com/kumahq/kuma-website/issues/1924