### PR TITLE
docs(policies): rework intro page and add concepts

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -1,3 +1,4 @@
+Aiven
 Argo CD
 [Kk]ong
 [Kk]ubernetes
@@ -15,6 +16,7 @@ backport
 Bagdi
 Bintray
 Bitnami
+[GkM]bps
 blockquotes?
 boolean
 CloudFormation
@@ -25,6 +27,7 @@ configs?
 conntrack
 cors
 CRD
+cron
 Curity
 Datadog
 datagrams?
@@ -47,6 +50,7 @@ endtabs?
 endtip
 endunless
 endwarning
+enum
 etcd
 Fargate
 firewalld
@@ -67,11 +71,13 @@ inbounds
 ini
 io
 iptables
+IPs?
 IPv6
 Istio
 jq
-json
-JsonPath
+JSON
+JSONPath
+JSONPatch
 jwks?
 jwt|JWT
 Keycloak
@@ -105,6 +111,7 @@ ngrok
 observability
 Okta
 opa
+[Oo]tel
 outbounds
 passthrough
 PayPal

--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -19,6 +19,7 @@ Bitnami
 [GkM]bps
 blockquotes?
 boolean
+camelCase
 CloudFormation
 CLI
 CNI|cni
@@ -97,6 +98,8 @@ Luarocks
 MADR
 md
 minikube
+Maglev
+matchers
 Mockbin
 Moesif
 MongoDB
@@ -113,6 +116,7 @@ Okta
 opa
 [Oo]tel
 outbounds
+PascalCase
 passthrough
 PayPal
 plaintext
@@ -134,6 +138,7 @@ runtimes?
 sandboxing
 serializer
 serverless
+snake_case
 snis
 Speedscope
 Splunk

--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -68,7 +68,7 @@ httpbin
 HTTPie
 HTTPS?
 https?
-inbounds
+[iI]nbounds?
 ini
 io
 iptables
@@ -115,7 +115,7 @@ observability
 Okta
 opa
 [Oo]tel
-outbounds
+[Oo]utbounds?
 PascalCase
 passthrough
 PayPal

--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -118,6 +118,7 @@ PayPal
 plaintext
 policy_schema
 PowerShell
+Postgres
 prepend(?:ed|s)?
 profiler
 Prometheus
@@ -134,6 +135,7 @@ sandboxing
 serializer
 serverless
 snis
+Speedscope
 Splunk
 ssl
 std(?:in|out|err)
@@ -145,6 +147,7 @@ Syslog
 target[Rr]ef
 tbl
 tcpdump
+TLS
 transcoder
 ttl
 txt

--- a/.github/styles/config/vocabularies/Base/reject.txt
+++ b/.github/styles/config/vocabularies/Base/reject.txt
@@ -2,3 +2,4 @@ control-plane
 controlplane
 data-plane
 dataplane
+tls

--- a/.vale.ini
+++ b/.vale.ini
@@ -5,6 +5,7 @@ Vocab = Base
 
 Packages = Google
 SkippedScopes = code
+IgnoredClasses=code
 
 [*.md]
 BasedOnStyles = Vale, Google

--- a/app/_data/docs_nav_kuma_2.9.x.yml
+++ b/app/_data/docs_nav_kuma_2.9.x.yml
@@ -19,6 +19,8 @@ items:
             url: "/introduction/how-kuma-works/#kuma-vs-xyz"
       - text: Architecture
         url: /introduction/architecture/
+      - text: Concepts
+        url: /introduction/concepts/
       - text: Kuma requirements
         url: /introduction/kuma-requirements/
       - text: Release notes
@@ -278,10 +280,6 @@ items:
     items:
       - text: Introduction
         url: /policies/introduction/
-      - text: Applying Policies
-        url: /policies/applying-policies/
-      - text: Understanding TargetRef policies
-        url: "/policies/targetref"
       - text: MeshAccessLog
         url: /policies/meshaccesslog/
         items:

--- a/app/_data/docs_nav_kuma_dev.yml
+++ b/app/_data/docs_nav_kuma_dev.yml
@@ -279,7 +279,7 @@ items:
     group: true
     items:
       - text: Introduction
-        url: /policies/targetref/
+        url: /policies/introduction/
       - text: MeshAccessLog
         url: /policies/meshaccesslog/
         items:

--- a/app/_data/docs_nav_kuma_dev.yml
+++ b/app/_data/docs_nav_kuma_dev.yml
@@ -19,6 +19,8 @@ items:
             url: "/introduction/how-kuma-works/#kuma-vs-xyz"
       - text: Architecture
         url: /introduction/architecture/
+      - text: Concepts
+        url: /introduction/concepts/
       - text: Kuma requirements
         url: /introduction/kuma-requirements/
       - text: Release notes
@@ -277,11 +279,7 @@ items:
     group: true
     items:
       - text: Introduction
-        url: /policies/introduction/
-      - text: Applying Policies
-        url: /policies/applying-policies/
-      - text: Understanding TargetRef policies
-        url: "/policies/targetref"
+        url: /policies/targetref/
       - text: MeshAccessLog
         url: /policies/meshaccesslog/
         items:

--- a/app/_posts/2024-06-25-kuma-2-8-0.md
+++ b/app/_posts/2024-06-25-kuma-2-8-0.md
@@ -65,7 +65,7 @@ In the coming releases of Kuma we'll be providing a default `HostnameGenerator` 
 
 ## MeshPassthrough
 
-Passthrough enables users to allow traffic to exit the mesh directly at the sidecar.
+`MeshPassthrough` enables users to allow traffic to exit the mesh directly at the sidecar.
 This feature has existed in Kuma for a long time. However, as we were discussing with users it was becoming clear that it wasn't granular enough.
 With the advent of [advanced policy matching](https://kuma.io/docs/dev/policies/introduction/) we realised that it was easy to build a policy that would enable users to specify powerful passthrough rules.
 In 2.8 we're excited to finally ship a new policy: [`MeshPassthrough`](https://kuma.io/docs/2.8.x/policies/meshpassthrough/).
@@ -75,7 +75,7 @@ Use cases for using passthrough mode are:
 - Traffic internal to the organization that isn't secured by the mesh yet.
 - Progressive migration to the Mesh.
 
-These policies are easily composable together as with this example:
+Policies can be composed together :
 
 ```yaml
 apiVersion: kuma.io/v1alpha1
@@ -119,7 +119,7 @@ spec:
         protocol: tls
 ```
 
-Here depending on the labels on your dataplane proxy you may be able to access directly mongo, confluent cloud or both.
+Here depending on the labels on your data plane proxy you may be able to access directly mongo, confluent cloud or both.
 
 With these two new features we're hoping that migrating existing services to the mesh will become easier.
 This is a workflow we're focusing on and we'd love to hear from your experience.
@@ -130,11 +130,11 @@ We strongly suggest upgrading to Kuma 2.8.0. Upgrading is easy through `kumactl`
 
 Be sure to carefully read the [upgrade Guide](/docs/2.8.x/production/upgrades-tuning/upgrades/) and the [version specific upgrade notes](/docs/2.8.x/production/upgrades-tuning/upgrade-notes) before upgrading Kuma.
 
-## Join the community!
+## Join the community
 
 Join us on our [community channels](/community/), including official Slack chat, to learn more about Kuma.
 The community channels are useful for getting up and running with Kuma, as well as for learning how to contribute to and discuss the project roadmap.
 Kuma is a CNCF Sandbox project: neutral, open and inclusive.
 
-The community call is hosted [on the second Wednesday of every Month at 8:30am PDT](/community/).
+The community call is hosted [on the second Wednesday of every Month at 8:30 AM PDT](/community/).
 And don't forget to follow Kuma [on Twitter](https://twitter.com/kumamesh) and star it [on GitHub](https://github.com/kumahq/kuma)!

--- a/app/_posts/2024-06-25-kuma-2-8-0.md
+++ b/app/_posts/2024-06-25-kuma-2-8-0.md
@@ -67,7 +67,7 @@ In the coming releases of Kuma we'll be providing a default `HostnameGenerator` 
 
 Passthrough enables users to allow traffic to exit the mesh directly at the sidecar.
 This feature has existed in Kuma for a long time. However, as we were discussing with users it was becoming clear that it wasn't granular enough.
-With the advent of [advanced policy matching](https://kuma.io/docs/dev/policies/targetref/) we realised that it was easy to build a policy that would enable users to specify powerful passthrough rules.
+With the advent of [advanced policy matching](https://kuma.io/docs/dev/policies/introduction/) we realised that it was easy to build a policy that would enable users to specify powerful passthrough rules.
 In 2.8 we're excited to finally ship a new policy: [`MeshPassthrough`](https://kuma.io/docs/2.8.x/policies/meshpassthrough/).
 
 Use cases for using passthrough mode are:

--- a/app/_src/guides/migration-to-the-new-policies.md
+++ b/app/_src/guides/migration-to-the-new-policies.md
@@ -11,10 +11,10 @@ and enhance the matching functionality and overall UX.
 In this guide, we're going to setup a demo with old policies and then perform a migration to the new policies.
 
 ## Prerequisites
-- [Helm](https://helm.sh/) - a package manager for Kubernetes
-- [Kind](https://kind.sigs.k8s.io/) - a tool for running local Kubernetes clusters
-- [jq](https://jqlang.github.io/jq/) - a command-line JSON processor
-- [jd](https://github.com/josephburnett/jd) - a command-line util to visualise JSONPatch
+- [`helm`](https://helm.sh/) - a package manager for Kubernetes
+- [`kind`](https://kind.sigs.k8s.io/) - a tool for running local Kubernetes clusters
+- [`jq`](https://jqlang.github.io/jq/) - a command-line json processor
+- [`jd`](https://github.com/josephburnett/jd) - a command-line utility to visualise JSONPatch
 
 ## Start Kubernetes cluster
 
@@ -205,13 +205,13 @@ spec:
 
 It's time to migrate the demo app to the new policies.
 
-Each type of policy can be migrated separately; for example, once we have completely finished with the Timeouts,
-we will proceed to the next policy type, CircuitBreakers.
+Each type of policy can be migrated separately; for example, once we have completely finished with the `Timeout`s,
+we will proceed to the next policy type, `CircuitBreakers`.
 It's possible to migrate all policies at once, but small portions are preferable as they're easily reversible.
 
 The generalized migration process roughly consists of 4 steps:
 
-1. Create a new [targetRef](/docs/{{ page.version }}/policies/introduction) policy as a replacement for exising [source/destination](/docs/{{ page.version }}/policies/general-notes-about-kuma-policies/) policy (do not forget about default policies that might not be stored in your source control).
+1. Create a new [targetRef](/docs/{{ page.version }}/policies/introduction) policy as a replacement for existing [source/destination](/docs/{{ page.version }}/policies/general-notes-about-kuma-policies/) policy (do not forget about default policies that might not be stored in your source control).
 The corresponding new policy type can be found in [the table](/docs/{{ page.version }}/policies/introduction).
 Deploy the policy in [shadow mode](/docs/{{ page.version }}/policies/introduction/#applying-policies-in-shadow-mode) to avoid any traffic disruptions.
 2. Using Inspect API review the list of changes that are going to be created by the new policy.
@@ -264,7 +264,7 @@ This is because many old policies, like Timeout and CircuitBreaker, depend on Tr
    + {"permissions":[{"any":true}],"principals":[{"authenticated":{"principalName":{"exact":"spiffe://default/demo-app_kuma-demo_svc_5000"}}}]}
     ```
 
-    As we can see, the only difference is the policy name "MeshTrafficPermission" instead of "allow-all-default".
+    As we can see, the only difference is the policy name `MeshTrafficPermission` instead of `allow-all-default`.
     The value of the policy is the same.
 
 3. Remove the `kuma.io/effect: shadow` label:

--- a/app/_src/guides/migration-to-the-new-policies.md
+++ b/app/_src/guides/migration-to-the-new-policies.md
@@ -5,7 +5,7 @@ title: Migration to the new policies
 {{site.mesh_product_name}} provides two set of policies to configure proxies.
 The original [source/destination](/docs/{{ page.version }}/policies/general-notes-about-kuma-policies/) policies,
 while provided a lot of features, haven't met users expectations in terms of flexibility and transparency.
-The new [targetRef](/docs/{{ page.version }}/policies/targetref) policies were designed to preserve what already worked well,
+The new [targetRef](/docs/{{ page.version }}/policies/introduction) policies were designed to preserve what already worked well,
 and enhance the matching functionality and overall UX.
 
 In this guide, we're going to setup a demo with old policies and then perform a migration to the new policies.
@@ -211,9 +211,9 @@ It's possible to migrate all policies at once, but small portions are preferable
 
 The generalized migration process roughly consists of 4 steps:
 
-1. Create a new [targetRef](/docs/{{ page.version }}/policies/targetref) policy as a replacement for exising [source/destination](/docs/{{ page.version }}/policies/general-notes-about-kuma-policies/) policy (do not forget about default policies that might not be stored in your source control).
+1. Create a new [targetRef](/docs/{{ page.version }}/policies/introduction) policy as a replacement for exising [source/destination](/docs/{{ page.version }}/policies/general-notes-about-kuma-policies/) policy (do not forget about default policies that might not be stored in your source control).
 The corresponding new policy type can be found in [the table](/docs/{{ page.version }}/policies/introduction).
-Deploy the policy in [shadow mode](/docs/{{ page.version }}/policies/applying-policies/#applying-policies-in-shadow-mode) to avoid any traffic disruptions.
+Deploy the policy in [shadow mode](/docs/{{ page.version }}/policies/introduction/#applying-policies-in-shadow-mode) to avoid any traffic disruptions.
 2. Using Inspect API review the list of changes that are going to be created by the new policy.
 3. Remove `kuma.io/effect: shadow` label so that policy is applied in a normal mode.
 4. Observe metrics, traces and logs. If something goes wrong change policy's mode back to shadow and return to the step 2.

--- a/app/_src/guides/migration-to-the-new-policies.md
+++ b/app/_src/guides/migration-to-the-new-policies.md
@@ -13,7 +13,7 @@ In this guide, we're going to setup a demo with old policies and then perform a 
 ## Prerequisites
 - [`helm`](https://helm.sh/) - a package manager for Kubernetes
 - [`kind`](https://kind.sigs.k8s.io/) - a tool for running local Kubernetes clusters
-- [`jq`](https://jqlang.github.io/jq/) - a command-line json processor
+- [`jq`](https://jqlang.github.io/jq/) - a command-line JSON processor
 - [`jd`](https://github.com/josephburnett/jd) - a command-line utility to visualise JSONPatch
 
 ## Start Kubernetes cluster

--- a/app/_src/introduction/concepts.md
+++ b/app/_src/introduction/concepts.md
@@ -9,11 +9,46 @@ In this page we will introduce concepts that are core to understanding Kuma.
 The control-plane is the central management layer of {{ site.product_name }}. It is responsible for configuring and managing the behavior of the data plane,
 which handles the actual traffic between services.
 
-## Data-Plane Proxy / Sidecar
+## Data Plane
+
+### Data-Plane Proxy / Sidecar
 
 The data-plane handles traffic between services.
 It connects to the control-plane which computes a configuration specific to it.
 The data-plane proxy or Sidecar is the instance of Envoy running alongside the data-plane which will send and receive traffic from the rest of the service mesh.
+
+```mermaid
+-------------------------------------
+title: Representation of a Dataplane
+-------------------------------------
+flowchart LR
+
+clients@{ shape: processes, label: "clients" }
+servers@{ shape: processes, label: "servers"}
+
+subgraph Data-plane
+   app
+   subgraph data-plane proxy/Envoy
+   inbounds
+   outbounds
+   end
+end
+
+inbounds -.local traffic.-> app
+app -.local traffic.-> outbounds
+
+clients --> inbounds
+outbounds --> servers
+```
+
+### Inbound
+
+An inbound is the part of the data-plane proxy which receives traffic for a specific port.
+inbounds are usually grouped between different data-planes and form a service.
+
+### Outbound
+
+An outbound is the part 
 
 ## Resource
 

--- a/app/_src/introduction/concepts.md
+++ b/app/_src/introduction/concepts.md
@@ -6,18 +6,18 @@ In this page we will introduce concepts that are core to understanding Kuma.
 
 ## Control Plane
 
-The control-plane is the central management layer of {{ site.product_name }}. It is responsible for configuring and managing the behavior of the data plane,
+The control plane is the central management layer of {{ site.product_name }}. It is responsible for configuring and managing the behavior of the data plane,
 which handles the actual traffic between services.
 
 ## Data Plane
 
-### Data-Plane Proxy / Sidecar
+### Data Plane Proxy / Sidecar
 
-The data-plane handles traffic between services.
-It connects to the control-plane which computes a configuration specific to it.
-The data-plane proxy or Sidecar is the instance of Envoy running alongside the data-plane which will send and receive traffic from the rest of the service mesh.
+The data plane handles traffic between services.
+It connects to the control plane which computes a configuration specific to it.
+The data plane proxy or sidecar is the instance of Envoy running alongside the application which will send and receive traffic from the rest of the service mesh.
 
-```mermaid
+{% mermaid %}
 -------------------------------------
 title: Representation of a Dataplane
 -------------------------------------
@@ -26,9 +26,9 @@ flowchart LR
 clients@{ shape: processes, label: "clients" }
 servers@{ shape: processes, label: "servers"}
 
-subgraph Data-plane
+subgraph Data plane
    app
-   subgraph data-plane proxy/Envoy
+   subgraph data plane proxy/Envoy
    inbounds
    outbounds
    end
@@ -39,12 +39,12 @@ app -.local traffic.-> outbounds
 
 clients --> inbounds
 outbounds --> servers
-```
+{% endmermaid %}
 
 ### Inbound
 
-An inbound is the part of the data-plane proxy which receives traffic for a specific port.
-inbounds are usually grouped between different data-planes and form a service.
+An inbound is the part of the data plane proxy which receives traffic for a specific port.
+inbounds are usually grouped between different data planes and form a service.
 
 ### Outbound
 
@@ -58,7 +58,7 @@ Each resource is defined as a type of API object that has a specific purpose and
 
 A resource is most often expressed as yaml and can have 2 formats:
 
-- `Kubernetes` when the backing control-plane runs on Kubernetes. In this case {{ site.product_name }} resources are defined as Kubernetes Custom Resource Definitions.
+- `Kubernetes` when the backing control plane runs on Kubernetes. In this case {{ site.product_name }} resources are defined as Kubernetes Custom Resource Definitions.
 - `Universal` in other cases or when accessing resources through {{ site.product_name}}'s REST api.
 
 Resources are most commonly represented in yaml format.

--- a/app/_src/introduction/concepts.md
+++ b/app/_src/introduction/concepts.md
@@ -20,20 +20,17 @@ The data plane proxy or sidecar is the instance of Envoy running alongside the a
 It connects to the control plane which computes a configuration specific to it.
 
 {% mermaid %}
--------------------------------------
-title: Representation of a Dataplane
--------------------------------------
+
 flowchart LR
+clients
+servers
 
-clients@{ shape: processes, label: "clients" }
-servers@{ shape: processes, label: "servers"}
-
-subgraph Data plane
-   app
-   subgraph data plane proxy/Envoy
-   inbounds
-   outbounds
-   end
+subgraph data plane
+app
+subgraph data plane proxy/Envoy
+inbounds
+outbounds
+end
 end
 
 inbounds -.local traffic.-> app
@@ -41,14 +38,15 @@ app -.local traffic.-> outbounds
 
 clients --> inbounds
 outbounds --> servers
+
 {% endmermaid %}
 
-### Inbound
+#### Inbound
 
 An inbound is the part of the data plane proxy which receives traffic for a specific port.
 Inbounds are usually grouped between different data planes and form a service.
 
-### Outbound
+#### Outbound
 
 An outbound is the part of the data plane proxy which sends traffic for a specific service.
 Outbounds group multiple remote inbounds as endpoints.

--- a/app/_src/introduction/concepts.md
+++ b/app/_src/introduction/concepts.md
@@ -34,4 +34,4 @@ Policies are a specific type of Resources which controls the behaviour, security
 They can enable traffic management, security, observability and traffic reliability.
 
 Policies always have a clear specific area of impact and goal.
-To learn more about [policies checkout the in depth introduction](/docs/{{ page.version }}/policies/targetref).
+To learn more about [policies checkout the in depth introduction](/docs/{{ page.version }}/policies/introduction).

--- a/app/_src/introduction/concepts.md
+++ b/app/_src/introduction/concepts.md
@@ -46,7 +46,7 @@ outbounds --> servers
 ### Inbound
 
 An inbound is the part of the data plane proxy which receives traffic for a specific port.
-inbounds are usually grouped between different data planes and form a service.
+Inbounds are usually grouped between different data planes and form a service.
 
 ### Outbound
 

--- a/app/_src/introduction/concepts.md
+++ b/app/_src/introduction/concepts.md
@@ -2,11 +2,11 @@
 title: Concepts
 ---
 
-In this page we will introduce concepts that are core to understanding {{ site.product_name }}.
+In this page we will introduce concepts that are core to understanding {{ site.mesh_product_name }}.
 
 ## Control Plane
 
-The control plane is the central management layer of {{ site.product_name }}. It is responsible for configuring and managing the behavior of the data plane,
+The control plane is the central management layer of {{ site.mesh_product_name }}. It is responsible for configuring and managing the behavior of the data plane,
 which handles the actual traffic between services.
 
 ## Data Plane
@@ -52,14 +52,14 @@ An outbound is the part
 
 ## Resource
 
-A resource is an object or entity that can be created, managed, and interacted with in {{ site.product_name }}.
+A resource is an object or entity that can be created, managed, and interacted with in {{ site.mesh_product_name }}.
 Resources are the building blocks that define the behavior and state of your service mesh.
 Each resource is defined as a type of API object that has a specific purpose and is represented by its state and configuration.
 
 A resource is most often expressed as yaml and can have 2 formats:
 
-- `Kubernetes` when the backing control plane runs on Kubernetes. In this case {{ site.product_name }} resources are defined as Kubernetes Custom Resource Definitions.
-- `Universal` in other cases or when accessing resources through {{ site.product_name}}'s REST api.
+- `Kubernetes` when the backing control plane runs on Kubernetes. In this case {{ site.mesh_product_name }} resources are defined as Kubernetes Custom Resource Definitions.
+- `Universal` in other cases or when accessing resources through {{ site.mesh_product_name}}'s REST api.
 
 Resources are most commonly represented in yaml format.
 

--- a/app/_src/introduction/concepts.md
+++ b/app/_src/introduction/concepts.md
@@ -1,0 +1,37 @@
+---
+title: Concepts
+---
+
+In this page we will introduce concepts that are core to understanding Kuma.
+
+## Control-Plane
+
+The control-plane is the central management layer of {{ site.product_name }}. It is responsible for configuring and managing the behavior of the data plane,
+which handles the actual traffic between services.
+
+## Data-Plane Proxy / Sidecar
+
+The data-plane handles traffic between services.
+It connects to the control-plane which computes a configuration specific to it.
+The Data-Plane proxy or Sidecar is the instance of Envoy running alongside the data-plane which will send and receive traffic from the rest of the service mesh.
+
+## Resource
+
+A resource is an object or entity that can be created, managed, and interacted with in {{ site.product_name }}.
+Resources are the building blocks that define the behavior and state of your service-mesh.
+Each resource is defined as a type of API object that has a specific purpose and is represented by its state and configuration.
+
+A resource is most often expressed as yaml and can have 2 formats:
+
+- `Kubernetes` when the backing control-plane runs on Kubernetes. In this case {{ site.product_name }} resources are defined as Kubernetes Custom Resource Definitions.
+- `Universal` in other cases or when accessing resources through {{ site.product_name}}'s REST api.
+
+Resources are most commonly represented in yaml format.
+
+## Policy
+
+Policies are a specific type of Resources which controls the behaviour, security and communication of applications running inside your service mesh.
+They can enable traffic management, security, observability and traffic reliability.
+
+Policies always have a clear specific area of impact and goal.
+To learn more about [policies checkout the in depth introduction](/docs/{{ page.version }}/policies/targetref).

--- a/app/_src/introduction/concepts.md
+++ b/app/_src/introduction/concepts.md
@@ -65,7 +65,7 @@ Resources are most commonly represented in yaml format.
 
 ## Policy
 
-Policies are a specific type of resources that controls the behaviour, security and communication of applications running inside your service mesh.
+Policies are a specific type of resources that controls the behaviour and communication of applications running inside your service mesh.
 They can enable traffic management, security, observability and traffic reliability.
 
 Policies always have a clear specific area of impact and goal.

--- a/app/_src/introduction/concepts.md
+++ b/app/_src/introduction/concepts.md
@@ -4,7 +4,7 @@ title: Concepts
 
 In this page we will introduce concepts that are core to understanding Kuma.
 
-## Control-Plane
+## Control Plane
 
 The control-plane is the central management layer of {{ site.product_name }}. It is responsible for configuring and managing the behavior of the data plane,
 which handles the actual traffic between services.
@@ -13,7 +13,7 @@ which handles the actual traffic between services.
 
 The data-plane handles traffic between services.
 It connects to the control-plane which computes a configuration specific to it.
-The Data-Plane proxy or Sidecar is the instance of Envoy running alongside the data-plane which will send and receive traffic from the rest of the service mesh.
+The data-plane proxy or Sidecar is the instance of Envoy running alongside the data-plane which will send and receive traffic from the rest of the service mesh.
 
 ## Resource
 

--- a/app/_src/introduction/concepts.md
+++ b/app/_src/introduction/concepts.md
@@ -11,11 +11,13 @@ which handles the actual traffic between services.
 
 ## Data Plane
 
+The data plane handles traffic between services.
+In practice these are the apps that you build and that you want to put inside you service-mesh.
+
 ### Data Plane Proxy / Sidecar
 
-The data plane handles traffic between services.
-It connects to the control plane which computes a configuration specific to it.
 The data plane proxy or sidecar is the instance of Envoy running alongside the application which will send and receive traffic from the rest of the service mesh.
+It connects to the control plane which computes a configuration specific to it.
 
 {% mermaid %}
 -------------------------------------
@@ -48,7 +50,8 @@ inbounds are usually grouped between different data planes and form a service.
 
 ### Outbound
 
-An outbound is the part 
+An outbound is the part of the data plane proxy which sends traffic for a specific service.
+Outbounds group multiple remote inbounds as endpoints.
 
 ## Resource
 
@@ -63,7 +66,7 @@ A resource is most often expressed as yaml and can have 2 formats:
 
 Resources are most commonly represented in yaml format.
 
-## Policy
+### Policy
 
 Policies are a specific type of resources that controls the behaviour and communication of applications running inside your service mesh.
 They can enable traffic management, security, observability and traffic reliability.

--- a/app/_src/introduction/concepts.md
+++ b/app/_src/introduction/concepts.md
@@ -2,7 +2,7 @@
 title: Concepts
 ---
 
-In this page we will introduce concepts that are core to understanding Kuma.
+In this page we will introduce concepts that are core to understanding {{ site.product_name }}.
 
 ## Control Plane
 
@@ -53,7 +53,7 @@ An outbound is the part
 ## Resource
 
 A resource is an object or entity that can be created, managed, and interacted with in {{ site.product_name }}.
-Resources are the building blocks that define the behavior and state of your service-mesh.
+Resources are the building blocks that define the behavior and state of your service mesh.
 Each resource is defined as a type of API object that has a specific purpose and is represented by its state and configuration.
 
 A resource is most often expressed as yaml and can have 2 formats:
@@ -65,7 +65,7 @@ Resources are most commonly represented in yaml format.
 
 ## Policy
 
-Policies are a specific type of Resources which controls the behaviour, security and communication of applications running inside your service mesh.
+Policies are a specific type of resources that controls the behaviour, security and communication of applications running inside your service mesh.
 They can enable traffic management, security, observability and traffic reliability.
 
 Policies always have a clear specific area of impact and goal.

--- a/app/_src/networking/meshservice.md
+++ b/app/_src/networking/meshservice.md
@@ -303,7 +303,7 @@ relevant `MeshServices` via [`reachableBackends`](/docs/{{ page.version }}/produ
 
 This is the end goal of the migration. Destinations in the mesh are managed
 solely with `MeshService` resources and no longer via `kuma.io/service` tags and
-`Dataplane` inbounds.
+`Dataplane` inbounds. In the future this will become the default.
 
 ### Steps
 

--- a/app/_src/networking/meshservice.md
+++ b/app/_src/networking/meshservice.md
@@ -4,7 +4,7 @@ title: MeshService
 
 {% if_version lte:2.8.x %}
 {% warning %}
-This resource is experimental!
+This resource is experimental.
 In Kubernetes, to take advantage of the automatic generation described below,
 you need to set both [control plane configuration variables](/docs/{{ page.version }}/reference/kuma-cp/) `KUMA_EXPERIMENTAL_SKIP_PERSISTED_VIPS`
 and `KUMA_EXPERIMENTAL_GENERATE_MESH_SERVICES` to `"true"` on the zone control
@@ -288,7 +288,7 @@ Both `kuma.io/service` and `MeshService` are used to generate the Envoy resource
 Envoy Clusters and ClusterLoadAssignments. So having both enabled means roughly
 twice as many resources which in turn means potentially
 hitting the resource limits of the control plane and memory usage in the
-dataplane, before reachable backends
+data plane, before reachable backends
 would otherwise be necessary. Therefore, consider trying `ReachableBackends` as
 described below.
 

--- a/app/_src/policies/general-notes-about-kuma-policies.md
+++ b/app/_src/policies/general-notes-about-kuma-policies.md
@@ -3,7 +3,7 @@ title: General notes about Kuma policies
 ---
 {% if_version gte:2.6.x %}
 {% warning %}
-New to Kuma? You don't need this, check [`TargetRef` policies](/docs/{{ page.version }}/policies/introduction) instead.
+New to Kuma? You don't need this, check [`TargetRef` policies](/docs/{{ page.version }}/policies/targetref) instead.
 {% endwarning %}
 {% endif_version %}
 {% if_version lte:2.5.x %}

--- a/app/_src/policies/general-notes-about-kuma-policies.md
+++ b/app/_src/policies/general-notes-about-kuma-policies.md
@@ -3,7 +3,7 @@ title: General notes about Kuma policies
 ---
 {% if_version gte:2.6.x %}
 {% warning %}
-New to Kuma? You don't need this, check [`TargetRef` policies](/docs/{{ page.version }}/policies/targetref) instead.
+New to Kuma? You don't need this, check [`TargetRef` policies](/docs/{{ page.version }}/policies/introduction) instead.
 {% endwarning %}
 {% endif_version %}
 {% if_version lte:2.5.x %}
@@ -30,11 +30,11 @@ conf:
   ... # policy-specific configuration
 ```
 
-* sources - list of selectors that specify the dataplane objects where network traffic originates
-* destinations - list of selectors that specify the dataplane object the source traffic is sent to
+* sources - list of selectors that specify the data planes where network traffic originates
+* destinations - list of selectors that specify the data planes the source traffic is sent to
 * conf - configuration to apply to network traffic between sources and destinations
 
-{{site.mesh_product_name}} assumes that every dataplane object represents a service, even if it's a cron job that doesn't normally handle incoming traffic. This means the `kuma.io/service` tag is required for sources and destinations. Note the following requirements for values:
+{{site.mesh_product_name}} assumes that every data plane represents a service, even if it's a cron job that doesn't normally handle incoming traffic. This means the `kuma.io/service` tag is required for sources and destinations. Note the following requirements for values:
 
 * The wildcard character (*) is supported only as the selector value to match all traffic.
 * Tag values can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), and underscores (`_`).
@@ -42,9 +42,9 @@ conf:
 
 Tag and selector names can contain only alphanumeric characters, dots (`.`), dashes (`-`), colons (`:`), underscores (`_`), and slashes (`/`).
 
-All policies support arbitrary tags for the `sources` selector, but there are tag limitations for the `destinations` selector. For example, policies that are applied on the client side of a connection between two dataplane objects do not support arbitrary tags in the `destinations` selector. Only the `kuma.io/service` tag is supported in this case. This includes TrafficRoute, TrafficLog, and HealthCheck.
+All policies support arbitrary tags for the `sources` selector, but there are tag limitations for the `destinations` selector. For example, policies that are applied on the client side of a connection between two data planes do not support arbitrary tags in the `destinations` selector. Only the `kuma.io/service` tag is supported in this case. This includes TrafficRoute, TrafficLog, and HealthCheck.
 
-For example, this policy applies to all network traffic between all dataplane objects:
+For example, this policy applies to all network traffic between all data planes:
 
 ```yaml
 sources:
@@ -59,7 +59,7 @@ conf:
   ...
 ```
 
-This policy applies only to network traffic between dataplane objects for the specified services:
+This policy applies only to network traffic between data planes for the specified services:
 
 ```yaml
 sources:

--- a/app/_src/policies/introduction.md
+++ b/app/_src/policies/introduction.md
@@ -9,10 +9,7 @@ A policy is a set of configuration that will be used to generate the proxy confi
 
 ## What do policies look like?
 
-Like all [resources](/docs/{{ page.version }}/introduction/concepts#resource) in {{ site.mesh_product_name }}, there are two parts to a policy:
-
-1. The metadata
-2. The spec
+Like all [resources](/docs/{{ page.version }}/introduction/concepts#resource) in {{ site.mesh_product_name }}, there are two parts to a policy: the metadata and the spec.
 
 ### Metadata
 
@@ -59,7 +56,7 @@ spec: ... # spec data specific to the policy kind
 ```
 
 {% warning %}
-Policies are namespaced scope and currently the namespace must be the one the control-plane is running in `{{site.mesh_namespace}}` by default.
+Policies are namespace-scoped and currently the namespace must be the one the control-plane is running in `{{site.mesh_namespace}}` by default.
 {% endwarning %}
 
 {% endtab %}
@@ -74,7 +71,7 @@ Some policies apply to only a subset of the configuration of the proxy.
 - **Inbound policies** apply only to incoming traffic. The `spec.from[].targetRef` field defines the subset of clients that are going to be impacted by this policy.
 - **Outbound policies** apply only to outgoing traffic. The `spec.to[].targetRef` field defines the outbounds that are going to be impacted by this policy
 
-The actual configuration is defined in a `default` map.
+The actual configuration is defined under the `default` field.
 
 For example:
 
@@ -130,7 +127,7 @@ This means that converting policies between Universal and Kubernetes only means 
 
 ## Writing a `targetRef`
 
-`targetRef` is a concept borrowed from [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) its usage is fully defined in [MADR 005](https://github.com/kumahq/kuma/blob/master/docs/madr/decisions/005-policy-matching.md).
+`targetRef` is a concept borrowed from [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/). 
 Its goal is to select subsets of proxies with maximum flexibility.
 
 It looks like:
@@ -142,6 +139,8 @@ targetRef:
   tags:
     key: value # For kinds MeshSubset and MeshGateway a list of matching tags can be used
   proxyTypes: ["Sidecar", "Gateway"] # For kinds Mesh and MeshSubset a list of matching Dataplanes types can be used
+  labels:
+    key: value # In the case of policies that apply to labeled resources you can use these to apply the policy to each resource
 ```
 
 Here's an explanation of each kinds and their scope:
@@ -195,7 +194,7 @@ The `spec.to[].targetRef` section enables logging for any traffic going to `web-
 The `spec.from[].targetRef` section enables logging for any traffic coming from _anywhere_ in the `Mesh`.
 
 ### Omitting `targetRef`
-When a `targetRef` is not present. It is semantically equivalent to: `targetRef.kind: Mesh` meaning everything inside the mesh.
+When a `targetRef` is not present. It is semantically equivalent to: `targetRef.kind: Mesh` meaning everything inside the `Mesh`.
 
 ### Applying to specific proxy types
 The `targetRef` field can select a specific subset of data plane proxies. The field named `proxyTypes` can restrict policies to specific types of data plane proxies:
@@ -410,7 +409,7 @@ In other words:
    ```
 
 There is however, one exception to this when using `MeshService` with **outbound** policies (policies with `spec.to[].targetRef`).
-In this case, if you define a policy in the same namespace as the `MeshService` it is defined in a policy will be considered to be a **producer** policy.
+In this case, if you define a policy in the same namespace as the `MeshService` it is defined in, that policy will be considered a **producer** policy.
 This means that all clients of this service (even in different zones) will be impacted by this policy.
 
 An example of a producer policy is:

--- a/app/_src/policies/introduction.md
+++ b/app/_src/policies/introduction.md
@@ -1,6 +1,651 @@
 ---
 title: Policies
 ---
+{% if_version gte:2.9.x %}
+## What is a policy?
+
+A policy is a set of configuration that will be used to generate the proxy configuration.
+{{ site.mesh_product_name }} combines policies with dataplane configuration to generate the Envoy configuration of a proxy.
+
+## What do policies look like?
+
+Like all [resources](/docs/{{ page.version }}/introduction/concepts#resource) in {{ site.mesh_product_name }}, there are two parts to a policy:
+
+1. The metadata
+2. The spec
+
+### Metadata
+
+Metadata identifies the policies by its `name`, `type` and what `mesh` it's part of:
+
+{% tabs metadata %}
+{% tab metadata Universal %}
+
+```yaml
+type: ExamplePolicy
+name: my-policy-name
+mesh: default
+spec: ... # spec data specific to the policy kind
+```
+
+{% endtab %}
+{% tab metadata Kubernetes %}
+
+In Kubernetes all our policies are implemented as [custom resource definitions (CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) in the group `kuma.io/v1alpha1`.
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: ExamplePolicy
+metadata:
+  name: my-policy-name
+  namespace: {{ site.mesh_namespace }}
+spec: ... # spec data specific to the policy kind
+```
+
+By default the policy is created in the `default` mesh.
+You can specify the mesh by using the `kuma.io/mesh` label.
+
+For example:
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: ExamplePolicy
+metadata:
+  name: my-policy-name
+  namespace: {{ site.mesh_namespace }}
+  labels:
+    kuma.io/mesh: "my-mesh"
+spec: ... # spec data specific to the policy kind
+```
+
+{% warning %}
+Policies are namespaced scope and currently the namespace must be the one the control-plane is running in `{{site.mesh_namespace}}` by default.
+{% endwarning %}
+
+{% endtab %}
+{% endtabs %}
+
+### Spec
+
+The `spec` field contains the actual configuration of the policy.
+
+Some policies apply to only a subset of the configuration of the proxy.
+
+- **Inbound policies** apply only to incoming traffic. The `spec.from[].targetRef` field defines the subset of clients that are going to be impacted by this policy.
+- **Outbound policies** apply only to outgoing traffic. The `spec.to[].targetRef` field defines the outbounds that are going to be impacted by this policy
+
+The actual configuration is defined in a `default` map.
+
+For example:
+
+{% policy_yaml base-example %}
+```yaml
+type: ExamplePolicy
+name: my-example
+mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default: # Configuration that applies to outgoing traffic
+        key: value
+  from:
+    - targetRef:
+        kind: Mesh
+      default: # Configuration that applies to incoming traffic
+        key: value
+```
+{% endpolicy_yaml %}
+
+{% tip %}
+While some policies can have both a `to` and a `from` section, it is strongly advised to create 2 different policies, one for `to` and one for `from`.
+{% endtip %}
+
+Some policies are not directional and will not have `to` and `from`. Some examples of such policies are [`MeshTrace`](/docs/{{ page.version }}/policies/meshtrace) or [`MeshProxyPatch`](/docs/{{ page.version }}/policies/meshproxypatch).
+For example
+
+{% policy_yaml non-directional %}
+```yaml
+type: NonDirectionalPolicy
+name: my-example
+mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    key: value
+```
+{% endpolicy_yaml %}
+
+All specs have a **top level `targetRef`** which identifies which proxies this policy applies to.
+In particular, it defines which proxies have their Envoy configuration modified.
+
+{% tip %}
+One of the benefits of `targetRef` policies is that the spec is always the same between Kubernetes and Universal.
+
+This means that converting policies between Universal and Kubernetes only means rewriting the metadata.
+{% endtip %}
+
+## Writing a `targetRef`
+
+`targetRef` is a concept borrowed from [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) its usage is fully defined in [MADR 005](https://github.com/kumahq/kuma/blob/master/docs/madr/decisions/005-policy-matching.md).
+Its goal is to select subsets of proxies with maximum flexibility.
+
+It looks like:
+
+```yaml
+targetRef:
+  kind: Mesh | MeshSubset | MeshService | MeshGateway
+  name: "my-name" # For kinds MeshService, and MeshGateway a name has to be defined
+  tags:
+    key: value # For kinds MeshSubset and MeshGateway a list of matching tags can be used
+  proxyTypes: ["Sidecar", "Gateway"] # For kinds Mesh and MeshSubset a list of matching Dataplanes types can be used
+```
+
+Here's an explanation of each kinds and their scope:
+
+- Mesh: applies to all proxies running in the mesh
+- MeshSubset: same as Mesh but filters only proxies who have matching `targetRef.tags`
+- MeshService: all proxies with a tag `kuma.io/service` equal to `targetRef.name`.{% if_version gte:2.9.x %} This can work differently when using [explicit services](##using-policies-with-meshservice-meshmultizoneservice-and-meshexternalservice){% endif_version %}.
+- MeshGateway: targets proxies matched by the named MeshGateway
+    - Note that it's very strongly recommended to target MeshGateway proxies using this
+      kind, as opposed to MeshService/MeshServiceSubset.
+- MeshServiceSubset: same as `MeshService` but further refine to proxies that have matching `targetRef.tags`. ⚠️This is deprecated from version 2.9.x ⚠️.
+
+Consider the example below:
+
+{% policy_yaml accesslog_example %}
+```yaml
+type: MeshAccessLog
+name: example
+mesh: default
+spec:
+  targetRef: # top level targetRef
+    kind: MeshSubset
+    tags:
+        app: web-frontend
+  to:
+    - targetRef: # to level targetRef
+        kind: MeshService
+        name: web-backend
+      default:
+        backends:
+          - file:
+              format:
+                plain: '{"start_time": "%START_TIME%"}'
+              path: "/tmp/logs.txt"
+  from:
+    - targetRef: # from level targetRef
+        kind: Mesh
+      default:
+        backends:
+          - file:
+              format:
+                plain: '{"start_time": "%START_TIME%"}'
+              path: "/tmp/logs.txt"
+```
+{% endpolicy_yaml %}
+
+Using `spec.targetRef`, this policy targets all proxies that have a tag `app:web-frontend`.
+It defines the scope of this policy as applying to traffic either from or to dataplane proxies with the tag `app:web-frontend`.
+
+The `spec.to[].targetRef` section enables logging for any traffic going to `web-backend`.
+The `spec.from[].targetRef` section enables logging for any traffic coming from _anywhere_ in the `Mesh`.
+
+### Omitting `targetRef`
+When a `targetRef` is not present. It is semantically equivalent to: `targetRef.kind: Mesh` meaning everything inside the mesh.
+
+### Applying to specific proxy types
+The `targetRef` field can select a specific subset of data plane proxies. The field named `proxyTypes` can restrict policies to specific types of data plane proxies:
+- `Sidecar`: Targets data plane proxies acting as sidecars to applications.
+- `Gateway`: Applies to data plane proxies operating in Gateway mode.
+- Empty list: Defaults to targeting all data plane proxies.
+
+#### Example
+
+The following policy will only apply to gateway data-planes:
+{% policy_yaml proxytypes %}
+```yaml
+type: MeshTimeout
+name: gateway-only-timeout
+mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+    proxyTypes: ["Gateway"]
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        idleTimeout: 10s
+```
+{% endpolicy_yaml %}
+
+### Target resources
+
+Not every policy supports `to` and `from` levels. Additionally, not every resource can
+appear at every supported level. The specified top level resource can also affect which
+resources can appear in `to` or `from`.
+
+To help users, each policy documentation includes tables indicating which `targetRef` kinds is supported at each level.
+For each type of proxy, sidecar or builtin gateway, the table indicates for each
+`targetRef` level, which kinds are supported.
+
+#### Example tables
+
+These are just examples, remember to check the docs specific to your policy!
+
+{% tabs targetRef useUrlFragment=false %}
+{% tab targetRef Sidecar %}
+| `targetRef`             | Allowed kinds                                            |
+| ----------------------- | -------------------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`                      |
+| `to[].targetRef.kind`   | `Mesh`, `MeshService`                                    |
+| `from[].targetRef.kind` | `Mesh`                                                   |
+{% endtab %}
+
+{% tab targetRef Builtin Gateway %}
+| `targetRef`           | Allowed kinds                                    |
+| --------------------- | ------------------------------------------------ |
+| `targetRef.kind`      | `Mesh`, `MeshGateway`, `MeshGateway` with `tags` |
+| `to[].targetRef.kind` | `Mesh`                                           |
+{% endtab %}
+{% endtabs %}
+
+#### Sidecar
+
+We see that we can select sidecar proxies via any of the kinds that select
+sidecars and we can set both `to` and `from`.
+
+We can apply policy to:
+* all traffic originating at the sidecar _to_ anywhere (`to[].targetRef.kind: Mesh`)
+* traffic _to_ a specific `kuma.io/service` (`to[].targetRef.kind: MeshService`)
+
+We can also apply policy to:
+* traffic terminating at the sidecar _from_ anywhere in the mesh (`from[].targetRef.kind: Mesh`)
+
+#### Builtin gateways
+
+We see that we can select gateway proxies via any of the kinds that select
+gateways as well as specific gateway listeners and we can set only `to`.
+
+We can only apply policy to:
+* all traffic originating at the gateway _to_ anywhere (`to[].targetRef.kind: Mesh`)
+
+## Merging configuration
+
+It is necessary to define a policy for merging configuration,
+because a proxy can be targeted by multiple `targetRef`'s.
+
+We define a total order of policy priority:
+
+- MeshServiceSubset > MeshService > MeshSubset > Mesh (the more a `targetRef` is focused the higher priority it has)
+- If levels are equal the lexicographic order of policy names is used
+
+For `to` and `from` policies we concatenate the array for each matching policies.
+We then build configuration by merging each level using [JSON patch merge](https://www.rfc-editor.org/rfc/rfc7386).
+
+For example if I have 2 `default` ordered this way:
+
+```yaml
+default:
+  conf: 1
+  sub:
+    array: [1, 2, 3]
+    other: 50
+    other-array: [3, 4, 5]
+---
+default:
+  sub:
+    array: []
+    other: null
+    other-array: [5, 6]
+    extra: 2
+```
+
+The merge result is:
+
+```yaml
+default:
+  conf: 1
+  sub:
+    array: []
+    other-array: [5, 6]
+    extra: 2
+```
+
+## Using policies with `MeshService`, `MeshMultizoneService` and `MeshExternalService`.
+
+[`MeshService`](/docs/{{ page.version }}/networking/meshservice) is a feature to define services explicitly in {{ site.product_name }}.
+It can be selectively enabled and disable depending on the value of [meshServices.mode](/docs/{{ page.version }}/networking/meshservice/#migration) on your Mesh object.
+
+When using explicit services, `MeshServiceSubset` is no longer a valid kind and `MeshService` can only be used to select an actual `MeshService` resource (it can no longer select a `kuma.io/service`).
+
+In the following example we'll assume we have a `MeshService`:
+
+{% policy_yaml ms-1 namespace=kuma-demo %}
+```yaml
+type: MeshService
+name: my-service
+labels:
+  k8s.kuma.io/namespace: kuma-demo 
+  kuma.io/zone: my-zone
+  app: redis 
+spec:
+  selector:
+    dataplaneTags:
+      app: redis
+      k8s.kuma.io/namespace: kuma-demo 
+  ports:
+  - port: 6739
+    targetPort: 6739
+    appProtocol: tcp
+```
+{% endpolicy_yaml %}
+
+There are 2 ways to select a `MeshService`:
+
+If you are in the same namespace (or same zone in Universal) you can select one specific service by using its explicit name:
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: timeout-to-redis
+  namespace: kuma-demo
+spec:
+  to:
+  - targetRef:
+      kind: MeshService
+      name: redis
+    default:
+      connectionTimeout: 10s
+```
+
+Selecting all matching resources by labels:
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: all-in-my-namespace 
+  namespace: kuma-demo
+spec:
+  to:
+  - targetRef:
+      kind: MeshService
+      labels:
+        k8s.kuma.io/namespace: kuma-demo
+    default:
+      connectionTimeout: 10s
+```
+
+In this case this is equivalent to writing a specific policy for each service that matches this label (in our example for each service in this namespace in each zones).
+
+### Global, Zonal, Producer and Consumer policies
+
+Policies can be applied to a zone or to a namespace when using Kubernetes.
+Policies will always impact at most the scope at which they are defined.
+In other words:
+
+1. a policy applied to the global control plane will apply to all proxies in all zones.
+2. a policy applied to a zone will only apply to proxies inside this zone. It is equivalent to having:
+   ```yaml
+   spec:
+     targetRef: 
+       kind: MeshSubset
+       tags:
+         kuma.io/zone: "my-zone"
+   ```
+3. a policy applied to a namespace will only apply to proxies inside this namespace. It is equivalent to having:
+   ```yaml
+   spec:
+     targetRef: 
+       kind: MeshSubset
+       tags:
+         kuma.io/zone: "my-zone"
+         kuma.io/namespace: "my-ns"
+   ```
+
+There is however, one exception to this when using `MeshService` with **outbound** policies (policies with `spec.to[].targetRef`).
+In this case, if you define a policy in the same namespace as the `MeshService` it is defined in a policy will be considered to be a **producer** policy.
+This means that all clients of this service (even in different zones) will be impacted by this policy.
+
+An example of a producer policy is:
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: timeout-to-redis
+  namespace: kuma-demo
+spec:
+  to:
+  - targetRef:
+      kind: MeshService
+      name: redis
+    default:
+      connectionTimeout: 10s
+```
+
+The other type of policy is a consumer policy which most commonly use labels to match a service.
+
+An example of a consumer policy which would override the previous producer policy:
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: timeout-to-redis-consumer
+  namespace: kuma-demo
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        labels:
+          k8s.kuma.io/service-name: redis
+      default:
+        connectionTimeout: 10s
+```
+
+{% tip %}
+Remember that `labels` on a `MeshService` applies to _each_ matching `MeshService`. To communicate to services
+named the same way in different namespaces or zones with different configuration use a more specific set of labels.
+{% endtip %}
+
+{{ site.mesh_product_name }} adds a label `kuma.io/policy-role` to identify the type of the policy. The values of the label are:
+
+- **system**: Policies defined on global or in the zone's system namespace
+- **workload-owner**: Policies defined in a non system namespaces that do not have `spec.to` entries
+- **consumer**: Policies defined in a non system namespace that have `spec.to` which either do not use `name` or have a different `namespace`.
+- **producer**: Policies defined in the same namespace as the services identified in the `spec.to[].targetRef`.
+
+The merging order of the different policy scopes is: **global < zonal < producer < consumer**.
+
+### Example
+
+We have 2 clients client1 and client2 they run in different namespaces respectively ns1 and ns2.
+
+```mermaid
+flowchart LR
+subgraph ns1
+    client1(client)
+end
+subgraph ns2
+  client2(client)
+  server(MeshService: server)
+end
+client1 --> server
+client2 --> server
+```
+
+We're going to define a producer policy first:
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+    name: producer-policy
+    namespace: ns2
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        name: server
+      default:
+        idleTimeout: 20s
+```
+
+We know it's a producer policy because it is defined in the same namespace as the `MeshService: server` and names this server in its `spec.to[].targetRef`.
+So both client1 and client2 will receive the timeout of 20s.
+
+We now create a consumer policy:
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: consumer-policy
+  namespace: ns1
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        labels:
+          k8s.kuma.io/service-name: server
+      default:
+        idleTimeout: 30s
+```
+
+Here the policy only impacts client1 as client2 doesn't run in ns1. As consumer policies have a higher priority over producer policies, client1 will have a `idleTimeout: 30s`.
+
+We can define another policy to impact client2:
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: consumer-policy
+  namespace: ns2
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        labels:
+          k8s.kuma.io/service-name: server
+      default:
+        idleTimeout: 40s
+```
+
+Note that the only different here is the namespace, we now define a consumer policy inside `ns2`.
+
+{% tip %}
+Use labels for consumer policies and name for producer policies.
+It will be easier to differentiate between producer and consumer policies.
+{% endtip %}
+
+## Examples
+
+#### Applying a global default
+
+```yaml
+type: ExamplePolicy
+name: example
+mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        key: value
+```
+
+All traffic from any proxy (top level `targetRef`) going to any proxy (to `targetRef`) will have this policy applied with value `key=value`.
+
+#### Recommending to users
+
+```yaml
+type: ExamplePolicy
+name: example
+mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: MeshService
+        name: my-service
+      default:
+        key: value
+```
+
+All traffic from any proxy (top level `targetRef`) going to the service "my-service" (to `targetRef`) will have this policy applied with value `key=value`.
+
+This is useful when a service owner wants to suggest a set of configurations to its clients.
+
+#### Configuring all proxies of a team
+
+```yaml
+type: ExamplePolicy
+name: example
+mesh: default
+spec:
+  targetRef:
+    kind: MeshSubset
+    tags:
+      team: "my-team"
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        key: value
+```
+
+All traffic from any proxies (from `targetRef`) going to any proxy that has the tag `team=my-team` (top level `targetRef`) will have this policy applied with value `key=value`.
+
+This is a useful way to define coarse grain rules for example.
+
+#### Configuring all proxies in a zone
+
+```yaml
+type: ExamplePolicy
+name: example
+mesh: default
+spec:
+  targetRef:
+    kind: MeshSubset
+    tags:
+      kuma.io/zone: "east"
+  default:
+    key: value
+```
+
+All proxies in zone `east` (top level `targetRef`) will have this policy configured with `key=value`.
+
+This can be very useful when observability stores are different for each zone for example.
+
+#### Configuring all gateways in a Mesh
+
+```yaml
+type: ExamplePolicy
+name: example
+mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+    proxyTypes: ["Gateway"]
+  default:
+    key: value
+```
+
+All gateway proxies in mesh `default` will have this policy configured with `key=value`.
+
+This can be very useful when timeout configurations for gateways need to differ from those of other proxies.
+{% endif_version %}
+{% if_version lte:2.8.x %}
 Here you can find the list of Policies that {{site.mesh_product_name}} supports.
 
 Going forward from version 2.0, {{site.mesh_product_name}} is transitioning from [source/destination policies](/docs/{{ page.version }}/policies/general-notes-about-kuma-policies) to [`targetRef` policies](/docs/{{ page.version }}/policies/targetref).
@@ -33,3 +678,4 @@ If you already use source/destination policies you can keep using them. Future v
 You can mix targetRef and source/destination policies as long as they are of different types. For example: You can use `MeshTrafficPermission` with `FaultInjection` but you can't use `MeshTrafficPermission` with `TrafficPermission`.
 {% endif_version %}
 {% endwarning %}
+{% endif_version %}

--- a/app/_src/policies/introduction.md
+++ b/app/_src/policies/introduction.md
@@ -174,7 +174,8 @@ spec:
                 plain: '{"start_time": "%START_TIME%"}'
               path: "/tmp/logs.txt"
 ```
-{% endpolicy_yaml accesslog_inbound_example %}
+{% endpolicy_yaml %}
+{% policy_yaml accesslog_inbound_example %}
 ```yaml
 type: MeshAccessLog
 name: example-inbound

--- a/app/_src/policies/introduction.md
+++ b/app/_src/policies/introduction.md
@@ -232,7 +232,7 @@ spec:
 ```
 {% endpolicy_yaml %}
 
-### Target resources
+### `TargetRef` support for different policy types
 
 Not every policy supports `to` and `from` levels. Additionally, not every resource can
 appear at every supported level. The specified top level resource can also affect which
@@ -270,7 +270,7 @@ We can also apply policy as an _inbound_ policy with:
 | `targetRef.kind`      | `Mesh`, `MeshGateway`, `MeshGateway` with `tags` |
 | `to[].targetRef.kind` | `Mesh`                                           |
 
-The table above indicates that we can select builtin gateway vua `Mesh`, `MeshGateway` or even specific listeners with `MeshGateway` using tags. 
+The table above indicates that we can select builtin gateway via `Mesh`, `MeshGateway` or even specific listeners with `MeshGateway` using tags. 
 
 We can use the policy only as an _outbound_ policy with:
 * `to[].targetRef.kind: Mesh` all traffic from the gateway _to_ anywhere.
@@ -284,7 +284,7 @@ A proxy can be targeted by multiple `targetRef`'s, to define how policies are me
 
 We define a total order of policy priority:
 
-- MeshServiceSubset > MeshService > MeshSubset > Mesh (the more a `targetRef` is focused the higher priority it has)
+- `MeshServiceSubset` > `MeshService` > `MeshSubset` > `Mesh` (the more a `targetRef` is focused the higher priority it has)
 - If levels are equal the lexicographic order of policy names is used
 
 {% tip %}

--- a/app/_src/policies/introduction.md
+++ b/app/_src/policies/introduction.md
@@ -138,7 +138,7 @@ targetRef:
   labels:
     key: value # In the case of policies that apply to labeled resources you can use these to apply the policy to each resource
   sectionName: ASection # This is used when trying to attach to a specific part of a resource (for example a port of a `MeshService`)
-  namespace: ns # when in kubernetes this namespace the resource is inside.
+  namespace: ns # valid when the policy is applied by a Kubernetes control plane 
 ```
 
 Here's an explanation of each kinds and their scope:
@@ -203,7 +203,7 @@ The `spec.to[].targetRef` section enables logging for any traffic going to `web-
 The `spec.from[].targetRef` section enables logging for any traffic coming from _anywhere_ in the `Mesh`.
 
 ### Omitting `targetRef`
-When a `targetRef` is not present. It is semantically equivalent to: `targetRef.kind: Mesh` meaning everything inside the `Mesh`.
+When a `targetRef` is not present, it is semantically equivalent to `targetRef.kind: Mesh` and refers to everything inside the `Mesh`.
 
 ### Applying to specific proxy types
 The top level `targetRef` field can select a specific subset of data plane proxies. The field named `proxyTypes` can restrict policies to specific types of data plane proxies:
@@ -243,7 +243,7 @@ For each type of proxy, sidecar or builtin gateway, the table indicates for each
 
 #### Example tables
 
-These are just examples, remember to check the docs specific to your policy!
+These are just examples, remember to check the docs specific to your policy.
 
 {% tabs targetRef useUrlFragment=false %}
 {% tab targetRef Sidecar %}
@@ -287,7 +287,7 @@ We define a total order of policy priority:
 - If levels are equal the lexicographic order of policy names is used
 
 {% tip %}
-Remember that a broader a targetRef is the lower its priority is.
+Remember: the broader a `targetRef`, the lower its priority.
 {% endtip %}
 
 For `to` and `from` policies we concatenate the array for each matching policies.
@@ -394,7 +394,7 @@ In this case this is equivalent to writing a specific policy for each service th
 When `MeshService` have multiple ports, you can use `sectionName` to restrict policy to a single port.
 {% endtip %}
 
-### Global, Zonal, Producer and Consumer policies
+### Global, zonal, producer and consumer policies
 
 Policies can be applied to a zone or to a namespace when using Kubernetes.
 Policies will always impact at most the scope at which they are defined.
@@ -465,14 +465,14 @@ Remember that `labels` on a `MeshService` applies to _each_ matching `MeshServic
 named the same way in different namespaces or zones with different configuration use a more specific set of labels.
 {% endtip %}
 
-{{ site.mesh_product_name }} adds a label `kuma.io/policy-role` to identify the type of the policy. The values of the label are:
+{{ site.product_name }} adds a label `kuma.io/policy-role` to identify the type of the policy. The values of the label are:
 
 - **system**: Policies defined on global or in the zone's system namespace
 - **workload-owner**: Policies defined in a non system namespaces that do not have `spec.to` entries, or have both `spec.from` and `spec.to` entries
 - **consumer**: Policies defined in a non system namespace that have `spec.to` which either do not use `name` or have a different `namespace`
 - **producer**: Policies defined in the same namespace as the services identified in the `spec.to[].targetRef`
 
-The merging order of the different policy scopes is: **global < zonal < producer < consumer < worload-owner**.
+The merging order of the different policy scopes is: **workload-owner > consumer > producer > zonal > global**.
 
 ### Example
 
@@ -508,7 +508,7 @@ spec:
 ```
 
 We know it's a producer policy because it is defined in the same namespace as the `MeshService: server` and names this server in its `spec.to[].targetRef`.
-So both client1 and client2 will receive the timeout of 20s.
+So both client1 and client2 will receive the timeout of 20 seconds.
 
 We now create a consumer policy:
 
@@ -616,7 +616,7 @@ spec:
 
 All traffic from any proxies (from `targetRef`) going to any proxy that has the tag `team=my-team` (top level `targetRef`) will have this policy applied with value `key=value`.
 
-This is a useful way to define coarse grain rules for example.
+This is a useful way to define coarse-grained rules for example.
 
 #### Configuring all proxies in a zone
 
@@ -705,7 +705,7 @@ improving the overall system reliability without disrupting ongoing operations.
 
 ### Recommended setup
 
-It's not necessary but CLI tools like [jq](https://jqlang.github.io/jq/) and [jd](https://github.com/josephburnett/jd) can greatly improve the UX.
+It's not necessary but CLI tools like [jq](https://jqlang.github.io/jq/) and [jd](https://github.com/josephburnett/jd) can greatly improve working with {{ site.mesh_product_name }} resources.
 
 ### How to use shadow mode
 

--- a/app/_src/policies/introduction.md
+++ b/app/_src/policies/introduction.md
@@ -324,7 +324,7 @@ default:
 
 ## Using policies with `MeshService`, `MeshMultizoneService` and `MeshExternalService`.
 
-[`MeshService`](/docs/{{ page.version }}/networking/meshservice) is a feature to define services explicitly in {{ site.product_name }}.
+[`MeshService`](/docs/{{ page.version }}/networking/meshservice) is a feature to define services explicitly in {{ site.mesh_product_name }}.
 It can be selectively enabled and disable depending on the value of [meshServices.mode](/docs/{{ page.version }}/networking/meshservice/#migration) on your Mesh object.
 
 When using explicit services, `MeshServiceSubset` is no longer a valid kind and `MeshService` can only be used to select an actual `MeshService` resource (it can no longer select a `kuma.io/service`).
@@ -465,7 +465,7 @@ Remember that `labels` on a `MeshService` applies to _each_ matching `MeshServic
 named the same way in different namespaces or zones with different configuration use a more specific set of labels.
 {% endtip %}
 
-{{ site.product_name }} adds a label `kuma.io/policy-role` to identify the type of the policy. The values of the label are:
+{{ site.mesh_product_name }} adds a label `kuma.io/policy-role` to identify the type of the policy. The values of the label are:
 
 - **system**: Policies defined on global or in the zone's system namespace
 - **workload-owner**: Policies defined in a non system namespaces that do not have `spec.to` entries, or have both `spec.from` and `spec.to` entries

--- a/app/_src/policies/meshaccesslog.md
+++ b/app/_src/policies/meshaccesslog.md
@@ -82,7 +82,7 @@ If you haven't, see the [observability docs](/docs/{{ page.version }}/explore/ob
 
 {% endif_version %}
 
-To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
+To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 

--- a/app/_src/policies/meshaccesslog.md
+++ b/app/_src/policies/meshaccesslog.md
@@ -201,7 +201,7 @@ Example output:
 <details>
   <summary>TCP configuration with default fields:</summary>
 
-  <div markdown="1">
+  <div markdown="1" class="code">
 {% if_version lte:2.2.x %}
 ```yaml
 format:
@@ -262,7 +262,7 @@ format:
 <details>
   <summary>HTTP configuration with default fields:</summary>
 
-<div markdown="1">
+<div markdown="1" class="code">
 {% if_version lte:2.2.x %}
 ```yaml
 format:
@@ -976,7 +976,7 @@ Apply the configuration with `kumactl apply -f [..]` or with the [HTTP API](/doc
 To target [`ExternalServices`](/docs/{{ page.version }}/policies/external-services#usage), use `MeshService` as the `targetRef` kind with `name` set to  
 the `kuma.io/service` value.
 
-To target other non-mesh traffic, i.e. [passthrough traffic](/docs/{{ page.version }}/networking/non-mesh-traffic#outgoing), use `Mesh` as the `targetRef` kind. In this case, `%KUMA_DESTINATION_SERVICE%` is set to `external`.
+To target other non-mesh traffic, for example [passthrough traffic](/docs/{{ page.version }}/networking/non-mesh-traffic#outgoing), use `Mesh` as the `targetRef` kind. In this case, `%KUMA_DESTINATION_SERVICE%` is set to `external`.
 
 ## Select a built-in gateway
 

--- a/app/_src/policies/meshcircuitbreaker.md
+++ b/app/_src/policies/meshcircuitbreaker.md
@@ -21,14 +21,14 @@ plane proxy is allowed to freely flow through it. When it is **open** then the t
 {% endtip %}
 
 The conditions that determine when a circuit breaker is closed or open are being configured on connection limits or
-outlier detection basis. For outlier detection to open circuit breaker you can configure what we call "detectors".
+outlier detection basis. For outlier detection to open circuit breaker you can configure what we call _detectors_.
 This policy provides 5 different types of detectors, and they are triggered on some deviations in the upstream service
 behavior. All detectors could coexist on the same outbound interface.
 
 Once one of the detectors has been triggered the corresponding data plane proxy is ejected from the set of the load
 balancer for a period equal to [baseEjectionTime](#outlier-detection). Every further ejection of the same data plane
 proxy will further extend the [baseEjectionTime](#outlier-detection) multiplied by the number of ejections: for example
-the 4th ejection will be lasting for a period of time of `4 * baseEjectionTime`.
+the fourth ejection will be lasting for a period of time of `4 * baseEjectionTime`.
 
 This policy provides **passive** checks.
 If you want to configure **active** checks, please utilize the [MeshHealthCheck](/docs/{{ page.version }}/policies/meshhealthcheck)
@@ -82,16 +82,16 @@ To learn more about the information in this table, see the [matching docs](/docs
 ### Connection limits
 
 - **`maxConnections`** - (optional) The maximum number of connections allowed to be made to the upstream Envoy Cluster.
-  If not specified then equal to "1024".
+  If not specified then equal to _1024_.
 - **`maxConnectionPools`** - (optional) The maximum number of connection pools per Envoy Cluster that are concurrently
   supported at once. Set this for Envoy Clusters which create a large number of connection pools. If not specified, the
   default is unlimited.
 - **`maxPendingRequests`** - (optional) The maximum number of pending requests that are allowed to the upstream Envoy
-  Cluster. This limit is applied as a connection limit for non-HTTP traffic. If not specified then equal to "1024".
+  Cluster. This limit is applied as a connection limit for non-HTTP traffic. If not specified then equal to _1024_.
 - **`maxRetries`** - (optional) The maximum number of parallel retries that will be allowed to the upstream Envoy
-  Cluster. If not specified then equal to "3".
+  Cluster. If not specified then equal to _3_.
 - **`maxRequests`** - (optional) The maximum number of parallel requests that are allowed to be made to the upstream
-  Envoy Cluster. This limit does not apply to non-HTTP traffic. If not specified then equal to "1024".
+  Envoy Cluster. This limit does not apply to non-HTTP traffic. If not specified then equal to _1024_.
 
 ### Outlier detection
 

--- a/app/_src/policies/meshcircuitbreaker.md
+++ b/app/_src/policies/meshcircuitbreaker.md
@@ -75,7 +75,7 @@ target proxies are healthy or not.
 
 {% endif_version %}
 
-To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
+To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 

--- a/app/_src/policies/meshfaultinjection.md
+++ b/app/_src/policies/meshfaultinjection.md
@@ -112,7 +112,7 @@ That means that for 70% of requests, it returns 500 and for 50% of the 30% that 
 
 ### Abort
 
-Abort defines a configuration of not delivering requests to destination service and replacing the responses from destination dataplane by
+Abort defines a configuration of not delivering requests to destination service and replacing the responses from destination data plane by
 predefined status code.
 
 - `httpStatus` - HTTP status code which will be returned to source side, has to be in [100 - 599] range
@@ -129,7 +129,7 @@ Delay defines a configuration of delaying a response from a destination.
 
 ResponseBandwidth defines a configuration to limit the speed of responding to requests.
 
-- `limit` - represented by value measure in Gbps, Mbps, kbps, or bps, e.g. 10kbps
+- `limit` - represented by value measure in Gbps, Mbps, kbps, or bps, for example `10kbps`
 - `percentage` - a percentage of requests on which abort will be injected, has to be in [0.0 - 100.0] range. If the value is a double number, put it in quotes.
 
 ## Examples
@@ -192,7 +192,7 @@ Apply the configuration with `kumactl apply -f [..]` or with the [HTTP API](/doc
 {% endtab %}
 {% endtabs %}
 
-### 50.5% of requests to service backend from any service is going to be delayed by 5s
+### 50.5% of requests to service backend from any service is going to be delayed by 5 seconds
 
 {% tabs meshfaultinjection-from-all useUrlFragment=false %}
 {% tab meshfaultinjection-from-all Kubernetes %}

--- a/app/_src/policies/meshfaultinjection.md
+++ b/app/_src/policies/meshfaultinjection.md
@@ -71,7 +71,7 @@ Do **not** combine with [FaultInjection](/docs/{{ page.version }}/policies/fault
 
 {% endif_version %}
 
-To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
+To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 

--- a/app/_src/policies/meshgatewayroute.md
+++ b/app/_src/policies/meshgatewayroute.md
@@ -75,12 +75,12 @@ One application of this mechanism is to inject standard routes into all virtual 
 
 ## Matching
 
-`MeshGatewayRoute` allows HTTP requests to be matched by various criteria (e.g. URI path, HTTP headers).
+`MeshGatewayRoute` allows HTTP requests to be matched by various criteria (for example uri path, HTTP headers).
 When {{site.mesh_product_name}} generates the final Envoy configuration for a builtin gateway `Dataplane`, it combines all the matching `MeshGatewayRoutes` into a single set of routing tables, partitioned by the virtual hostname, which is specified either in the `MeshGateway` listener or in the `MeshGatewayRoute`.
 
 {{site.mesh_product_name}} sorts the rules in each table by specificity, so that routes with more specific match criteria are always ordered first.
 For example, a rule that matches on a HTTP header and a path is more specific than one that matches only on path, and the longest match path will be considered more specific.
-This ordering allows Kume to combine routing rules from multiple `MeshGatewayRoute` resources and still produce predictable results.
+This ordering allows {{site.mesh_product_name}} to combine routing rules from multiple `MeshGatewayRoute` resources and still produce predictable results.
 
 ## Filters
 

--- a/app/_src/policies/meshhealthcheck.md
+++ b/app/_src/policies/meshhealthcheck.md
@@ -61,7 +61,7 @@ This mode generates extra traffic to other proxies and services as described in 
 
 {% endif_version %}
 
-To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
+To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 

--- a/app/_src/policies/meshhealthcheck.md
+++ b/app/_src/policies/meshhealthcheck.md
@@ -249,8 +249,8 @@ We will apply the configuration with `kumactl apply -f [..]` or via the [HTTP AP
 
 ## Common configuration
 
-- **`interval`** - (optional) interval between consecutive health checks, if not specified then equal to "1m"
-- **`timeout`** - (optional) maximum time to wait for a health check response, if not specified then equal to "15s"
+- **`interval`** - (optional) interval between consecutive health checks, if not specified then equal to `1m`
+- **`timeout`** - (optional) maximum time to wait for a health check response, if not specified then equal to `15s`
 - **`unhealthyThreshold`** - (optional) number of consecutive unhealthy checks before considering a host unhealthy, if not specified then equal to 5
 - **`healthyThreshold`** - (optional) number of consecutive healthy checks before considering a host healthy, if not specified then equal to 1
 - **`initialJitter`** - (optional) if specified, Envoy will start health checking after a random time in

--- a/app/_src/policies/meshhttproute.md
+++ b/app/_src/policies/meshhttproute.md
@@ -55,7 +55,7 @@ depending on where the request coming from and where it's going to.
 
 {% endif_version %}
 
-If you don't understand this table you should read [matching docs](/docs/{{ page.version }}/policies/targetref).
+If you don't understand this table you should read [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 
@@ -463,7 +463,7 @@ spec:
 
 When several `MeshHTTPRoute` policies target the same data plane proxy they're merged.
 Similar to the new policies the merging order is determined by
-[the top level targetRef](/docs/{{ page.version }}/policies/targetref#merging-configuration).
+[the top level targetRef](/docs/{{ page.version }}/policies/introduction#merging-configuration).
 The difference is in `spec.to[].rules`.
 {{site.mesh_product_name}} treats `rules` as a key-value map
 where `matches` is a key and `default` is a value. For example MeshHTTPRoute policies:

--- a/app/_src/policies/meshhttproute.md
+++ b/app/_src/policies/meshhttproute.md
@@ -12,7 +12,7 @@ depending on where the request coming from and where it's going to.
 
 {% if_version lte:2.1.x %}
 {% warning %}
-`MeshHTTPRoute` does not route cross-zone traffic yet!
+`MeshHTTPRoute` does not route cross-zone traffic yet.
 {% endwarning %}
 {% endif_version %}
 

--- a/app/_src/policies/meshhttproute.md
+++ b/app/_src/policies/meshhttproute.md
@@ -463,7 +463,7 @@ spec:
 
 When several `MeshHTTPRoute` policies target the same data plane proxy they're merged.
 Similar to the new policies the merging order is determined by
-[the top level targetRef](/docs/{{ page.version }}/policies/introduction#merging-configuration).
+[the top level targetRef](/docs/{{ page.version }}/policies/introduction).
 The difference is in `spec.to[].rules`.
 {{site.mesh_product_name}} treats `rules` as a key-value map
 where `matches` is a key and `default` is a value. For example MeshHTTPRoute policies:

--- a/app/_src/policies/meshhttproute.md
+++ b/app/_src/policies/meshhttproute.md
@@ -89,7 +89,7 @@ them in a `MeshHTTPRoute`!
   - **`value`** - actual value that's going to be matched depending on the `type`
 - **`method`** - (optional) - HTTP2 method, available values are
   `CONNECT`, `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PATCH`, `POST`, `PUT`, `TRACE`
-- **`queryParams`** - (optional) - list of HTTP URL query parameters. Multiple matches are ANDed together
+- **`queryParams`** - (optional) - list of HTTP URL query parameters. Multiple matches are combined together
   such that all listed matches must succeed
   - **`type`** - one of `Exact` or `RegularExpression`
   - **`name`** - name of the query parameter

--- a/app/_src/policies/meshloadbalancingstrategy.md
+++ b/app/_src/policies/meshloadbalancingstrategy.md
@@ -48,7 +48,7 @@ When using this policy, the [localityAwareLoadBalancing](/docs/{{ page.version }
 
 {% endif_version %}
 
-To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
+To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 

--- a/app/_src/policies/meshloadbalancingstrategy.md
+++ b/app/_src/policies/meshloadbalancingstrategy.md
@@ -157,7 +157,7 @@ there is already a hash generated, the hash is returned immediately, ignoring th
     - **`name`** - the name of the request header that will be used to obtain the hash key.
   - **`cookie`**:
     - **`name`** - the name of the cookie that will be used to obtain the hash key.
-    - **`ttl`** - (optional) if specified, a cookie with the TTL will be generated if the cookie is not present.
+    - **`ttl`** - (optional) if specified, a cookie with the time to live will be generated if the cookie is not present.
     - **`path`** - (optional) the name of the path for the cookie.
   - **`connection`**:
     - **`sourceIP`** - if true, then hashing is based on a source IP address.
@@ -165,7 +165,7 @@ there is already a hash generated, the hash is returned immediately, ignoring th
     - **`name`** - the name of the URL query parameter that will be used to obtain the hash key. If the parameter is not 
     present, no hash will be produced. Query parameter names are case-sensitive.
   - **`filterState`**:
-    - **`key`** – the name of the Object in the per-request filterState, which is an `Envoy::Hashable` object. If there is 
+    - **`key`** – the name of the Object in the per-request `filterState`, which is an `Envoy::Hashable` object. If there is 
     no data associated with the key, or the stored object is not `Envoy::Hashable`, no hash will be produced.
 
 #### Random
@@ -201,8 +201,8 @@ must be prime number limited to 5000011. If it is not specified, the default is 
     - **`name`** - the name of the URL query parameter that will be used to obtain the hash key. If the parameter is not
       present, no hash will be produced. Query parameter names are case-sensitive.
   - **`filterState`**:
-    - **`key`** – the name of the Object in the per-request filterState, which is an Envoy::Hashable object. If there is
-      no data associated with the key, or the stored object is not Envoy::Hashable, no hash will be produced.
+    - **`key`** – the name of the Object in the per-request `filterState`, which is an `Envoy::Hashable` object. If there is
+      no data associated with the key, or the stored object is not `Envoy::Hashable`, no hash will be produced.
 
 ## Examples
 
@@ -426,9 +426,9 @@ spec:
 ```
 {% endpolicy_yaml %}
 
-### Prioritize traffic to dataplanes within the same datacenter and fallback cross zone in specific order
+### Prioritize traffic to data planes within the same data center and fallback cross zone in specific order
 
-Requests to backend will be distributed based on weights, with 99.9% of requests routed to data planes in the same datacenter, 0.099% to data planes in the same region, and the remainder to other local instances.
+Requests to backend will be distributed based on weights, with 99.9% of requests routed to data planes in the same data center, 0.099% to data planes in the same region, and the remainder to other local instances.
 
 When no healthy backends are available within the local zone, traffic from data planes in zones `us-1`, `us-2`, and `us-3` will only fall back to zones `us-1`, `us-2`, and `us-3`, while in zones `eu-1`, `eu-2`, and `eu-3` will only fall back to zones `eu-1`, `eu-2`, and `eu-3`. If there are no healthy instances in all zones `eu-[1-3]` or `us-[1-3]`, requests from any instance will then fall back to `us-4`. If there are no healthy instances in `us-4`, the request will fail, as the last rule, by default, has a type of `None`, meaning no fallback is allowed.
 

--- a/app/_src/policies/meshloadbalancingstrategy.md
+++ b/app/_src/policies/meshloadbalancingstrategy.md
@@ -193,7 +193,7 @@ must be prime number limited to 5000011. If it is not specified, the default is 
     - **`name`** - the name of the request header that will be used to obtain the hash key.
   - **`cookie`**:
     - **`name`** - the name of the cookie that will be used to obtain the hash key.
-    - **`ttl`** - (optional) if specified, a cookie with the _time to live_ will be generated if the cookie is not present.
+    - **`ttl`** - (optional) if specified, a cookie with this _time to live_ will be generated if the cookie is not present.
     - **`path`** - (optional) the name of the path for the cookie.
   - **`connection`**:
     - **`sourceIP`** - if true, then hashing is based on a source IP address.

--- a/app/_src/policies/meshloadbalancingstrategy.md
+++ b/app/_src/policies/meshloadbalancingstrategy.md
@@ -157,7 +157,7 @@ there is already a hash generated, the hash is returned immediately, ignoring th
     - **`name`** - the name of the request header that will be used to obtain the hash key.
   - **`cookie`**:
     - **`name`** - the name of the cookie that will be used to obtain the hash key.
-    - **`ttl`** - (optional) if specified, a cookie with the time to live will be generated if the cookie is not present.
+    - **`ttl`** - (optional) if specified, a cookie with this _time to live_ will be generated if the cookie is not present.
     - **`path`** - (optional) the name of the path for the cookie.
   - **`connection`**:
     - **`sourceIP`** - if true, then hashing is based on a source IP address.

--- a/app/_src/policies/meshloadbalancingstrategy.md
+++ b/app/_src/policies/meshloadbalancingstrategy.md
@@ -165,7 +165,7 @@ there is already a hash generated, the hash is returned immediately, ignoring th
     - **`name`** - the name of the URL query parameter that will be used to obtain the hash key. If the parameter is not 
     present, no hash will be produced. Query parameter names are case-sensitive.
   - **`filterState`**:
-    - **`key`** – the name of the Object in the per-request `filterState`, which is an `Envoy::Hashable` object. If there is 
+    - **`key`** the name of the Object in the per-request `filterState`, which is an `Envoy::Hashable` object. If there is 
     no data associated with the key, or the stored object is not `Envoy::Hashable`, no hash will be produced.
 
 #### Random
@@ -201,7 +201,7 @@ must be prime number limited to 5000011. If it is not specified, the default is 
     - **`name`** - the name of the URL query parameter that will be used to obtain the hash key. If the parameter is not
       present, no hash will be produced. Query parameter names are case-sensitive.
   - **`filterState`**:
-    - **`key`** – the name of the Object in the per-request `filterState`, which is an `Envoy::Hashable` object. If there is
+    - **`key`** the name of the Object in the per-request `filterState`, which is an `Envoy::Hashable` object. If there is
       no data associated with the key, or the stored object is not `Envoy::Hashable`, no hash will be produced.
 
 ## Examples

--- a/app/_src/policies/meshloadbalancingstrategy.md
+++ b/app/_src/policies/meshloadbalancingstrategy.md
@@ -105,7 +105,7 @@ Advanced locality-aware load balancing provides a powerful means of defining how
         - **`AnyExcept`** - traffic will be load balanced to every available zone except those specified in zones list.
         - **`None`** - traffic will not be load balanced to any zone.
       - **`zones`** - list of zone names
-  - **`failoverThreshold.percentage`** - (optional) defines the percentage of live destination dataplane proxies below which load balancing to the next priority starts. .e.g: If you have this set to 70 and you have 10 dataplane proxies it will start load balancing to the next priority when the number of healthy destinations falls under 7. The value to be in (0.0 - 100.0] range (Default 50). If the value is a double number, put it in quotes.
+  - **`failoverThreshold.percentage`** - (optional) defines the percentage of live destination data plane proxies below which load balancing to the next priority starts. .e.g: If you have this set to 70 and you have 10 data plane proxies it will start load balancing to the next priority when the number of healthy destinations falls under 7. The value to be in (0.0 - 100.0] range (Default 50). If the value is a double number, put it in quotes.
 
 #### Zone Egress support
 
@@ -128,7 +128,7 @@ RoundRobin is a load balancing algorithm that distributes requests across availa
 
 #### LeastRequest
 
-LeastRequest selects N random available hosts as specified in 'choiceCount' (2 by default) and picks the host which has 
+`LeastRequest` selects N random available hosts as specified in `choiceCount` (2 by default) and picks the host which has 
 the fewest active requests.
 
 - **`choiceCount`** - (optional) is the number of random healthy hosts from which the host with the fewest active requests will 
@@ -165,8 +165,8 @@ there is already a hash generated, the hash is returned immediately, ignoring th
     - **`name`** - the name of the URL query parameter that will be used to obtain the hash key. If the parameter is not 
     present, no hash will be produced. Query parameter names are case-sensitive.
   - **`filterState`**:
-    - **`key`** – the name of the Object in the per-request filterState, which is an Envoy::Hashable object. If there is 
-    no data associated with the key, or the stored object is not Envoy::Hashable, no hash will be produced.
+    - **`key`** – the name of the Object in the per-request filterState, which is an `Envoy::Hashable` object. If there is 
+    no data associated with the key, or the stored object is not `Envoy::Hashable`, no hash will be produced.
 
 #### Random
 
@@ -193,7 +193,7 @@ must be prime number limited to 5000011. If it is not specified, the default is 
     - **`name`** - the name of the request header that will be used to obtain the hash key.
   - **`cookie`**:
     - **`name`** - the name of the cookie that will be used to obtain the hash key.
-    - **`ttl`** - (optional) if specified, a cookie with the TTL will be generated if the cookie is not present.
+    - **`ttl`** - (optional) if specified, a cookie with the _time to live_ will be generated if the cookie is not present.
     - **`path`** - (optional) the name of the path for the cookie.
   - **`connection`**:
     - **`sourceIP`** - if true, then hashing is based on a source IP address.

--- a/app/_src/policies/meshmetric.md
+++ b/app/_src/policies/meshmetric.md
@@ -264,7 +264,7 @@ backends:
       path: /metrics
 ```
 
-This tells {{site.mesh_product_name}} to expose an HTTP endpoint with Prometheus metrics on port `5670` and URI path `/metrics`.
+This tells {{site.mesh_product_name}} to expose an HTTP endpoint with Prometheus metrics on port `5670` and uri path `/metrics`.
 
 The metrics endpoint is forwarded to the standard Envoy [Prometheus metrics endpoint](https://www.envoyproxy.io/docs/envoy/latest/operations/admin#get--stats?format=prometheus) and supports the same query parameters.
 You can pass the `filter` query parameter to limit the results to metrics whose names match a given regular expression.
@@ -333,7 +333,7 @@ Please upload the certificate and the key to the machine, and then define the fo
 
 We no longer support activeMTLSBackend, if you need to encrypt and authorize the metrics use [Secure metrics with TLS](#secure-metrics-with-tls) with a combination of [one of the authorization methods](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
 
-##### Running multiple prometheus deployments
+##### Running multiple Prometheus deployments
 
 If you need to run multiple instances of Prometheus and want to target different set of Data Plane Proxies you can do this by using Client ID setting on both `MeshMetric` (`clientId`) and [Prometheus configuration](https://github.com/prometheus/prometheus/pull/13278/files#diff-17f1012e0c2fbd9bcd8dff3c23b18ff4b6676eef3beca6f8a3e72e6a36633334R2233) (`client_id`).
 
@@ -393,7 +393,7 @@ spec:
 ```
 {% endpolicy_yaml %}
 
-And policy for secondary Prometheus deployment that will pick dataplane proxies with tag `prometheus: secondary`. 
+And policy for secondary Prometheus deployment that will pick data plane proxies with tag `prometheus: secondary`. 
 {% policy_yaml second %}
 ```yaml
 type: MeshMetric

--- a/app/_src/policies/meshmetric.md
+++ b/app/_src/policies/meshmetric.md
@@ -104,7 +104,7 @@ Profiles are predefined sets of metrics with manual `include` and `exclude` func
 There are 3 sections:
 - `appendProfiles` - allows to combine multiple predefined profiles of metrics.
 Right now you can only define one profile but this might change it the future
-(e.g. there might be feature related profiles like "Fault injection profile" and "Circuit Breaker profile" so you can mix and match the ones that you need based on your features usage).
+(for example there might be feature related profiles like "Fault injection profile" and "Circuit Breaker profile" so you can mix and match the ones that you need based on your features usage).
 Today only 3 profiles are available: `All`, `Basic` and `None`.
 `All` profile contains all metrics produced by Envoy.
 `Basic` profile contains all metrics needed by {{site.mesh_product_name}} dashboards and [golden 4 signals](https://sre.google/sre-book/monitoring-distributed-systems/) metrics.

--- a/app/_src/policies/meshmetric.md
+++ b/app/_src/policies/meshmetric.md
@@ -51,7 +51,7 @@ If you haven't already read the [observability docs](/docs/{{ page.version }}/ex
 
 {% endtabs %}
 
-To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
+To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 

--- a/app/_src/policies/meshpassthrough.md
+++ b/app/_src/policies/meshpassthrough.md
@@ -19,7 +19,7 @@ When using this policy, the [passthrough mode](/docs/{{ page.version }}/networki
 {% endtab %}
 {% endtabs %}
 
-To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
+To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 

--- a/app/_src/policies/meshpassthrough.md
+++ b/app/_src/policies/meshpassthrough.md
@@ -38,7 +38,7 @@ The following describes the default configuration settings of the `MeshPassthrou
   - **`value`**: Destination address based on the defined `type`.
   - **`port`**: Port at which external destination is available. When not defined it caches all traffic to the address.
   - **`protocol`**: Defines protocol of the external destination.
-    - **`tcp`**: **Can't be used when `type` is `Domain` (at TCP level we are not able to disinguish domain, in this case it is going to hijack whole traffic on this port)**.
+    - **`tcp`**: **Can't be used when `type` is `Domain` (at TCP level we are not able to distinguish domain, in this case it is going to hijack whole traffic on this port)**.
     - **`tls`**: Should be used when TLS traffic is originated by the client application.
     - **`http`**
     - **`http2`**
@@ -123,7 +123,7 @@ spec:
 ```
 {% endpolicy_yaml %}
 
-### Allow a subset of services to communicate with specifc external endpoints
+### Allow a subset of services to communicate with specific external endpoints
 
 {% policy_yaml example3 %}
 ```yaml

--- a/app/_src/policies/meshproxypatch.md
+++ b/app/_src/policies/meshproxypatch.md
@@ -1499,7 +1499,7 @@ all modifications from both policies will be applied.
 
 ## JSONPatch
 
-If you use JSONPatch, remember to always use _camelCase_ instead of _snakeCase_ in `path` parameter even though you see _snakeCase_ in Envoy Config Dump.
+If you use JSONPatch, remember to always use _camelCase_ instead of _snake_case_ in `path` parameter even though you see _snake_case_ in Envoy Config Dump.
 
 ## Examples
 

--- a/app/_src/policies/meshproxypatch.md
+++ b/app/_src/policies/meshproxypatch.md
@@ -78,8 +78,8 @@ To learn more about the information in this table, see the [matching docs](/docs
 `MeshProxyPatch` lets you specify modifications in `appendModification` block that can add a new resource, patch an existing resource or remove an existing resource.
 
 Each xDS resource modification consists of 3 fields:
-* `operation` - operation applied to the generated config (e.g. `Add`, `Remove`, `Patch`).
-* `match` - some operations can be applied on matched resources (e.g. remove only resource of given name, patch all outbound resources).
+* `operation` - operation applied to the generated config (for example: `Add`, `Remove`, `Patch`).
+* `match` - some operations can be applied on matched resources (for example: remove only resource of given name, patch all outbound resources).
 {% if_version gte:2.2.x %}
 
 and one of
@@ -1497,9 +1497,9 @@ All modifications from `appendModification` list are always merged.
 For example, if there is a policy with `targetRef.kind: Mesh` and second policy with `targetRef.kind: MeshService` that matches a data plane proxy,
 all modifications from both policies will be applied.
 
-## Json patch
+## JSONPatch
 
-If you use json patch, remember to always use _snakeCase_ instead of _camel_case_ in `path` parameter even though you see _camel_case_ in Envoy Config Dump.
+If you use JSONPatch, remember to always use _camelCase_ instead of _snakeCase_ in `path` parameter even though you see _snakeCase_ in Envoy Config Dump.
 
 ## Examples
 
@@ -1607,9 +1607,9 @@ spec:
 {% endtab %}
 {% endtabs %}
 
-### Lua filter
+### lua filter
 
-Here is and example of Lua filter that adds the new `x-header: test` header to all outgoing HTTP requests to service `offers`.
+Here is and example of lua filter that adds the new `x-header: test` header to all outgoing HTTP requests to service `offers`.
 
 {% tabs lua-filter useUrlFragment=false %}
 {% tab lua-filter Kubernetes %}

--- a/app/_src/policies/meshproxypatch.md
+++ b/app/_src/policies/meshproxypatch.md
@@ -69,7 +69,7 @@ Do **not** combine with [Proxy Template](/docs/{{ page.version }}/policies/proxy
 {% endif_version %}
 {% endif_version %}
 
-To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
+To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 

--- a/app/_src/policies/meshratelimit.md
+++ b/app/_src/policies/meshratelimit.md
@@ -7,7 +7,7 @@ This policy uses new policy matching algorithm.
 Do **not** combine with [Rate Limit](/docs/{{ page.version }}/policies/rate-limit).
 {% endwarning %}
 
-This policy enables per-instance service request limiting. Policy supports ratelimiting of HTTP/HTTP2 requests and TCP connections.
+This policy enables per-instance service request limiting. Policy supports rate limiting of HTTP/HTTP2 requests and TCP connections.
 
 The `MeshRateLimit` policy leverages Envoy's [local rate limiting](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter) for HTTP/HTTP2 and [local rate limit filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/local_rate_limit_filter) for TCP connections.
 

--- a/app/_src/policies/meshratelimit.md
+++ b/app/_src/policies/meshratelimit.md
@@ -60,7 +60,7 @@ Rate limiting supports an [ExternalService](/docs/{{ page.version }}/policies/ex
 
 {% endif_version %}
 
-To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
+To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 

--- a/app/_src/policies/meshretry.md
+++ b/app/_src/policies/meshretry.md
@@ -84,7 +84,7 @@ This policy enables {{site.mesh_product_name}} to know how to behave if there is
 
 {% endif_version %}
 
-To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
+To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 

--- a/app/_src/policies/meshretry.md
+++ b/app/_src/policies/meshretry.md
@@ -7,7 +7,7 @@ This policy uses new policy matching algorithm.
 Do **not** combine with [Retry](/docs/{{ page.version }}/policies/retry).
 {% endwarning %}
 
-This policy enables {{site.mesh_product_name}} to know how to behave if there is a failed scenario (i.e. HTTP request) which could be retried.
+This policy enables {{site.mesh_product_name}} to know how to behave if there are failed requests which could be retried.
 
 ## TargetRef support matrix
 
@@ -91,15 +91,15 @@ To learn more about the information in this table, see the [matching docs](/docs
 The policy let you configure retry behaviour for `HTTP`, `GRPC` and `TCP` protocols.
 The protocol is selected by picking the most [specific protocol](/docs/{{ page.version }}/policies/protocol-support-in-kuma).
 
-Each protocol has a separate section under `default` in the policy YAML.
+Each protocol has a separate section under `default` in the policy yaml.
 Some sections are common between protocols or have similar meaning.
 
 ### Retry on
 
 The field `retryOn` is a list of conditions which will cause a retry.
 
-For `HTTP` these are related to the response status code or method ("5xx", "429", "HttpMethodGet").
-For `gRPC` these are status codes in response headers ("canceled", "deadline-exceeded", etc.).
+For `HTTP` these are related to the response status code or method (`5xx`, `429`, `HttpMethodGet`).
+For `gRPC` these are status codes in response headers (`canceled`, `deadline-exceeded`, etc.).
 There is no equivalent for `TCP`.
 
 One or more conditions can be specified, for example:
@@ -148,31 +148,31 @@ retryOn:
   - Unavailable
 ```
 
-### Backoff
+### Back off
 
 This parameter is applicable to both `HTTP` and `GRPC`.
 
 It consists of `BaseInterval` (the amount of time between retries) and 
 `MaxInterval` (the maximal amount of time taken between retries).
 
-We use a fully jittered exponential back-off algorithm for retries.
+We use an exponential back-off algorithm with jitter for retries.
 Given a base interval B and retry number N,
 the back-off for the retry is in the range **[0, (2<sup>N</sup> - 1) × B)**.
 
-For example, given a 25ms interval, the first retry will be delayed randomly by 0-24ms,
-the 2nd by 0-74ms,
-the 3rd by 0-174ms, 
+For example, given a 25 ms interval, the first retry will be delayed randomly by 0-24 ms,
+the second by 0-74 ms,
+the third by 0-174 ms, 
 and so on.
 
 The interval is capped at a `MaxInterval`, which defaults to 10 times the `BaseInterval`.
 
-### Rate limited backoff
+### Rate limited back off
 
 This parameter is applicable to both `HTTP` and `GRPC`.
 
-MeshRetry can be configured in such a way that
+`MeshRetry` can be configured in such a way that
 when the upstream server rate limits the request and responds with a header like `retry-after` or `x-ratelimit-reset`
-it uses the value from the header to determine **when** to send the retry request instead of the [backoff](#backoff) algorithm.
+it uses the value from the header to determine **when** to send the retry request instead of the [back off](#back-off) algorithm.
 
 #### Example
 
@@ -208,7 +208,7 @@ x-ratelimit-reset: 1706096119
 The request will be retried at `Wed Jan 24 2024 11:35:19 GMT+0000`.
 
 If the response does not contain `retry-after` or `x-ratelimit-reset` header (with valid integer value)
-then the amount of time to wait before issuing a request is determined by [backoff](#backoff) algorithm.
+then the amount of time to wait before issuing a request is determined by [back off](#back-off) algorithm.
 
 ## Examples
 

--- a/app/_src/policies/meshtcproute.md
+++ b/app/_src/policies/meshtcproute.md
@@ -54,7 +54,7 @@ depending on where the request is coming from and where it's going to.
 
 {% endif_version %}
 
-For more information, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
+For more information, see the [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 

--- a/app/_src/policies/meshtimeout.md
+++ b/app/_src/policies/meshtimeout.md
@@ -351,13 +351,13 @@ spec:
 
 | Property                   | default |
 |----------------------------|---------|
-| idleTimeout                | 1h      |
-| connectionTimeout          | 5s      |
-| http.requestTimeout        | 15s     |
-| http.streamIdleTimeout     | 30m     |
-| http.maxStreamDuration     | 0s      |
-| http.maxConnectionDuration | 0s      |
-{% if_version inline:true gte:2.6.x %}| http.requestHeadersTimeout | 0s      |{% endif_version %}
+| idleTimeout                | `1h`      |
+| connectionTimeout          | `5s`      |
+| http.requestTimeout        | `15s`    |
+| http.streamIdleTimeout     | `30m`    |
+| http.maxStreamDuration     | `0s`     |
+| http.maxConnectionDuration | `0s`     |
+{% if_version inline:true gte:2.6.x %}| http.requestHeadersTimeout | `0s`      |{% endif_version %}
 
 {% if_version eq:2.1.x %}
 If you don't specify a `from` or `to` section , the defaults from [`Timeout`](/docs/{{ page.version }}/policies/timeout) will be used. This

--- a/app/_src/policies/meshtimeout.md
+++ b/app/_src/policies/meshtimeout.md
@@ -91,13 +91,13 @@ service is marked as http. More on this in [protocol support section](/docs/{{ p
 
 MeshTimeout policy lets you configure multiple timeouts:
 
-- connectionTimeout
-- idleTimeout
-- http requestTimeout
-- http streamIdleTimeout
-- http maxStreamDuration
-- http maxConnectionDuration
-{% if_version inline:true gte:2.6.x %}- http requestHeadersTimeout{% endif_version %}
+- `connectionTimeout`
+- `idleTimeout`
+- `http.requestTimeout`
+- `http.streamIdleTimeout`
+- `http.maxStreamDuration`
+- `http.maxConnectionDuration`
+{% if_version inline:true gte:2.6.x %}- `http.requestHeadersTimeout`{% endif_version %}
 
 ### Timeouts explained
 
@@ -351,13 +351,13 @@ spec:
 
 | Property                   | default |
 |----------------------------|---------|
-| idleTimeout                | `1h`      |
-| connectionTimeout          | `5s`      |
-| http.requestTimeout        | `15s`    |
-| http.streamIdleTimeout     | `30m`    |
-| http.maxStreamDuration     | `0s`     |
-| http.maxConnectionDuration | `0s`     |
-{% if_version inline:true gte:2.6.x %}| http.requestHeadersTimeout | `0s`      |{% endif_version %}
+| `idleTimeout`                | `1h`      |
+| `connectionTimeout`          | `5s`      |
+| `http.requestTimeout`        | `15s`    |
+| `http.streamIdleTimeout`     | `30m`    |
+| `http.maxStreamDuration`     | `0s`     |
+| `http.maxConnectionDuration` | `0s`     |
+{% if_version inline:true gte:2.6.x %}| `http.requestHeadersTimeout` | `0s`      |{% endif_version %}
 
 {% if_version eq:2.1.x %}
 If you don't specify a `from` or `to` section , the defaults from [`Timeout`](/docs/{{ page.version }}/policies/timeout) will be used. This

--- a/app/_src/policies/meshtimeout.md
+++ b/app/_src/policies/meshtimeout.md
@@ -79,7 +79,7 @@ Do **not** combine with [Timeout policy](/docs/{{ page.version }}/policies/timeo
 {% endif_version %}
 {% endif_version %}
 
-To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
+To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 

--- a/app/_src/policies/meshtls.md
+++ b/app/_src/policies/meshtls.md
@@ -22,7 +22,7 @@ Backends and default mode values are taken from [the Mesh object](/docs/{{ page.
 {% endtab %}
 {% endtabs %}
 
-To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
+To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 

--- a/app/_src/policies/meshtrace.md
+++ b/app/_src/policies/meshtrace.md
@@ -14,13 +14,13 @@ You must [explicitly specify the protocol](/docs/{{ page.version }}/policies/pro
 
 {{site.mesh_product_name}} currently supports the following trace exposition formats:
 
-- `zipkin` traces in this format can be sent to [many different tracing backends](https://github.com/openzipkin/openzipkin.github.io/issues/65)
-- `datadog`
+- `Zipkin` traces in this format can be sent to [many different tracing backends](https://github.com/openzipkin/openzipkin.github.io/issues/65)
+- `Datadog`
 
 {% warning %}
 Services still need to be instrumented to preserve the trace chain across requests made across different services.
 
-You can instrument with a language library of your choice ([for zipkin](https://zipkin.io/pages/tracers_instrumentation) and [for datadog](https://docs.datadoghq.com/tracing/setup_overview/setup/java/?tab=containers)).
+You can instrument with a language library of your choice ([for Zipkin](https://zipkin.io/pages/tracers_instrumentation) and [for Datadog](https://docs.datadoghq.com/tracing/setup_overview/setup/java/?tab=containers)).
 For HTTP you can also manually forward the following headers:
 
 - `x-request-id`
@@ -821,9 +821,9 @@ you can target parts of a `Mesh` by using a finer-grained `targetRef` and a desi
 This is especially useful when you want traces to never leave a world region, or a cloud, for example.
 
 In this example, we have two zones `east` and `west`, each of these with their own Zipkin collector: `east.zipkincollector:9411/api/v2/spans` and `west.zipkincollector:9411/api/v2/spans`.
-We want dataplane proxies in each zone to only send traces to their local collector.
+We want data plane proxies in each zone to only send traces to their local collector.
 
-To do this, we use a `TargetRef` kind value of `MeshSubset` to filter which dataplane proxy a policy applies to.
+To do this, we use a `TargetRef` kind value of `MeshSubset` to filter which data plane proxy a policy applies to.
 
 {% tabs meshtrace-region useUrlFragment=false %}
 {% tab meshtrace-region Universal %}

--- a/app/_src/policies/meshtrace.md
+++ b/app/_src/policies/meshtrace.md
@@ -67,7 +67,7 @@ For HTTP you can also manually forward the following headers:
 
 {% endif_version %}
 
-To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/targetref).
+To learn more about the information in this table, see the [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 

--- a/app/_src/policies/meshtrafficpermission.md
+++ b/app/_src/policies/meshtrafficpermission.md
@@ -47,7 +47,7 @@ Do **not** combine with [TrafficPermission](/docs/{{ page.version }}/policies/tr
 {% endtabs %}
 {% endif_version %}
 
-If you don't understand this table you should read [matching docs](/docs/{{ page.version }}/policies/targetref).
+If you don't understand this table you should read [matching docs](/docs/{{ page.version }}/policies/introduction).
 
 ## Configuration
 

--- a/app/_src/policies/targetref.md
+++ b/app/_src/policies/targetref.md
@@ -9,7 +9,12 @@ A policy is a set of configuration that will be used to generate the proxy confi
 
 ## What do policies look like?
 
+{% if_version gte:2.9.x %}
 Like all [resources](/docs/{{ page.version }}/introduction/concepts#resource) in {{ site.mesh_product_name }}, there are two parts to a policy:
+{% endif_version %}
+{% if_version lte:2.8.x %}
+Policies are made of two parts:
+{% endif_version %}
 
 1. The metadata
 2. The spec

--- a/app/_src/policies/targetref.md
+++ b/app/_src/policies/targetref.md
@@ -1,5 +1,5 @@
 ---
-title: Policies 
+title: Understanding TargetRef policies
 ---
 
 ## What is a policy?
@@ -7,14 +7,9 @@ title: Policies
 A policy is a set of configuration that will be used to generate the proxy configuration.
 {{ site.mesh_product_name }} combines policies with dataplane configuration to generate the Envoy configuration of a proxy.
 
-## What do policies look like?
+## What do `targetRef` policies look like?
 
-{% if_version gte:2.9.x %}
-Like all [resources](/docs/{{ page.version }}/introduction/concepts#resource) in {{ site.mesh_product_name }}, there are two parts to a policy:
-{% endif_version %}
-{% if_version lte:2.8.x %}
-Policies are made of two parts:
-{% endif_version %}
+There are two parts to a policy:
 
 1. The metadata
 2. The spec
@@ -74,16 +69,18 @@ Policies are namespaced scope and currently the namespace must be the one the co
 
 The `spec` field contains the actual configuration of the policy.
 
-Some policies apply to only a subset of the configuration of the proxy.
+All specs have a **top level `targetRef`** which identifies which proxies this policy applies to.
+In particular, it defines which proxies have their Envoy configuration modified.
 
-- **Inbound policies** apply only to incoming traffic. The `spec.from[].targetRef` field defines the subset of clients that are going to be impacted by this policy.
-- **Outbound policies** apply only to outgoing traffic. The `spec.to[].targetRef` field defines the outbounds that are going to be impacted by this policy 
+Some policies also support further narrowing.
+
+The `spec.to[].targetRef` field defines rules that applies to outgoing traffic of proxies selected by `spec.targetRef`.
+The `spec.from[].targetRef` field defines rules that applies to incoming traffic of proxies selected by `spec.targetRef`.
 
 The actual configuration is defined in a `default` map.
 
 For example:
 
-{% policy_yaml base-example %}
 ```yaml
 type: ExamplePolicy
 name: my-example
@@ -102,16 +99,10 @@ spec:
       default: # Configuration that applies to incoming traffic
         key: value
 ```
-{% endpolicy_yaml %}
 
-{% tip %}
-While some policies can have both a `to` and a `from` section, it is strongly advised to create 2 different policies, one for `to` and one for `from`.
-{% endtip %}
-
-Some policies are not directional and will not have `to` and `from`. Some examples of such policies are [`MeshTrace`](/docs/{{ page.version }}/policies/meshtrace) or [`MeshProxyPatch`](/docs/{{ page.version }}/policies/meshproxypatch).
+Some policies are not directional and will not have `to` and `from`.
 For example
 
-{% policy_yaml non-directional %}
 ```yaml
 type: NonDirectionalPolicy
 name: my-example
@@ -122,10 +113,6 @@ spec:
   default:
     key: value
 ```
-{% endpolicy_yaml %}
-
-All specs have a **top level `targetRef`** which identifies which proxies this policy applies to.
-In particular, it defines which proxies have their Envoy configuration modified.
 
 {% tip %}
 One of the benefits of `targetRef` policies is that the spec is always the same between Kubernetes and Universal.
@@ -133,7 +120,7 @@ One of the benefits of `targetRef` policies is that the spec is always the same 
 This means that converting policies between Universal and Kubernetes only means rewriting the metadata.
 {% endtip %}
 
-## Writing a `targetRef`
+#### Writing a `targetRef`
 
 `targetRef` is a concept borrowed from [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) its usage is fully defined in [MADR 005](https://github.com/kumahq/kuma/blob/master/docs/madr/decisions/005-policy-matching.md).
 Its goal is to select subsets of proxies with maximum flexibility.
@@ -152,10 +139,10 @@ targetRef:
 {% if_version gte:2.6.x %}
 ```yaml
 targetRef:
-  kind: Mesh | MeshSubset | MeshService | MeshGateway
-  name: "my-name" # For kinds MeshService, and MeshGateway a name has to be defined
+  kind: Mesh | MeshSubset | MeshService | MeshServiceSubset | MeshGateway
+  name: "my-name" # For kinds MeshService, MeshServiceSubset and MeshGateway a name has to be defined
   tags:
-    key: value # For kinds MeshSubset and MeshGateway a list of matching tags can be used
+    key: value # For kinds MeshServiceSubset, MeshSubset and MeshGateway a list of matching tags can be used
   proxyTypes: ["Sidecar", "Gateway"] # For kinds Mesh and MeshSubset a list of matching Dataplanes types can be used
 ```
 {% endif_version %}
@@ -164,24 +151,33 @@ Here's an explanation of each kinds and their scope:
 
 - Mesh: applies to all proxies running in the mesh
 - MeshSubset: same as Mesh but filters only proxies who have matching `targetRef.tags`
-- MeshService: all proxies with a tag `kuma.io/service` equal to `targetRef.name`.{% if_version gte:2.9.x %} This can work differently when using [explicit services](##using-policies-with-meshservice-meshmultizoneservice-and-meshexternalservice){% endif_version %}.
+- MeshService: all proxies with a tag `kuma.io/service` equal to `targetRef.name`
+- MeshServiceSubset: same as `MeshService` but further refine to proxies that have matching `targetRef.tags`
 - MeshGateway: targets proxies matched by the named MeshGateway
     - Note that it's very strongly recommended to target MeshGateway proxies using this
       kind, as opposed to MeshService/MeshServiceSubset.
-- MeshServiceSubset: same as `MeshService` but further refine to proxies that have matching `targetRef.tags`. ⚠️This is deprecated from version 2.9.x ⚠️.
+
+{% if_version gte:2.6.x %}
+In {{site.mesh_product_name}} 2.6.x, the `targetRef` field gained the ability to select a specific subset of data plane proxies. To further refine policy enforcement, a new field named `proxyTypes` has been introduced. It allows you to target policies to specific types of data plane proxies:
+- `Sidecar`: Targets data plane proxies acting as sidecars to applications.
+- `Gateway`: Applies to data plane proxies operating in Gateway mode.
+- Empty list: Defaults to targeting all data plane proxies.
+{% endif_version %}
 
 Consider the example below:
 
-{% policy_yaml accesslog_example %}
 ```yaml
-type: MeshAccessLog
-name: example
-mesh: default
+apiVersion: kuma.io/v1alpha1
+kind: MeshAccessLog
+metadata:
+  name: example
+  namespace: {{ site.mesh_namespace }}
+  labels:
+    kuma.io/mesh: default
 spec:
   targetRef: # top level targetRef
-    kind: MeshSubset
-    tags:
-        app: web-frontend
+    kind: MeshService
+    name: web-frontend
   to:
     - targetRef: # to level targetRef
         kind: MeshService
@@ -202,46 +198,12 @@ spec:
                 plain: '{"start_time": "%START_TIME%"}'
               path: "/tmp/logs.txt"
 ```
-{% endpolicy_yaml %}
 
-Using `spec.targetRef`, this policy targets all proxies that have a tag `app:web-frontend`.
-It defines the scope of this policy as applying to traffic either from or to dataplane proxies with the tag `app:web-frontend`.
+Using `spec.targetRef`, this policy targets all proxies that implement the service `web-frontend`.
+It defines the scope of this policy as applying to traffic either from or to `web-frontend` services.
 
-The `spec.to[].targetRef` section enables logging for any traffic going to `web-backend`.
-The `spec.from[].targetRef` section enables logging for any traffic coming from _anywhere_ in the `Mesh`.
-
-{% if_version gte:2.9.x %}
-### Omitting `targetRef`
-When a `targetRef` is not present. It is semantically equivalent to: `targetRef.kind: Mesh` meaning everything inside the mesh.
-{% endif_version %}
-
-{% if_version gte:2.6.x %}
-### Applying to specific proxy types
-The `targetRef` field can select a specific subset of data plane proxies. The field named `proxyTypes` can restrict policies to specific types of data plane proxies:
-- `Sidecar`: Targets data plane proxies acting as sidecars to applications.
-- `Gateway`: Applies to data plane proxies operating in Gateway mode.
-- Empty list: Defaults to targeting all data plane proxies.
-
-#### Example
-
-The following policy will only apply to gateway data-planes:
-{% policy_yaml proxytypes %}
-```yaml
-type: MeshTimeout
-name: gateway-only-timeout
-mesh: default
-spec:
-  targetRef:
-    kind: Mesh
-    proxyTypes: ["Gateway"]
-  to:
-    - targetRef:
-        kind: Mesh
-      default:
-        idleTimeout: 10s
-```
-{% endpolicy_yaml %}
-{% endif_version %}
+The `spec.to.targetRef` section enables logging for any traffic going to `web-backend`.
+The `spec.from.targetRef` section enables logging for any traffic coming from _any service_ in the `Mesh`.
 
 ### Target resources
 
@@ -262,7 +224,7 @@ These are just examples, remember to check the docs specific to your policy!
 {% tab targetRef Sidecar %}
 | `targetRef`             | Allowed kinds                                            |
 | ----------------------- | -------------------------------------------------------- |
-| `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`                      |
+| `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
 | `to[].targetRef.kind`   | `Mesh`, `MeshService`                                    |
 | `from[].targetRef.kind` | `Mesh`                                                   |
 {% endtab %}
@@ -306,6 +268,7 @@ This table looks like:
 | `Mesh`              | ✅        | ✅  | ❌   |
 | `MeshSubset`        | ✅        | ❌  | ❌   |
 | `MeshService`       | ✅        | ❌  | ✅   |
+| `MeshServiceSubset` | ✅        | ❌  | ❌   |
 | `MeshGateway`       | ✅        | ❌  | ❌   |
 
 Here it indicates that the top level can use any targetRef kinds. But in
@@ -313,7 +276,7 @@ Here it indicates that the top level can use any targetRef kinds. But in
 only kind `MeshService`.
 {% endif_version %}
 
-## Merging configuration
+### Merging configuration
 
 It is necessary to define a policy for merging configuration,
 because a proxy can be targeted by multiple `targetRef`'s.
@@ -355,239 +318,7 @@ default:
     extra: 2
 ```
 
-{% if_version gte:2.9.x %}
-## Using policies with `MeshService`, `MeshMultizoneService` and `MeshExternalService`.
-
-[`MeshService`](/docs/{{ page.version }}/networking/networking) is a feature to define services explicitly in {{ site.product_name }}.
-It can be selectively enabled and disable depending on the value of [meshServices.mode](/docs/{{ page.version }}/networking/meshservice/#migration) on your Mesh object.
-
-When using explicit services, `MeshServiceSubset` is no longer a valid kind and `MeshService` can only be used to select an actual `MeshService` resource (it can no longer select a `kuma.io/service`).
-
-In the following example we'll assume we have a `MeshService`:
-
-{% policy_yaml ms-1 namespace=kuma-demo %}
-```yaml
-type: MeshService
-name: my-service
-labels:
-  k8s.kuma.io/namespace: kuma-demo 
-  kuma.io/zone: my-zone
-  app: redis 
-spec:
-  selector:
-    dataplaneTags:
-      app: redis
-      k8s.kuma.io/namespace: kuma-demo 
-  ports:
-  - port: 6739
-    targetPort: 6739
-    appProtocol: tcp
-```
-{% endpolicy_yaml %}
-
-There are 2 ways to select a `MeshService`:
-
-If you are in the same namespace (or same zone in Universal) you can select one specific service by using its explicit name:
-
-```yaml
-apiVersion: kuma.io/v1alpha1
-kind: MeshTimeout
-metadata:
-  name: timeout-to-redis
-  namespace: kuma-demo
-spec:
-  to:
-  - targetRef:
-      kind: MeshService
-      name: redis
-    default:
-      connectionTimeout: 10s
-```
-
-Selecting all matching resources by labels:
-
-```yaml
-apiVersion: kuma.io/v1alpha1
-kind: MeshTimeout
-metadata:
-  name: all-in-my-namespace 
-  namespace: kuma-demo
-spec:
-  to:
-  - targetRef:
-      kind: MeshService
-      labels:
-        k8s.kuma.io/namespace: kuma-demo
-    default:
-      connectionTimeout: 10s
-```
-
-In this case this is equivalent to writing a specific policy for each service that matches this label (in our example for each service in this namespace in each zones). 
-
-### Global, Zonal, Producer and Consumer policies
-
-Policies can be applied to a zone or to a namespace when using Kubernetes.
-Policies will always impact at most the scope at which they are defined.
-In other words:
-
-1. a policy applied to the global control plane will apply to all proxies in all zones.
-2. a policy applied to a zone will only apply to proxies inside this zone. It is equivalent to having:
-   ```yaml
-   spec:
-     targetRef: 
-       kind: MeshSubset
-       tags:
-         kuma.io/zone: "my-zone"
-   ```
-3. a policy applied to a namespace will only apply to proxies inside this namespace. It is equivalent to having:
-   ```yaml
-   spec:
-     targetRef: 
-       kind: MeshSubset
-       tags:
-         kuma.io/zone: "my-zone"
-         kuma.io/namespace: "my-ns"
-   ```
-
-There is however, one exception to this when using `MeshService` with **outbound** policies (policies with `spec.to[].targetRef`).
-In this case, if you define a policy in the same namespace as the `MeshService` it is defined in a policy will be considered to be a **producer** policy.
-This means that all clients of this service (even in different zones) will be impacted by this policy.
-
-An example of a producer policy is:
-
-```yaml
-apiVersion: kuma.io/v1alpha1
-kind: MeshTimeout
-metadata:
-  name: timeout-to-redis
-  namespace: kuma-demo
-spec:
-  to:
-  - targetRef:
-      kind: MeshService
-      name: redis
-    default:
-      connectionTimeout: 10s
-```
-
-The other type of policy is a consumer policy which most commonly use labels to match a service.
-
-An example of a consumer policy which would override the previous producer policy:
-
-```yaml
-apiVersion: kuma.io/v1alpha1
-kind: MeshTimeout
-metadata:
-  name: timeout-to-redis-consumer
-  namespace: kuma-demo
-spec:
-  to:
-    - targetRef:
-        kind: MeshService
-        labels:
-          k8s.kuma.io/service-name: redis
-      default:
-        connectionTimeout: 10s
-```
-
-{% tip %}
-Remember that `labels` on a `MeshService` applies to _each_ matching `MeshService`. To communicate to services
-named the same way in different namespaces or zones with different configuration use a more specific set of labels. 
-{% endtip %}
-
-{{ site.mesh_product_name }} adds a label `kuma.io/policy-role` to identify the type of the policy. The values of the label are:
-
-- **system**: Policies defined on global or in the zone's system namespace
-- **workload-owner**: Policies defined in a non system namespaces that do not have `spec.to` entries
-- **consumer**: Policies defined in a non system namespace that have `spec.to` which either do not use `name` or have a different `namespace`.
-- **producer**: Policies defined in the same namespace as the services identified in the `spec.to[].targetRef`.  
-
-The merging order of the different policy scopes is: **global < zonal < producer < consumer**.
-
-### Example
-
-We have 2 clients client1 and client2 they run in different namespaces respectively ns1 and ns2.
-
-```mermaid
-flowchart LR
-subgraph ns1
-    client1(client)
-end
-subgraph ns2
-  client2(client)
-  server(MeshService: server)
-end
-client1 --> server
-client2 --> server
-```
-
-We're going to define a producer policy first:
-```yaml
-apiVersion: kuma.io/v1alpha1
-kind: MeshTimeout
-metadata:
-    name: producer-policy
-    namespace: ns2
-spec:
-  to:
-    - targetRef:
-        kind: MeshService
-        name: server
-      default:
-        idleTimeout: 20s
-```
-
-We know it's a producer policy because it is defined in the same namespace as the `MeshService: server` and names this server in its `spec.to[].targetRef`.
-So both client1 and client2 will receive the timeout of 20s.
-
-We now create a consumer policy:
-
-```yaml
-apiVersion: kuma.io/v1alpha1
-kind: MeshTimeout
-metadata:
-  name: consumer-policy
-  namespace: ns1
-spec:
-  to:
-    - targetRef:
-        kind: MeshService
-        labels:
-          k8s.kuma.io/service-name: server
-      default:
-        idleTimeout: 30s
-```
-
-Here the policy only impacts client1 as client2 doesn't run in ns1. As consumer policies have a higher priority over producer policies, client1 will have a `idleTimeout: 30s`.
-
-We can define another policy to impact client2:
-
-```yaml
-apiVersion: kuma.io/v1alpha1
-kind: MeshTimeout
-metadata:
-  name: consumer-policy
-  namespace: ns2
-spec:
-  to:
-    - targetRef:
-        kind: MeshService
-        labels:
-          k8s.kuma.io/service-name: server
-      default:
-        idleTimeout: 40s
-```
-
-Note that the only different here is the namespace, we now define a consumer policy inside `ns2`.
-
-{% tip %}
-Use labels for consumer policies and name for producer policies.
-It will be easier to differentiate between producer and consumer policies.
-{% endtip %}
-
-{% endif_version %}
-
-## Examples
+### Examples
 
 #### Applying a global default
 

--- a/app/_src/production/upgrades-tuning/fine-tuning.md
+++ b/app/_src/production/upgrades-tuning/fine-tuning.md
@@ -144,22 +144,22 @@ A recommended path of migration is to start with a coarse grain `MeshTrafficPerm
 If you choose `Postgres` as a configuration store for {{site.mesh_product_name}} on Universal,
 please be aware of the following key settings that affect performance of {{site.mesh_product_name}} Control Plane.
 
-* `KUMA_STORE_POSTGRES_CONNECTION_TIMEOUT` : connection timeout to the Postgres database (default: 5s)
-* `KUMA_STORE_POSTGRES_MAX_OPEN_CONNECTIONS` : maximum number of open connections to the Postgres database (default: unlimited)
+* `KUMA_STORE_POSTGRES_CONNECTION_TIMEOUT` : connection timeout to the Postgres database (default: `5s`)
+* `KUMA_STORE_POSTGRES_MAX_OPEN_CONNECTIONS` : maximum number of open connections to the Postgres database (default: `unlimited`)
 
 ### KUMA_STORE_POSTGRES_CONNECTION_TIMEOUT
 
-The default value will work well in those cases where both `kuma-cp` and Postgres database are deployed in the same datacenter / cloud region.
+The default value will work well in those cases where both `kuma-cp` and Postgres database are deployed in the same data center / cloud region.
 
-However, if you're pursuing a more distributed topology, e.g. by hosting `kuma-cp` on premise and using Postgres as a service in the cloud, the default value might no longer be enough.
+However, if you're pursuing a more distributed topology, for example by hosting `kuma-cp` on premise and using Postgres as a service in the cloud, the default value might no longer be enough.
 
 ### KUMA_STORE_POSTGRES_MAX_OPEN_CONNECTIONS
 
-The more dataplanes join your meshes, the more connections to Postgres database {{site.mesh_product_name}} might need to fetch configurations and update statuses.
+The more data planes join your meshes, the more connections to Postgres database {{site.mesh_product_name}} might need to fetch configurations and update statuses.
 
 As of version 1.4.1 the default value is 50.
 
-However, if your Postgres database (e.g., as a service in the cloud) only permits a small number of concurrent connections, you will have to adjust {{site.mesh_product_name}} configuration respectively.
+However, if your Postgres database (for example as a service in the cloud) only permits a small number of concurrent connections, you will have to adjust {{site.mesh_product_name}} configuration respectively.
 
 ## Snapshot Generation
 
@@ -167,27 +167,27 @@ However, if your Postgres database (e.g., as a service in the cloud) only permit
 This is advanced topic describing {{site.mesh_product_name}} implementation internals
 {% endwarning %}
 
-The main task of the control plane is to provide config for dataplanes. When a dataplane connects to the control plane, the CP starts a new goroutine.
-This goroutine runs the reconciliation process with given interval (1s by default). During this process, all dataplanes and policies are fetched for matching.
-When matching is done, the Envoy config (including policies and available endpoints of services) for given dataplane is generated and sent only if there is an actual change.
+The main task of the control plane is to provide config for data planes. When a data plane connects to the control plane, the control plane starts a new Goroutine.
+This Goroutine runs the reconciliation process with given interval (`1s` by default). During this process, all data planes and policies are fetched for matching.
+When matching is done, the Envoy config (including policies and available endpoints of services) for given data plane is generated and sent only if there is an actual change.
 
-* `KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL` : interval for re-generating configuration for Dataplanes connected to the Control Plane (default: 1s)
+* `KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL` : interval for re-generating configuration for data planes connected to the control plane (default: `1s`)
 
-This process can be CPU intensive with high number of dataplanes therefore you can control the interval time for a single dataplane.
-You can lower the interval scarifying the latency of the new config propagation to avoid overloading the CP. For example,
-changing it to 5s means that when you apply a policy (like TrafficPermission) or the new dataplane of the service is up or down, CP will generate and send new config within 5 seconds.
+This process can be CPU intensive with high number of data planes therefore you can control the interval time for a single data plane.
+You can lower the interval scarifying the latency of the new config propagation to avoid overloading the control plane. For example,
+changing it to 5 seconds means that when you apply a policy (like `MeshTrafficPermission`) or the new data plane of the service is up or down, control plane will generate and send new config within 5 seconds.
 
-For systems with high traffic, keeping old endpoints for such a long time (5s) may not be acceptable. To solve this, you can use passive or active [health checks](/docs/{{ page.version }}/policies/health-check) provided by {{site.mesh_product_name}}.
+For systems with high traffic, keeping old endpoints for such a long time (5 seconds) may not be acceptable. To solve this, you can use passive or active [health checks](/docs/{{ page.version }}/policies/health-check) provided by {{site.mesh_product_name}}.
 
 Additionally, to avoid overloading the underlying storage there is a cache that shares fetch results between concurrent reconciliation processes for multiple dataplanes.
 
-* `KUMA_STORE_CACHE_EXPIRATION_TIME` : expiration time for elements in cache (1s by default).
+* `KUMA_STORE_CACHE_EXPIRATION_TIME` : expiration time for elements in cache (1 second by default).
 
 You can also change the expiration time, but it should not exceed `KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL`, otherwise CP will be wasting time building Envoy config with the same data.
 
 ## Profiling
 
-{{site.mesh_product_name}}'s control plane ships with [pprof](https://golang.org/pkg/net/http/pprof/) endpoints so you can profile and debug the performance of the `kuma-cp` process.
+{{site.mesh_product_name}}'s control plane ships with [`pprof`](https://golang.org/pkg/net/http/pprof/) endpoints so you can profile and debug the performance of the `kuma-cp` process.
 
 To enable the debugging endpoints, you can set the `KUMA_DIAGNOSTICS_DEBUG_ENDPOINTS` environment variable to `true` before starting `kuma-cp` and use one of the following methods to retrieve the profiling information:
 
@@ -262,7 +262,7 @@ runtime:
 
 ## Envoy
 
-### Envoy concurrency tunning
+### Envoy concurrency tuning
 
 Envoy allows configuring the number of [worker threads ](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/intro/threading_model)used for processing requests. Sometimes it might be useful to change the default number of worker threads e.g.: high CPU machine with low traffic. Depending on the type of deployment, there are different mechanisms in `kuma-dp` to change Envoy’s concurrency level.
 
@@ -292,7 +292,7 @@ spec:
 
 {% tab envoy Universal %}
 
-Envoy on Linux, by default, starts with the flag `--cpuset-threads`. In this case, cpuset size is used to determine the number of worker threads on systems. When the value is not present then the number of worker threads is based on the number of hardware threads on the machine. `Kuma-dp` allows tuning that value by providing a `--concurrency` flag with the number of worker threads to create.
+Envoy on Linux, by default, starts with the flag `--cpuset-threads`. In this case, `cpuset` size is used to determine the number of worker threads on systems. When the value is not present then the number of worker threads is based on the number of hardware threads on the machine. `Kuma-dp` allows tuning that value by providing a `--concurrency` flag with the number of worker threads to create.
 
 ```sh
 kuma-dp run \

--- a/app/_src/production/upgrades-tuning/fine-tuning.md
+++ b/app/_src/production/upgrades-tuning/fine-tuning.md
@@ -33,7 +33,7 @@ can be also mitigated by defining [MeshTrafficPermissions](/docs/{{ page.version
 
 Switching on the flag will result in computing a graph of dependencies between the services
 and generating XDS configuration that enables communication **only** with services that are allowed to communicate with each other
-(their [effective](/docs/{{ page.version }}/policies/targetref/#merging-configuration) action is **not** `deny`).
+(their [effective](/docs/{{ page.version }}/policies/introduction) action is **not** `deny`).
 
 For example: if a service `b` can be called only by service `a`:
 

--- a/app/_src/production/upgrades-tuning/fine-tuning.md
+++ b/app/_src/production/upgrades-tuning/fine-tuning.md
@@ -68,8 +68,8 @@ Sections below highlight the most important aspects of this feature, if you want
 
 The following kinds affect the graph generation and performance:
 - all levels of `MeshService`
-- [top](/docs/{{ page.version }}/policies/targetref/#target-resources) level `MeshSubset` and `MeshServiceSubset` with `k8s.kuma.io/namespace`, `k8s.kuma.io/service-name`, `k8s.kuma.io/service-port` tags
-- [from](/docs/{{ page.version }}/policies/targetref/#target-resources) level `MeshSubset` and `MeshServiceSubset` with all tags
+- [top](/docs/{{ page.version }}/policies/introduction) level `MeshSubset` and `MeshServiceSubset` with `k8s.kuma.io/namespace`, `k8s.kuma.io/service-name`, `k8s.kuma.io/service-port` tags
+- [from](/docs/{{ page.version }}/policies/introduction) level `MeshSubset` and `MeshServiceSubset` with all tags
 
 If you define a MeshTrafficPermission with other kind, like this one:
 

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-routes.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-routes.md
@@ -7,7 +7,7 @@ use [`MeshHTTPRoute`](/docs/{{ page.version }}/policies/meshhttproute) and
 [`MeshTCPRoute`](/docs/{{ page.version }}/policies/meshtcproute).
 
 Using these route resources with a gateway requires [using `spec.targetRef` to target
-gateway data plane proxies](/docs/{{ page.version }}/policies/targetref/#target-resources).
+gateway data plane proxies](/docs/{{ page.version }}/policies/introduction).
 Otherwise, [filtering and routing traffic](/docs/{{ page.version }}/policies/meshhttproute) is
 configured as outlined in the docs.
 


### PR DESCRIPTION
Have a central concepts page to link from there to different other pages.

Change pages to make policies intro docs simpler

- Adds page: https://deploy-preview-1956--kuma.netlify.app/docs/dev/introduction/concepts/
- Add merge the policy reference to just be: https://deploy-preview-1956--kuma.netlify.app/docs/dev/policies/targetref/


Fix #1824