### PR TITLE
docs(install): replace Kind with Minikube for simple test installations

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -95,6 +95,7 @@ Mockbin
 Moesif
 MongoDB
 Multus
+mTLS
 NAD
 namespace[sd]?
 navtabs
@@ -138,7 +139,6 @@ target[Rr]ef
 tbl
 tcpdump
 TLS
-tls
 transcoder
 ttl
 txt

--- a/app/_src/guides/federate.md
+++ b/app/_src/guides/federate.md
@@ -28,10 +28,10 @@ minikube start -p mesh-global
 ```
 
 ### Setup the minikube tunnel
-If you are using Minikube for local testing, you can take advantage of the built-in minikube tunnel command. This command allows load balancer addresses to be provisioned using localhost.
+If you are using minikube for local testing, you can take advantage of the built-in minikube tunnel command. This command allows load balancer addresses to be provisioned using localhost.
 
 {% tip %}
-Using nohup will allow the tunnel to continue running should your current terminal session end. 
+Using `nohup` will allow the tunnel to continue running should your current terminal session end. 
 {% endtip %}
 
 ```sh

--- a/app/_src/guides/federate.md
+++ b/app/_src/guides/federate.md
@@ -11,6 +11,7 @@ This way you can:
 
 ## Prerequisites
 - Completed [quickstart](/docs/{{ page.version }}/quickstart/kubernetes-demo/) to set up a zone control plane with demo application
+- Have [kumactl installed and in your path](/docs/{{ page.version }}/production/install-kumactl)
 
 ## Start a global control plane
 
@@ -51,23 +52,19 @@ We skip default mesh creation as we will bring mesh from zone control plane in t
 
 ### Sync endpoint
 
-Find the external IP and port of the `{{site.mesh_cp_zone_sync_name_prefix}}global-zone-sync` service in the `{{site.mesh_namespace}}` namespace:
-
-```sh
-kubectl get services -n {{site.mesh_namespace}}
-NAMESPACE     NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)                                                                  AGE
-{{site.mesh_namespace}}   {{site.mesh_cp_zone_sync_name_prefix}}global-zone-sync     LoadBalancer   10.105.9.10     35.226.196.103   5685:30685/TCP                                                           89s
-{{site.mesh_namespace}}   {{site.mesh_cp_name}}     ClusterIP      10.105.12.133   <none>           5681/TCP,443/TCP,5676/TCP,5677/TCP,5678/TCP,5679/TCP,5682/TCP,5653/UDP   90s
-```
-
-You can also retrieve the IP directly with:
+Find and save the external IP and port of the `{{site.mesh_cp_zone_sync_name_prefix}}global-zone-sync` service in the `{{site.mesh_namespace}}` namespace:
 
 ```shell
-export KDS_IP=$(kubectl get svc --namespace {{site.mesh_namespace}} {{site.mesh_cp_zone_sync_name_prefix}}global-zone-sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+export KDS_IP=$(kubectl --context=mesh-global get svc --namespace {{site.mesh_namespace}} {{site.mesh_cp_zone_sync_name_prefix}}global-zone-sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 ```
 
-In this example the value is `35.226.196.103:5685`. You pass this as the value of `<global-kds-address>` when you federate the zone control plane.
-If you see `<Pending>` you either need to wait until load balancer is provisioned or you need to make sure that your Kubernetes cluster support provisioning load balancers. 
+{% tip %}
+If you are using minikube, you should use [`host.minikube.internal`](https://minikube.sigs.k8s.io/docs/handbook/host-access/) to ensure networking works correctly.
+
+```sh
+export KDS_IP=host.minikube.internal
+```
+{% endtip %}
 
 ## Copy resources from zone to global control plane
 
@@ -98,14 +95,6 @@ kubectl apply --context=mesh-global -f resources.yaml
 ## Connect zone control plane to global control plane
 
 Update Helm deployment of zone control plane to configure connection to the global control plane.
-
-{% tip %}
-If you are using minikube, you should use [`host.minikube.internal`](https://minikube.sigs.k8s.io/docs/handbook/host-access/) to ensure networking works correctly.
-
-```sh
-export KDS_IP=host.minikube.internal
-```
-{% endtip %}
 
 
 ```sh

--- a/app/_src/guides/federate.md
+++ b/app/_src/guides/federate.md
@@ -24,7 +24,7 @@ It can be a cluster running locally or in a public cloud like AWS EKS, GCP GKE, 
 {% endtip %}
 
 ```sh
-minikube start -p kuma-mesh-global
+minikube start -p mesh-global
 ```
 
 ### Setup the minikube tunnel
@@ -35,13 +35,13 @@ Using nohup will allow the tunnel to continue running should your current termin
 {% endtip %}
 
 ```sh
-nohup minikube tunnel -p &
+nohup minikube tunnel -p mesh-global &
 ```
 
 ### Deploy a global control plane
 
 ```sh
-helm install --kube-context=kind-mesh-global --create-namespace --namespace {{site.mesh_namespace}} \
+helm install --kube-context=mesh-global --create-namespace --namespace {{site.mesh_namespace}} \
 --set {{site.set_flag_values_prefix}}controlPlane.mode=global \
 --set {{site.set_flag_values_prefix}}controlPlane.defaults.skipMeshCreation=true \
 {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }}
@@ -60,6 +60,12 @@ NAMESPACE     NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP 
 {{site.mesh_namespace}}   {{site.mesh_cp_name}}     ClusterIP      10.105.12.133   <none>           5681/TCP,443/TCP,5676/TCP,5677/TCP,5678/TCP,5679/TCP,5682/TCP,5653/UDP   90s
 ```
 
+You can also retrieve the IP directly with:
+
+```shell
+export KDS_IP=$(kubectl get svc --namespace {{site.mesh_namespace}} {{site.mesh_cp_zone_sync_name_prefix}}global-zone-sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+```
+
 In this example the value is `35.226.196.103:5685`. You pass this as the value of `<global-kds-address>` when you federate the zone control plane.
 If you see `<Pending>` you either need to wait until load balancer is provisioned or you need to make sure that your Kubernetes cluster support provisioning load balancers. 
 
@@ -69,12 +75,12 @@ To federate zone control plane without any traffic interruption, we need to copy
 First, we need to expose API server of zone control plane:
 
 ```sh
-kubectl --context=kind-mesh-zone port-forward svc/{{site.mesh_cp_name}} -n {{site.mesh_namespace}} 5681:5681
+kubectl --context=mesh-zone port-forward svc/{{site.mesh_cp_name}} -n {{site.mesh_namespace}} 5681:5681
 ```
 
 Then we export resources:
 ```sh
-export ZONE_USER_ADMIN_TOKEN=$(kubectl --context=kind-mesh-zone get secrets -n {{site.mesh_namespace}} admin-user-token -ojson | jq -r .data.value | base64 -d)
+export ZONE_USER_ADMIN_TOKEN=$(kubectl --context=mesh-zone get secrets -n {{site.mesh_namespace}} admin-user-token -ojson | jq -r .data.value | base64 -d)
 kumactl config control-planes add \
   --address http://localhost:5681 \
   --headers "authorization=Bearer $ZONE_USER_ADMIN_TOKEN" \
@@ -86,19 +92,28 @@ kumactl export --profile=federation-with-policies --format=kubernetes > resource
 
 And finally, we apply resources on global control plane
 ```sh
-kubectl apply --context=kind-mesh-global -f resources.yaml
+kubectl apply --context=mesh-global -f resources.yaml
 ```
 
 ## Connect zone control plane to global control plane
 
 Update Helm deployment of zone control plane to configure connection to the global control plane.
 
+{% tip %}
+If you are using minikube, you should use [`host.minikube.internal`](https://minikube.sigs.k8s.io/docs/handbook/host-access/) to ensure networking works correctly.
+
+```sh
+export KDS_IP=host.minikube.internal
+```
+{% endtip %}
+
+
 ```sh
 helm upgrade --kube-context=mesh-zone --namespace {{site.mesh_namespace}} \
 --set {{site.set_flag_values_prefix}}controlPlane.mode=zone \
 --set {{site.set_flag_values_prefix}}controlPlane.zone=zone-1 \
 --set {{site.set_flag_values_prefix}}ingress.enabled=true \
---set {{site.set_flag_values_prefix}}controlPlane.kdsGlobalAddress=grpcs://<global-kds-address>:5685 \
+--set {{site.set_flag_values_prefix}}controlPlane.kdsGlobalAddress=grpcs://${KDS_IP}:5685 \
 --set {{site.set_flag_values_prefix}}controlPlane.tls.kdsZoneClient.skipVerify=true \
 {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }}
 ```
@@ -108,7 +123,7 @@ helm upgrade --kube-context=mesh-zone --namespace {{site.mesh_namespace}} \
 To verify federation, first port-forward the API service from the global control plane to port 15681 to avoid collision with previous port forward. 
 
 ```sh
-kubectl --context=kind-mesh-global port-forward svc/{{site.mesh_cp_name}} -n {{site.mesh_namespace}} 15681:5681
+kubectl --context=mesh-global port-forward svc/{{site.mesh_cp_name}} -n {{site.mesh_namespace}} 15681:5681
 ```
 
 And then navigate to [127.0.0.1:15681/gui](http://127.0.0.1:15681/gui) to see the GUI.
@@ -122,7 +137,7 @@ You should eventually see
 
 We can check policy synchronization from global control plane to zone control plane by applying a policy on global control plane:
 
-```
+```sh
 echo "apiVersion: kuma.io/v1alpha1
 kind: MeshCircuitBreaker
 metadata:
@@ -143,12 +158,12 @@ spec:
         maxConnections: 2
         maxPendingRequests: 8
         maxRetries: 2
-        maxRequests: 2" | kubectl --context=kind-mesh-global apply -f -
+        maxRequests: 2" | kubectl --context=mesh-global apply -f -
 ```
 
 If we execute the following command:
 ```sh
-kubectl get --context=kind-mesh-zone meshcircuitbreakers -A
+kubectl get --context=mesh-zone meshcircuitbreakers -A
 ```
 The policy should be eventually available in zone control plane
 ```

--- a/app/_src/guides/federate.md
+++ b/app/_src/guides/federate.md
@@ -24,11 +24,19 @@ It can be a cluster running locally or in a public cloud like AWS EKS, GCP GKE, 
 {% endtip %}
 
 ```sh
-kind create cluster --name=mesh-global
+minikube start -p kuma-mesh-global
 ```
 
-By default, Kind does not support LoadBalancer therefore we need to configure it by following this [guide](https://kind.sigs.k8s.io/docs/user/loadbalancer/).
-Note that all public cloud providers support load balancers out of the box.
+### Setup the minikube tunnel
+If you are using Minikube for local testing, you can take advantage of the built-in minikube tunnel command. This command allows load balancer addresses to be provisioned using localhost.
+
+{% tip %}
+Using nohup will allow the tunnel to continue running should your current terminal session end. 
+{% endtip %}
+
+```sh
+nohup minikube tunnel -p &
+```
 
 ### Deploy a global control plane
 

--- a/app/_src/guides/gateway-builtin.md
+++ b/app/_src/guides/gateway-builtin.md
@@ -49,8 +49,12 @@ spec:
 ```
 
 {% warning %}
-The Kubernetes cluster needs to support LoadBalancer for this to work.
-This may not be the case if the Kubernetes cluster is running locally with `kind` or `k3d`. 
+The Kubernetes cluster needs to support `LoadBalancer` for this to work.
+
+If you are running `minikube` you will want to open a [tunnel](https://minikube.sigs.k8s.io/docs/handbook/accessing/#loadbalancer-access) with `minikube tunnel -p mesh-zone`.
+
+You may not have support for `LoadBalancer` if you are running locally with `kind` or `k3d`.
+One option for `kind` is [kubernetes-sigs/cloud-provider-kind](https://github.com/kubernetes-sigs/cloud-provider-kind) may be helpful.
 {% endwarning %}
 
 ### Define a listener using `MeshGateway`

--- a/app/_src/guides/gateway-delegated.md
+++ b/app/_src/guides/gateway-delegated.md
@@ -32,8 +32,12 @@ flowchart LR
 Follow the steps on the [Kong docs website](https://docs.konghq.com/kubernetes-ingress-controller/latest/get-started/) to install the ingress controller.
 
 {% warning %}
-The Kubernetes cluster needs to support LoadBalancer for this to work.
-This may not be the case if the Kubernetes cluster is running locally with `kind` or `k3d`.
+The Kubernetes cluster needs to support `LoadBalancer` for this to work.
+
+If you are running `minikube` you will want to open a [tunnel](https://minikube.sigs.k8s.io/docs/handbook/accessing/#loadbalancer-access) with `minikube tunnel -p mesh-zone`.
+
+You may not have support for `LoadBalancer` if you are running locally with `kind` or `k3d`.
+One option for `kind` is [kubernetes-sigs/cloud-provider-kind](https://github.com/kubernetes-sigs/cloud-provider-kind) may be helpful.
 {% endwarning %}
 
 ## Enable sidecar injection on the `kong` namespace

--- a/app/_src/quickstart/kubernetes-demo.md
+++ b/app/_src/quickstart/kubernetes-demo.md
@@ -25,10 +25,10 @@ demo-app --> redis
 
 ## Start Kubernetes cluster
 
-Start a new Kubernetes cluster on your local machine by executing the command below. The -p option creates a new profile named 'kuma-zone'."
+Start a new Kubernetes cluster on your local machine by executing the command below. The -p option creates a new profile named 'mesh-zone'."
 
 ```sh
-minikube start -p kuma-zone
+minikube start -p mesh-zone
 ```
 
 {% tip %}

--- a/app/_src/quickstart/kubernetes-demo.md
+++ b/app/_src/quickstart/kubernetes-demo.md
@@ -21,14 +21,14 @@ demo-app --> redis
 
 ## Prerequisites
 - [Helm](https://helm.sh/) - a package manager for Kubernetes
-- [Kind](https://kind.sigs.k8s.io/) - a tool for running local Kubernetes clusters
+- [Minikube](https://minikube.sigs.k8s.io/docs/) - a tool for running local Kubernetes clusters
 
 ## Start Kubernetes cluster
 
-Start a new Kubernetes cluster on your local machine by executing:
+Start a new Kubernetes cluster on your local machine by executing the command below. The -p option creates a new profile named 'kuma-zone'."
 
 ```sh
-kind create cluster --name=mesh-zone
+minikube start -p kuma-zone
 ```
 
 {% tip %}

--- a/app/_src/quickstart/kubernetes-demo.md
+++ b/app/_src/quickstart/kubernetes-demo.md
@@ -21,7 +21,7 @@ demo-app --> redis
 
 ## Prerequisites
 - [Helm](https://helm.sh/) - a package manager for Kubernetes
-- [Minikube](https://minikube.sigs.k8s.io/docs/) - a tool for running local Kubernetes clusters
+- [minikube](https://minikube.sigs.k8s.io/docs/) - a tool for running local Kubernetes clusters
 
 ## Start Kubernetes cluster
 


### PR DESCRIPTION
- Updated installation instructions to use Minikube instead of Kind.
- Modified references throughout relevant pages to reflect Minikube.
- Ensured steps are clear for users to set up Minikube.

Closes #1649

Signed-off-by: dascole joe.dascole@konghq.com