### PR TITLE
chore(navbar): fix 2.9 navbar

### DIFF
--- a/app/_data/docs_nav_kuma_2.9.x.yml
+++ b/app/_data/docs_nav_kuma_2.9.x.yml
@@ -242,6 +242,8 @@ items:
             url: /networking/service-discovery/
           - text: MeshService
             url: "/networking/meshservice/"
+          - text: MeshMultiZoneService
+            url: "/networking/meshmultizoneservice/"
           - text: HostnameGenerator
             url: "/networking/hostnamegenerator/"
           - text: DNS
@@ -425,6 +427,15 @@ items:
             url: "/policies/meshpassthrough/#configuration"
           - text: Examples
             url: "/policies/meshpassthrough/#examples"
+      - text: MeshTLS
+        url: /policies/meshtls/
+        items:
+          - text: TargetRef support matrix
+            url: "/policies/meshpassthrough/#targetref-support-matrix"
+          - text: Configuration
+            url: "/policies/meshpassthrough/#configuration"
+          - text: Examples
+            url: "/policies/meshpassthrough/#examples"
       - title: Previous Policies
         group: true
         items:
@@ -473,6 +484,8 @@ items:
         url: /guides/otel-metrics/
       - text: Migration to the new policies
         url: /guides/migration-to-the-new-policies/
+      - text: Progressively rolling in strict MTLS
+        url: /guides/progressively-rolling-in-strict-mtls/
   - title: Reference
     group: true
     items:


### PR DESCRIPTION
I think mistakenly the 2.9 navbar was copied from 2.8 and not dev

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
