### PR TITLE
ci(vale): enforce heading capitalization

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -15,3 +15,4 @@ TokenIgnores = {%.*?%}, \
 {{.*?}}, \
 (?:)(/[(A-Za-z0-9)(\055/)(_)]*/), \
 ({\#.*})
+Google.Headings = error


### PR DESCRIPTION
This way we'll get an error when the capitalization in a heading is wonky