### PR TITLE
fix(gateway): don't use MeshGateway tags that cannot be referenced from Mesh*Route

### DIFF
--- a/app/_src/explore/gateway.md
+++ b/app/_src/explore/gateway.md
@@ -315,7 +315,7 @@ spec:
         protocol: HTTP
         hostname: foo.example.com
         tags:
-          port: http/8080
+          port: http-8080
 " | kubectl apply -f -
 ```
 
@@ -335,7 +335,7 @@ conf:
       protocol: HTTP
       hostname: foo.example.com
       tags:
-        port: http/8080
+        port: http-8080
 ```
 
 {% endtab %}
@@ -367,7 +367,7 @@ spec:
   selectors:
     - match:
         kuma.io/service: edge-gateway
-        port: http/8080
+        port: http-8080
   conf:
     http:
       rules:
@@ -391,7 +391,7 @@ name: edge-gateway-route
 selectors:
   - match:
       kuma.io/service: edge-gateway
-      port: http/8080
+      port: http-8080
 conf:
   http:
     rules:

--- a/app/_src/guides/gateway-builtin.md
+++ b/app/_src/guides/gateway-builtin.md
@@ -79,7 +79,7 @@ spec:
       - port: 8080
         protocol: HTTP
         tags:
-          port: http/8080
+          port: http-8080
 " | kubectl apply -f -
 ```
 
@@ -291,7 +291,7 @@ spec:
           certificates:
             - secret: my-gateway-certificate
         tags:
-          port: http/8080
+          port: http-8080
 " | kubectl apply -f -
 ```
 

--- a/app/_src/policies/meshgateway.md
+++ b/app/_src/policies/meshgateway.md
@@ -32,7 +32,7 @@ conf:
     protocol: HTTP
     hostname: foo.example.com
     tags:
-      port: http/8080 
+      port: http-8080 
 ```
 {% endtab %}
 {% tab usage Kubernetes %}
@@ -52,7 +52,7 @@ spec:
       protocol: HTTP
       hostname: foo.example.com
       tags:
-        port: http/8080 
+        port: http-8080 
 ```
 {% endtab %}
 {% endtabs %}

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
@@ -82,7 +82,7 @@ spec:
       - port: 8080
         protocol: HTTP
         tags:
-          port: http/8080
+          port: http-8080
 ```
 
 {% endtab %}
@@ -100,7 +100,7 @@ conf:
     - port: 8080
       protocol: HTTP
       tags:
-        port: http/8080
+        port: http-8080
 ```
 
 {% endtab %}
@@ -133,7 +133,7 @@ spec:
         protocol: HTTP
         hostname: foo.example.com
         tags:
-          port: http/8080
+          port: http-8080
 ```
 
 {% endtab %}
@@ -152,7 +152,7 @@ conf:
       protocol: HTTP
       hostname: foo.example.com
       tags:
-        port: http/8080
+        port: http-8080
 ```
 
 {% endtab %}

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-routes.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-routes.md
@@ -25,7 +25,7 @@ spec:
     kind: MeshGateway
     name: edge-gateway
     tags: # optional, for selecting specific listeners
-      port: http/8080
+      port: http-8080
   to:
     - targetRef:
         kind: Mesh


### PR DESCRIPTION
Fixes: #1810

We will improve validation in next release to so that won't be able to shoot themselves in the foot: https://github.com/kumahq/kuma/issues/11806

