### PR TITLE
docs(policies): add navbar to introduction

### DIFF
--- a/app/_data/docs_nav_kuma_2.9.x.yml
+++ b/app/_data/docs_nav_kuma_2.9.x.yml
@@ -280,6 +280,21 @@ items:
     items:
       - text: Introduction
         url: /policies/introduction/
+        items:
+          - text: What is a policy?
+            url: "/policies/introduction/#what-is-a-policy"
+          - text: What do policies look like?
+            url: "/policies/introduction/#what-do-policies-look-like"
+          - text: Writing a targetRef
+            url: "/policies/introduction/#writing-a-targetref"
+          - text: Merging configuration
+            url: "/policies/introduction/#merging-configuration"
+          - text: Using policies with MeshService
+            url: "/policies/introduction/#using-policies-with-meshservice-meshmultizoneservice-and-meshexternalservice"
+          - text: Examples
+            url: "/policies/introduction/#examples"
+          - text: Applying policies in shadow mode
+            url: "/policies/introduction/#applying-policies-in-shadow-mode"
       - text: MeshAccessLog
         url: /policies/meshaccesslog/
         items:

--- a/app/_data/docs_nav_kuma_dev.yml
+++ b/app/_data/docs_nav_kuma_dev.yml
@@ -280,6 +280,21 @@ items:
     items:
       - text: Introduction
         url: /policies/introduction/
+        items:
+          - text: What is a policy?
+            url: "/policies/introduction/#what-is-a-policy"
+          - text: What do policies look like?
+            url: "/policies/introduction/#what-do-policies-look-like"
+          - text: Writing a targetRef
+            url: "/policies/introduction/#writing-a-targetref"
+          - text: Merging configuration
+            url: "/policies/introduction/#merging-configuration"
+          - text: Using policies with MeshService
+            url: "/policies/introduction/#using-policies-with-meshservice-meshmultizoneservice-and-meshexternalservice"
+          - text: Examples
+            url: "/policies/introduction/#examples"
+          - text: Applying policies in shadow mode
+            url: "/policies/introduction/#applying-policies-in-shadow-mode"
       - text: MeshAccessLog
         url: /policies/meshaccesslog/
         items:

--- a/app/_src/policies/introduction.md
+++ b/app/_src/policies/introduction.md
@@ -206,8 +206,8 @@ When a `targetRef` is not present, it is semantically equivalent to `targetRef.k
 
 ### Applying to specific proxy types
 The top level `targetRef` field can select a specific subset of data plane proxies. The field named `proxyTypes` can restrict policies to specific types of data plane proxies:
-- `Sidecar`: Targets data plane proxies acting as sidecars to applications (including provided Gateway).
-- `Gateway`: Applies to data plane proxies operating in built-in Gateway mode.
+- `Sidecar`: Targets data plane proxies acting as sidecars to applications (including [delegated gateways](/docs/{{ page.version }}/using-mesh/managing-ingress-traffic/delegated/)).
+- `Gateway`: Applies to data plane proxies operating in [built-in Gateway](/docs/{{ page.version }}/using-mesh/managing-ingress-traffic/builtin/) mode.
 - Empty list: Defaults to targeting all data plane proxies.
 
 #### Example

--- a/app/_src/policies/introduction.md
+++ b/app/_src/policies/introduction.md
@@ -206,8 +206,8 @@ When a `targetRef` is not present, it is semantically equivalent to `targetRef.k
 
 ### Applying to specific proxy types
 The top level `targetRef` field can select a specific subset of data plane proxies. The field named `proxyTypes` can restrict policies to specific types of data plane proxies:
-- `Sidecar`: Targets data plane proxies acting as sidecars to applications.
-- `Gateway`: Applies to data plane proxies operating in Gateway mode.
+- `Sidecar`: Targets data plane proxies acting as sidecars to applications (including provided Gateway).
+- `Gateway`: Applies to data plane proxies operating in built-in Gateway mode.
 - Empty list: Defaults to targeting all data plane proxies.
 
 #### Example
@@ -234,14 +234,13 @@ spec:
 
 Given a MeshGateway:
 
-{% policy_yaml meshgatewayex %}
 ```yaml
-type: MeshGateway
+apiVersion: kuma.io/v1alpha1
+kind: MeshGateway
 mesh: default
-name: edge
-selectors:
-- match:
-    kuma.io/service: edge-gateway
+metadata:
+  name: edge
+  namespace: kuma-system
 conf:
   listeners:
   - port: 80
@@ -253,7 +252,6 @@ conf:
     tags:
       port: https-443
 ```
-{% endpolicy_yaml %}
 
 Policies can attach to all listeners:
 


### PR DESCRIPTION
Navbar was missing and the page is super long. Navbar in this case improves navigation.
Also two small nits:
* policy_yaml does not work with old policies (MeshGateway is considered old in this case, because it does not have spec)
* Add more clarification to Sidecar / Gateway selector
