### PR TITLE
fix(quickstart): don't use MeshService in spec.targetRef

### DIFF
--- a/app/_src/quickstart/kubernetes-demo.md
+++ b/app/_src/quickstart/kubernetes-demo.md
@@ -172,8 +172,9 @@ metadata:
   name: redis
 spec:
   targetRef:
-    kind: MeshService
-    name: redis_kuma-demo_svc_6379
+    kind: MeshSubset
+    tags:
+      kuma.io/service: redis_kuma-demo_svc_6379
   from:
     - targetRef:
         kind: MeshSubset


### PR DESCRIPTION
From 2.9 this is deprecated so let's avoid having a quickstart guide with deprecated examples...