### PR TITLE
fix(features): change link for requesting features to kuma repo as we store feature requests there

### DIFF
--- a/app/_layouts/features.html
+++ b/app/_layouts/features.html
@@ -40,7 +40,7 @@ layout: default
         <div>
             <center>
                 Would you like to submit or request a new feature? Please open an issue at the <a
-                    href="https://github.com/kumahq/kuma-website">kuma-website</a> repository.
+                    href="https://github.com/kumahq/kuma/issues">Kuma repository</a>.
             </center>
         </div>
     </div>


### PR DESCRIPTION
It does not make sense to point people with request feature to add them on docs instead on main Kuma repo