### PR TITLE
feat(app/nav): add 2.9.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1.2'
+          ruby-version: "3.1.2"
           bundler-cache: true
       - working-directory: jekyll-kuma-plugins
         run: bundle install
@@ -183,7 +183,9 @@ jobs:
 
   vale:
     name: Lint docs
-    runs-on: ubuntu-latest
+    # Had to pin to 22.04 because of https://github.com/errata-ai/vale-action/issues/128.
+    # Once fixed upstream we can put it back to latest.
+    runs-on: ubuntu-22.04
     steps:
       - name: Get changed files
         id: changed-files

--- a/app/_data/docs_nav_kuma_2.9.x.yml
+++ b/app/_data/docs_nav_kuma_2.9.x.yml
@@ -1,0 +1,497 @@
+generate: true
+assume_generated: true
+items:
+  - title: Introduction
+    group: true
+    items:
+      - text: About service meshes
+        url: /introduction/about-service-meshes
+      - text: Overview of Kuma
+        url: /introduction/overview-of-kuma/
+      - text: How Kuma works
+        url: /introduction/how-kuma-works/
+        items:
+          - text: Dependencies
+            url: "/introduction/how-kuma-works/#dependencies"
+          - text: VM and K8s support
+            url: "/introduction/how-kuma-works/#vm-and-k8s-support"
+          - text: Kuma vs XYZ
+            url: "/introduction/how-kuma-works/#kuma-vs-xyz"
+      - text: Architecture
+        url: /introduction/architecture/
+      - text: Kuma requirements
+        url: /introduction/kuma-requirements/
+      - text: Release notes
+        url: /docs/changelog/
+        absolute_url: true
+        generate: false
+  - title: Quickstart
+    group: true
+    items:
+      - text: Deploy Kuma on Kubernetes
+        url: /quickstart/kubernetes-demo
+        items:
+          - text: Prerequisites
+            url: "/quickstart/kubernetes-demo/#prerequisites"
+          - text: Start Kubernetes cluster
+            url: "/quickstart/kubernetes-demo/#start-kubernetes-cluster"
+          - text: Install Kuma
+            url: "/quickstart/kubernetes-demo/#install-kuma"
+          - text: Deploy demo application
+            url: "/quickstart/kubernetes-demo/#deploy-demo-application"
+          - text: Explore GUI
+            url: "/quickstart/kubernetes-demo/#explore-the-gui"
+          - text: Introduce zero-trust security
+            url: "/quickstart/kubernetes-demo/#introduce-zero-trust-security"
+          - text: Next steps
+            url: "/quickstart/kubernetes-demo/#next-steps"
+      - text: Deploy Kuma on Universal
+        url: /quickstart/universal-demo
+  - title: Kuma in Production
+    group: true
+    items:
+      - text: Overview
+        url: /production/
+      - title: Deployment topologies
+        group: true
+        items:
+          - text: Overview
+            url: /production/deployment/
+          - text: Single-zone deployment
+            url: /production/deployment/single-zone/
+          - text: Multi-zone deployment
+            url: /production/deployment/multi-zone/
+      - text: Install kumactl
+        url: /production/install-kumactl/
+      - text: Use Kuma
+        url: /production/use-mesh/
+      - title: Control plane deployment
+        group: true
+        items:
+          - text: Deploy a single-zone control plane
+            url: /production/cp-deployment/single-zone/
+          - text: Deploy a multi-zone global control plane
+            url: /production/cp-deployment/multi-zone/
+          - text: Zone Ingress
+            url: /production/cp-deployment/zone-ingress/
+          - text: Zone Egress
+            url: /production/cp-deployment/zoneegress/
+          - text: Configure zone proxy authentication
+            url: /production/cp-deployment/zoneproxy-auth/
+          - text: Control plane configuration reference
+            url: /reference/kuma-cp
+            generate: false
+          - text: Systemd
+            url: /production/cp-deployment/systemd/
+          - text: Kubernetes
+            url: /production/cp-deployment/kubernetes/
+          - text: kumactl
+            url: /explore/cli
+      - text: Configuring your Mesh and multi-tenancy
+        url: /production/mesh/
+      - title: Data plane configuration
+        group: true
+        items:
+          - text: Data plane proxy
+            url: /production/dp-config/dpp/
+          - text: Configure the data plane on Kubernetes
+            url: /production/dp-config/dpp-on-kubernetes/
+          - text: Configure the data plane on Universal
+            url: /production/dp-config/dpp-on-universal/
+          - text: Configure the Kuma CNI
+            url: /production/dp-config/cni/
+          - text: Configure transparent proxying
+            url: /production/dp-config/transparent-proxying/
+          - text: IPv6 support
+            url: /production/dp-config/ipv6/
+      - title: Secure your deployment
+        group: true
+        items:
+          - text: Manage secrets
+            url: /production/secure-deployment/secrets/
+          - text: Kuma API access control
+            url: /production/secure-deployment/api-access-control/
+          - text: Authentication with the API server
+            url: /production/secure-deployment/api-server-auth/
+          - text: Authentication with the data plane proxy
+            url: /production/secure-deployment/dp-auth/
+          - text: Configure data plane proxy membership
+            url: /production/secure-deployment/dp-membership/
+          - text: Secure access accross services
+            url: /production/secure-deployment/certificates/
+      - text: Kuma user interface
+        url: /production/gui/
+      - text: Inspect API
+        url: /explore/inspect-api/
+        items:
+          - text: Matched policies
+            url: "/explore/inspect-api/#matched-policies"
+          - text: Affected data plane proxies
+            url: "/explore/inspect-api/#affected-data-plane-proxies"
+          - text: Envoy proxy configuration
+            url: "/explore/inspect-api/#envoy-proxy-configuration"
+      - title: Upgrades and tuning
+        group: true
+        items:
+          - text: Upgrade Kuma
+            url: /production/upgrades-tuning/upgrades/
+          - text: Performance fine-tuning
+            url: /production/upgrades-tuning/fine-tuning/
+          - text: Version specific upgrade notes
+            url: /production/upgrades-tuning/upgrade-notes/
+      - text: Control Plane Configuration
+        url: /documentation/configuration/
+        items:
+          - text: Modifying the configuration
+            url: /documentation/configuration/#modifying-the-configuration
+          - text: Inspecting the configuration
+            url: /documentation/configuration/#inspecting-the-configuration
+          - text: Store
+            url: /documentation/configuration/#store
+  - title: Using Kuma
+    group: true
+    items:
+      - title: Zero Trust & Application Security
+        group: true
+        items:
+          - text: Mutual TLS
+            url: /policies/mutual-tls/
+            items:
+              - text: Usage of "builtin" CA
+                url: "/policies/mutual-tls/#usage-of-builtin-ca"
+              - text: Usage of "provided" CA
+                url: "/policies/mutual-tls/#usage-of-provided-ca"
+              - text: Permissive mTLS
+                url: "/policies/mutual-tls/#permissive-mtls"
+              - text: Certificate Rotation
+                url: "/policies/mutual-tls/#certificate-rotation"
+          - text: External Service
+            url: /policies/external-services/
+            items:
+              - text: Usage
+                url: "/policies/external-services/#usage"
+              - text: Builtin Gateway support
+                url: "/policies/external-services/#builtin-gateway-support"
+      - title: Resiliency & Failover
+        group: true
+        items:
+        - text: Dataplane Health
+          url: /documentation/health/
+          items:
+            - text: MeshCircuitBreaker Policy
+              url: "/documentation/health/#meshcircuitbreaker-policy"
+            - text: Kubernetes and Universal Service Probes
+              url: "/documentation/health/#kubernetes-and-universal-service-probes"
+            - text: MeshHealthCheck Policy
+              url: "/documentation/health/#meshhealthcheck-policy"
+        - text: Service Health Probes
+          url: /policies/service-health-probes/
+          items:
+            - text: Kubernetes
+              url: "/policies/service-health-probes/#kubernetes"
+            - text: Universal probes
+              url: "/policies/service-health-probes/#universal-probes"
+      - title: Managing incoming traffic with gateways
+        group: true
+        items:
+          - text: How ingress works in Kuma
+            url: "/using-mesh/managing-ingress-traffic/overview/"
+          - text: Delegated gateways
+            url: "/using-mesh/managing-ingress-traffic/delegated/"
+          - text: Built-in gateways
+            url: "/using-mesh/managing-ingress-traffic/builtin/"
+          - text: Running built-in gateway pods on Kubernetes
+            url: "/using-mesh/managing-ingress-traffic/builtin-k8s/"
+          - text: Configuring built-in listeners
+            url: "/using-mesh/managing-ingress-traffic/builtin-listeners/"
+          - text: Configuring built-in routes
+            url: "/using-mesh/managing-ingress-traffic/builtin-routes/"
+          - text: Using the Kubernetes Gateway API
+            url: "/using-mesh/managing-ingress-traffic/gateway-api/"
+      - text: Observability
+        url: /explore/observability/
+        items:
+          - text: Demo setup
+            url: "/explore/observability/#demo-setup"
+          - text: Control plane metrics
+            url: "/explore/observability/#control-plane-observability"
+          - text: Configuring Prometheus
+            url: "/explore/observability/#configuring-prometheus"
+          - text: Configuring Grafana
+            url: "/explore/observability/#configuring-grafana"
+          - text: Configuring Datadog
+            url: "/explore/observability/#configuring-datadog"
+          - text: Observability in multi-zone
+            url: "/explore/observability/#observability-in-multi-zone"
+      - title: Route & Traffic shaping
+        group: true
+        items:
+          - text: Protocol support in Kuma
+            url: /policies/protocol-support-in-kuma/
+            items:
+              - text: HTTP/2 support
+                url: "/policies/protocol-support-in-kuma/#http2-support"
+              - text: TLS support
+                url: "/policies/protocol-support-in-kuma/#tls-support"
+              - text: Websocket support
+                url: "/policies/protocol-support-in-kuma/#websocket-support"
+      - title: Service Discovery & Networking
+        group: true
+        items:
+          - text: Service Discovery
+            url: /networking/service-discovery/
+          - text: MeshService
+            url: "/networking/meshservice/"
+          - text: HostnameGenerator
+            url: "/networking/hostnamegenerator/"
+          - text: DNS
+            url: /networking/dns/
+            items:
+              - text: How it works
+                url: "/networking/dns/#how-it-works"
+              - text: Installation
+                url: "/networking/dns/#installation"
+              - text: Configuration
+                url: "/networking/dns/#configuration"
+              - text: Usage
+                url: "/networking/dns/#usage"
+          - text: Non-mesh traffic
+            url: "/networking/non-mesh-traffic/"
+            items:
+              - text: Incoming
+                url: "/networking/non-mesh-traffic/#incoming"
+              - text: Outgoing
+                url: "/networking/non-mesh-traffic/#outgoing"
+          - text: MeshExternalService
+            url: /networking/meshexternalservice/
+            items:
+              - text: Configuration
+                url: "/networking/meshexternalservice/#configuration"
+              - text: Examples
+                url: "/networking/meshexternalservice/#examples"
+          - text: Transparent Proxying
+            url: /networking/transparent-proxying/
+  - title: Policies
+    group: true
+    items:
+      - text: Introduction
+        url: /policies/introduction/
+      - text: Applying Policies
+        url: /policies/applying-policies/
+      - text: Understanding TargetRef policies
+        url: "/policies/targetref"
+      - text: MeshAccessLog
+        url: /policies/meshaccesslog/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshaccesslog/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshaccesslog/#configuration"
+          - text: Examples
+            url: "/policies/meshaccesslog/#examples"
+      - text: MeshCircuitBreaker
+        url: /policies/meshcircuitbreaker/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshcircuitbreaker/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshcircuitbreaker/#configuration"
+          - text: Examples
+            url: "/policies/meshcircuitbreaker/#examples"
+      - text: MeshFaultInjection
+        url: /policies/meshfaultinjection/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshfaultinjection/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshfaultinjection/#configuration"
+          - text: Examples
+            url: "/policies/meshfaultinjection/#examples"
+      - text: MeshHealthCheck
+        url: /policies/meshhealthcheck/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshhealthcheck/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshhealthcheck/#configuration"
+          - text: Examples
+            url: "/policies/meshhealthcheck/#examples"
+      - text: MeshHTTPRoute
+        url: /policies/meshhttproute/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshhttproute/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshhttproute/#configuration"
+          - text: Examples
+            url: "/policies/meshhttproute/#examples"
+          - text: Merging
+            url: "/policies/meshhttproute/#merging"
+      - text: MeshMetric
+        url: /policies/meshmetric/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshmetric/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshmetric/#configuration"
+          - text: Prometheus
+            url: "/policies/meshmetric/#prometheus"
+          - text: OpenTelemetry
+            url: "/policies/meshmetric/#opentelemetry"
+          - text: Examples
+            url: "/policies/meshmetric/#examples"
+      - text: MeshProxyPatch
+        url: /policies/meshproxypatch/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshproxypatch/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshproxypatch/#configuration"
+          - text: Examples
+            url: "/policies/meshproxypatch/#examples"
+          - text: Merging
+            url: "/policies/meshproxypatch/#merging"
+      - text: MeshRateLimit
+        url: /policies/meshratelimit/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshratelimit/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshratelimit/#configuration"
+          - text: Examples
+            url: "/policies/meshratelimit/#examples"
+      - text: MeshRetry
+        url: /policies/meshretry/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshretry/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshretry/#configuration"
+          - text: Examples
+            url: "/policies/meshretry/#examples"
+      - text: MeshTCPRoute
+        url: /policies/meshtcproute/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshtcproute/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshtcproute/#configuration"
+          - text: Examples
+            url: "/policies/meshtcproute/#examples"
+          - text: Route policies with different types targeting the same destination
+            url: "/policies/meshtcproute/#route-policies-with-different-types-targeting-the-same-destination"
+      - text: MeshTimeout
+        url: /policies/meshtimeout/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshtimeout/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshtimeout/#configuration"
+          - text: Examples
+            url: "/policies/meshtimeout/#examples"
+      - text: MeshTrace
+        url: /policies/meshtrace/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshtrace/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshtrace/#configuration"
+          - text: Examples
+            url: "/policies/meshtrace/#examples"
+      - text: MeshTrafficPermission
+        url: /policies/meshtrafficpermission/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshtrafficpermission/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshtrafficpermission/#configuration"
+          - text: Examples
+            url: "/policies/meshtrafficpermission/#examples"
+      - text: MeshLoadBalancingStrategy
+        url: /policies/meshloadbalancingstrategy/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshloadbalancingstrategy/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshloadbalancingstrategy/#configuration"
+          - text: Examples
+            url: "/policies/meshloadbalancingstrategy/#examples"
+      - text: MeshPassthrough
+        url: /policies/meshpassthrough/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshpassthrough/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshpassthrough/#configuration"
+          - text: Examples
+            url: "/policies/meshpassthrough/#examples"
+      - title: Previous Policies
+        group: true
+        items:
+          - text: General notes about Kuma policies
+            url: /policies/general-notes-about-kuma-policies/
+          - text: How Kuma chooses the right policy to apply
+            url: /policies/how-kuma-chooses-the-right-policy-to-apply/
+          - text: Traffic Permissions
+            url: /policies/traffic-permissions/
+          - text: Traffic Route
+            url: /policies/traffic-route/
+          - text: Traffic Metrics
+            url: /policies/traffic-metrics/
+          - text: Traffic Trace
+            url: /policies/traffic-trace/
+          - text: Traffic Log
+            url: /policies/traffic-log/
+          - text: Locality-aware Load Balancing
+            url: /policies/locality-aware/
+          - text: Fault Injection
+            url: /policies/fault-injection/
+          - text: Health Check
+            url: /policies/health-check/
+          - text: Circuit Breaker
+            url: /policies/circuit-breaker/
+          - text: Retry
+            url: /policies/retry/
+          - text: Timeout
+            url: /policies/timeout/
+          - text: Rate Limit
+            url: /policies/rate-limit/
+          - text: Virtual Outbound
+            url: /policies/virtual-outbound/
+          - text: MeshGatewayRoute
+            url: /policies/meshgatewayroute/
+  - title: Guides
+    group: true
+    items:
+      - text: Federate zone control plane
+        url: /guides/federate/
+      - text: Add a builtin Gateway
+        url: /guides/gateway-builtin/
+      - text: Add Kong as a delegated Gateway
+        url: /guides/gateway-delegated/
+      - text: Collect Metrics with OpenTelemetry
+        url: /guides/otel-metrics/
+      - text: Migration to the new policies
+        url: /guides/migration-to-the-new-policies/
+  - title: Reference
+    group: true
+    items:
+      - text: HTTP API
+        url: /reference/http-api/
+      - text: Kubernetes annotations and labels
+        url: /reference/kubernetes-annotations/
+      - text: Kuma data collection
+        url: /reference/data-collection/
+      - text: Control plane configuration reference
+        url: /reference/kuma-cp
+      - text: Envoy proxy template
+        url: /reference/proxy-template/
+  - title: Community
+    group: true
+    items:
+      - text: License
+        url: /community/license/
+      - text: Contribute to Kuma
+        url: /community/contribute-to-kuma/
+unlisted:
+  - url: /


### PR DESCRIPTION
Adds navigation for `release-2.9.x` and fixes `404` on `/docs/2.9.x`.
Also fixes ci error in `Docs lint` due to [error: externally-managed-environment on ubuntu ubuntu-24.04](https://github.com/errata-ai/vale-action/issues/128) when installing `docutils`, by pin ubuntu to `22.04`.