### PR TITLE
fix(policies): mesh access log target ref table

### DIFF
--- a/app/_src/policies/meshaccesslog.md
+++ b/app/_src/policies/meshaccesslog.md
@@ -19,18 +19,11 @@ If you haven't, see the [observability docs](/docs/{{ page.version }}/explore/ob
 {% if_version gte:2.4.x %}
 {% tabs targetRef useUrlFragment=false %}
 {% tab targetRef Sidecar %}
-{% if_version gte:2.9.x %}
-| `targetRef`             | Allowed kinds                                            |
-| ----------------------- | -------------------------------------------------------- |
-| `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
-| `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService`             |
-| `from[].targetRef.kind` | `Mesh`                                                   |
-{% endif_version %}
 {% if_version gte:2.4.x %}
 | `targetRef`             | Allowed kinds                                            |
 | ----------------------- | -------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
-| `to[].targetRef.kind`   | `Mesh`, `MeshService`                                    |
+| `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService`(since 2.9.x)|
 | `from[].targetRef.kind` | `Mesh`                                                   |
 {% endif_version %}
 {% endtab %}
@@ -53,17 +46,11 @@ If you haven't, see the [observability docs](/docs/{{ page.version }}/explore/ob
 
 {% if_version gte:2.6.x %}
 {% tab targetRef Delegated Gateway %}
-{% if_version gte:2.9.x %}
-| `targetRef`             | Allowed kinds                                            |
-| ----------------------- | -------------------------------------------------------- |
-| `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
-| `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService`             |
-{% endif_version %}
 {% if_version gte:2.6.x %}
 | `targetRef`             | Allowed kinds                                            |
 | ----------------------- | -------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
-| `to[].targetRef.kind`   | `Mesh`, `MeshService`                                    |
+| `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService`(since 2.9.x)|
 {% endif_version %}
 {% endtab %}
 {% endif_version %}


### PR DESCRIPTION
The table was broken because there is gte:2.9.x and gte:2.4.x so it renders two tables (as one)

Maybe we can do some double nesting but I think better option is just to add small annotation on all versions

Fix https://github.com/kumahq/kuma-website/issues/1917