### PR TITLE
ci(vale): ignore mermaid blocks

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -9,7 +9,8 @@ SkippedScopes = code
 [*.md]
 BasedOnStyles = Vale, Google
 BlockIgnores = (\((http.*://|\.\/|\/).*?\)), \
-{\:.*?}
+{\:.*?}, \
+(?s)({% mermaid %}.*?{% endmermaid %})
 TokenIgnores = {%.*?%}, \
 {{.*?}}, \
 (?:)(/[(A-Za-z0-9)(\055/)(_)]*/), \


### PR DESCRIPTION
Ideally we'd check _some_ of the contents but there's too much noise since Vale doesn't natively understand it.