### PR TITLE
Scroll tabs to top on click

### DIFF
--- a/app/_assets/javascripts/tabs.js
+++ b/app/_assets/javascripts/tabs.js
@@ -20,6 +20,7 @@ class TabsComponent {
     if (!this.options['useUrlFragment']) {
       event.preventDefault();
     }
+    event.target.scrollIntoView({ behavior: "smooth", block: "start" });
     const selectedTab = event.currentTarget;
     this.setSelectedTab(selectedTab);
     this.dispatchTabSelectedEvent(event.target.dataset.slug);

--- a/app/_assets/styles/custom/components/_vuepress-tabs.scss
+++ b/app/_assets/styles/custom/components/_vuepress-tabs.scss
@@ -52,6 +52,7 @@
   display: flex;
   padding: 0.25em 0.5em;
   text-decoration: none;
+  scroll-margin-top: $navbarHeight;
 }
 
 .tabs-component-panels {


### PR DESCRIPTION
Pages where "jumping" when clicking on tabs because the difference in height (and that we toggle all the tabs with the same slug).

As proposed in slack scroll tabs to top on click 


Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
