### PR TITLE
ci(vale): fix reporter, only annotate errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,8 @@ jobs:
         name: Run Vale
         with:
           files: "${{ steps.changed-files.outputs.result }}"
-          reporter: github-pr-review
+          reporter: github-pr-check
           reviewdog_url: https://github.com/reviewdog/reviewdog/releases/download/v0.18.1/reviewdog_0.18.1_Linux_x86_64.tar.gz
+          fail_on_error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,6 +1,6 @@
 StylesPath = .github/styles
 
-MinAlertLevel = suggestion
+MinAlertLevel = error
 Vocab = Base
 
 Packages = Google


### PR DESCRIPTION
This will only show errors as annotations on the diff.

We are currently not showing anything from Vale. This will show errors. For example, rejected word errors