### PR TITLE
docs(migration): add gateway setup

### DIFF
--- a/app/_src/guides/migration-to-the-new-policies.md
+++ b/app/_src/guides/migration-to-the-new-policies.md
@@ -453,8 +453,7 @@ Always refer to the spec to ensure your new resource is valid.
 
 Note that `MeshHTTPRoute` has precedence over `MeshGatewayRoute`.
 
-In the next sections we're going to assume we have the `MeshGateway` and
-`MeshGatewayInstance`:
+Let's deploy the following `MeshGateway` and `MeshGatewayInstance`:
 
 ```sh
 echo "---

--- a/app/_src/guides/migration-to-the-new-policies.md
+++ b/app/_src/guides/migration-to-the-new-policies.md
@@ -525,8 +525,8 @@ So in our example:
 spec:
   selectors:
     - match:
-        kuma.io/service: edge-gateway
-        vhost: foo.example.com
+        kuma.io/service: demo-app-gateway_kuma-demo_svc
+        port: http-80
 ```
 
 becomes:
@@ -535,13 +535,14 @@ becomes:
 spec:
   targetRef:
     kind: MeshGateway
-    name: edge
+    name: demo-app
     tags:
-      vhost: foo.example.com
+      port: http-80
   to:
 ```
 
-because we're now using the _name_ of the `MeshGateway` instead of its `kuma.io/service`.
+because we're now using the _name_ of the `MeshGateway`
+instead of the `kuma.io/service` it matches.
 
 #### Spec
 

--- a/app/_src/guides/migration-to-the-new-policies.md
+++ b/app/_src/guides/migration-to-the-new-policies.md
@@ -500,6 +500,8 @@ metadata:
 spec:
   conf:
    http:
+    hostnames:
+    - example.com
     rules:
     - matches:
       - path:
@@ -560,13 +562,10 @@ Note that for `MeshHTTPRoute` the `hostnames` are directly under the `to` entry:
     http:
       hostnames:
         - example.com
-      rules:
-        - matches:
-            - path:
-                match: PREFIX
-                value: /
-          # ...
+      # ...
 ```
+
+becomes:
 
 ```yaml
   to:
@@ -574,13 +573,7 @@ Note that for `MeshHTTPRoute` the `hostnames` are directly under the `to` entry:
         kind: Mesh
       hostnames:
         - example.com
-      rules:
-        - matches:
-            - path:
-                match: PathPrefix
-                value: /
-          default:
-            # ...
+      # ...
 ```
 
 ##### Matching
@@ -588,12 +581,12 @@ Note that for `MeshHTTPRoute` the `hostnames` are directly under the `to` entry:
 Matching works the same as before. Remember that for `MeshHTTPRoute` that merging is done on a match
 basis. So it's possible for one route to define `filters` and another
 `backendRefs` for a given match, and the resulting rule would both apply the filters and route to the
-backends:
+backends.
+
+Given two routes, one with:
 
 ```yaml
   to:
-    - targetRef:
-        kind: Mesh
       rules:
         - matches:
             - path:
@@ -608,14 +601,10 @@ backends:
                       value: xyz
 ```
 
-becomes
+and the other:
 
 ```yaml
   to:
-    - targetRef:
-        kind: Mesh
-      hostnames:
-        - example.com
       rules:
         - matches:
             - path:
@@ -629,8 +618,8 @@ becomes
                   version: v0
 ```
 
-Traffic to `/` would have the `x-custom-header` added and be sent to the `v0`
-versions of `backend_kuma-demo_svc_3001`.
+traffic to `/` would have the `x-custom-header` added and be sent to the
+`version: v0` tagged instances of `backend_kuma-demo_svc_3001`.
 
 ##### Filters
 
@@ -665,6 +654,8 @@ So all in all we have:
      to:
      - targetRef:
          kind: Mesh
+       hostnames:
+         - example.com
        rules:
        - default:
            backendRefs:

--- a/app/_src/guides/migration-to-the-new-policies.md
+++ b/app/_src/guides/migration-to-the-new-policies.md
@@ -453,7 +453,11 @@ Always refer to the spec to ensure your new resource is valid.
 
 Note that `MeshHTTPRoute` has precedence over `MeshGatewayRoute`.
 
-Let's deploy the following `MeshGateway` and `MeshGatewayInstance`:
+We're going to start with a gateway and simple legacy `MeshGatewayRoute`,
+look at how to migrate `MeshGatewayRoutes` in general
+and then finish with migrating our example `MeshGatewayRoute`.
+
+Let's start with the following `MeshGateway` and `MeshGatewayInstance`:
 
 ```sh
 echo "---


### PR DESCRIPTION
Part of https://github.com/kumahq/kuma-website/issues/1961

[Rendered](https://deploy-preview-2016--kuma.netlify.app/docs/2.9.x/guides/migration-to-the-new-policies/#meshgatewayroute---meshhttproutemeshtcproute)