### PR TITLE
fix(MeshService): namespace on example

### DIFF
--- a/app/_src/networking/meshservice.md
+++ b/app/_src/networking/meshservice.md
@@ -18,7 +18,7 @@ the analog of a Kubernetes `Service`.
 
 A basic example follows to illustrate the structure:
 
-{% policy_yaml meshservice_example %}
+{% policy_yaml meshservice_example namespace=kuma-demo %}
 ```yaml
 type: MeshService
 name: redis
@@ -29,7 +29,7 @@ spec:
   selector:
     dataplaneTags: # tags in Dataplane object, see below
       app: redis
-      k8s.kuma.io/namespace: redis-system # added automatically
+      k8s.kuma.io/namespace: kuma-demo # added automatically
   ports:
   - port: 6739
     targetPort: 6739

--- a/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/policyyaml.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/policyyaml.rb
@@ -62,7 +62,7 @@ module Jekyll
             # remove ```yaml header and ``` footer and read each document one by one
             content = content.gsub(/`{3}yaml\n/, '').gsub(/`{3}/, '')
             site_data = context.registers[:site].config
-            mesh_namespace = site_data['mesh_namespace']
+            mesh_namespace = @params["namespace"] || site_data['mesh_namespace']
             uni_content = ""
             kube_content = ""
             YAML.load_stream(content) do |yaml_data|


### PR DESCRIPTION
`kuma-system` doesn't make sense

https://deploy-preview-1952--kuma.netlify.app/docs/dev/networking/meshservice/#meshservice