### PR TITLE
chore(contributing): update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,34 +59,50 @@ Signed-off-by: Jane Smith <jane.smith@example.com>
 
 In most cases, you can add this signoff to your commit automatically with the `-s` flag to `git commit`. You must use your real name and a reachable email address (sorry, no pseudonyms or anonymous contributions).
 
-### Running the site locally
+### Setup
+
+#### Prerequisites
+
+1. Make sure you have the right ruby version installed (`cat .ruby-version`).
+2. Install [yarn](https://classic.yarnpkg.com/en/docs/install)
+
+#### Installation
 
 Clone the repository and run:
-```
+```bash
 make install
 ```
-make sure you have the right ruby version installed (`cat .ruby-version`).
-Jekyll is a static-site generator, so first we need to build the site and compile the assets:
+
+On macOS you might face issues with clang when installing gems. In that case try the following:
+```bash
+gem install <gem> -- --with-cflags="-Wno-incompatible-function-pointer-types"
 ```
+
+### Development
+
+If you want to make changes to the docs or the assets and see them reflected on the browser, you need to run the site with:
+```bash
+make run
+```
+This will run `jekyll serve` and `vite` in the background wich will re-build the corresponding pages whenever a doc or asset changes,
+while running `netlify dev` so that all the redirects work locally.
+
+### Production build
+
+Jekyll is a static-site generator, so first we need to build the site and compile the assets:
+```bash
 make build
 ```
+
 Note: If you face any issues, e.g. the asset don't look right, try cleaning the cache first and re-build the site:
-```
+```bash
 make clean && make build
 ```
 
-Next, run
-```
+Next, run the production build locally
+```bash
 make serve
 ```
 which will run `Netlify` locally in a local dev server, similar to production, making all the redirects, env variables, etc.
 available. You can visit http://localhost:8888/ and start reading the documentation.
-
-#### Modifying files locally
-
-If you want to make changes to the docs or the assets and see them reflected on the browser, you need to run the site with:
-```
-make run
-```
-This will run `jekyll serve` and `vite` in the background wich wil re-build the corresponding pages whenever a doc or asset changes,
-while running `netlify dev` so that all the redirects work locally.
+In case you are stuck in `⠼ Waiting for framework port 4000`, please retry.


### PR DESCRIPTION
Restructured `CONTRIBUTING.md` section `Running the site locally` into sections `Setup`, `Development`, `Production build` and added more information.

I faced some issues when running `make install` on a fairly fresh system (M3):
- Missed to install `yarn`
- Error when installing gem `posix-spawn`. This is possibly not limited to `posix-spawn` though. Added the instructions to resolve this.
