### PR TITLE
fix(features): add new kuma install guide and link it across project

### DIFF
--- a/app/_data/docs_nav_kuma_2.9.x.yml
+++ b/app/_data/docs_nav_kuma_2.9.x.yml
@@ -19,6 +19,8 @@ items:
             url: "/introduction/how-kuma-works/#kuma-vs-xyz"
       - text: Architecture
         url: /introduction/architecture/
+      - text: Install Kuma
+        url: /introduction/install-kuma/
       - text: Concepts
         url: /introduction/concepts/
       - text: Kuma requirements
@@ -63,8 +65,6 @@ items:
             url: /production/deployment/single-zone/
           - text: Multi-zone deployment
             url: /production/deployment/multi-zone/
-      - text: Install kumactl
-        url: /production/install-kumactl/
       - text: Use Kuma
         url: /production/use-mesh/
       - title: Control plane deployment

--- a/app/_data/docs_nav_kuma_dev.yml
+++ b/app/_data/docs_nav_kuma_dev.yml
@@ -19,6 +19,8 @@ items:
             url: "/introduction/how-kuma-works/#kuma-vs-xyz"
       - text: Architecture
         url: /introduction/architecture/
+      - text: Install Kuma
+        url: /introduction/install-kuma/
       - text: Concepts
         url: /introduction/concepts/
       - text: Kuma requirements
@@ -63,8 +65,6 @@ items:
             url: /production/deployment/single-zone/
           - text: Multi-zone deployment
             url: /production/deployment/multi-zone/
-      - text: Install kumactl
-        url: /production/install-kumactl/
       - text: Use Kuma
         url: /production/use-mesh/
       - title: Control plane deployment

--- a/app/_src/guides/federate.md
+++ b/app/_src/guides/federate.md
@@ -11,7 +11,12 @@ This way you can:
 
 ## Prerequisites
 - Completed [quickstart](/docs/{{ page.version }}/quickstart/kubernetes-demo/) to set up a zone control plane with demo application
+{% if_version lte:2.8.x %}
 - Have [kumactl installed and in your path](/docs/{{ page.version }}/production/install-kumactl)
+{% endif_version %}
+{% if_version gte:2.9.x %}
+- Have [kumactl installed and in your path](/docs/{{ page.version }}/introduction/install-kuma/)
+{% endif_version %}
 
 ## Start a global control plane
 

--- a/app/_src/index.md
+++ b/app/_src/index.md
@@ -32,7 +32,12 @@ The core maintainer of Kuma is **Kong**, the maker of the popular open-source Ko
 
 [Read about Kuma](/docs/{{ page.version }}/introduction/overview-of-kuma)
 
+{% if_version lte:2.8.x %}
 [Install Kuma](/install/latest/)
+{% endif_version %}
+{% if_version gte:2.9.x %}
+[Install Kuma](/docs/{{ page.version }}/introduction/install-kuma)
+{% endif_version %}
 
 {% if_version gte:2.6.x %}[Jump to quickstart](/docs/{{ page.version }}/quickstart/kubernetes-demo/){% endif_version %}{% if_version lte:2.5.x %}[Jump to quickstart](/docs/{{ page.version }}/quickstart/kubernetes/){% endif_version %}
 

--- a/app/_src/introduction/how-kuma-works.md
+++ b/app/_src/introduction/how-kuma-works.md
@@ -72,7 +72,12 @@ Out of the box, {{site.mesh_product_name}} ships with a bundled [Envoy](https://
 {{site.mesh_product_name}} ships with an executable `kuma-dp` that executes the bundled `envoy` executable to create the data plane proxy. For details, see the {%if_version lte:2.1.x %}[Overview](/docs/{{ page.version }}/introduction/what-is-kuma){%endif_version%}{%if_version gte:2.2.x %}[Overview](/docs/{{ page.version }}/introduction/overview-of-kuma){%endif_version%}.
 {% endtip %}
 
+{% if_version lte:2.8.x %}
 [Install {{site.mesh_product_name}}](/install/) and follow the instructions to get up and running in a few steps.
+{% endif_version %}
+{% if_version gte:2.9.x %}
+[Install {{site.mesh_product_name}}](/docs/{{ page.version }}/introduction/install-kuma/) and follow the instructions to get up and running in a few steps.
+{% endif_version %}
 
 ## VM and K8s support
 
@@ -88,7 +93,7 @@ In reality, we want Service Mesh to be available *before* we implement other tra
 
 Unlike other control planes, {{site.mesh_product_name}} natively runs across every platform - Kubernetes, VMs and Bare Metal - and it's not limited in scope (like many other control planes that only work on Kubernetes only). {{site.mesh_product_name}} can run on both existing brownfield applications (that are most likely running on VMs), as well as new and modern greenfield applications that may be running on containers and Kubernetes.
 
-Unlike other control planes, {{site.mesh_product_name}} is easy to use. Anybody - from any team - can implement {{site.mesh_product_name}} in [three simple steps](/install/) across both traditional monolithic applications and modern microservices.
+Unlike other control planes, {{site.mesh_product_name}} is easy to use. Anybody - from any team - can [set up {{site.mesh_product_name}}](/install/) across both traditional monolithic applications and modern microservices.
 
 Finally, by leveraging out-of-the-box policies and {{site.mesh_product_name}}'s powerful tagging selectors, we can implement a variety of behaviors in a variety of topologies, similar to multi-cloud and multi-region architectures.
 

--- a/app/_src/introduction/install-kuma.md
+++ b/app/_src/introduction/install-kuma.md
@@ -1,0 +1,35 @@
+---
+title: Install Kuma
+content_type: how-to
+---
+
+{% tip %}
+This guide is mostly useful for Universal setup, as for Kubernetes we recommend using `kubectl` for managing [resources](/docs/{{ page.version }}/introduction/concepts#resource).
+More in [Kubernetes quickstart guide](/docs/{{ page.version }}/quickstart/kubernetes-demo/).
+{% endtip %}
+
+This is simple guide on how to install {{site.mesh_product_name}} on your machine.
+
+1. Go to the [{{site.mesh_product_name}} packages](https://cloudsmith.io/~kong/repos/{{site.mesh_product_name_path}}-binaries-release/packages/?q=version%3A{{ page.version_data.version }}) 
+page to download and extract the installation archive for your OS, or download and extract the latest release automatically (Linux or macOS):
+```shell
+curl -L {{site.links.web}}{% if page.edition %}/{{page.edition}}{% endif %}/installer.sh | VERSION={{ page.version_data.version }} sh -
+```
+2. To finish installation, add {{site.mesh_product_name}} binaries to path:
+```shell
+export PATH=$PATH:$(pwd)/{{site.mesh_product_name_path}}-{{ page.version_data.version }}/bin
+```
+This directory contains binaries for `kuma-dp`, `kuma-cp`, `kumactl`, `envoy` and `coredns`
+
+{% tip %}
+If you only need `kumactl` on macOS you can install it via `brew install kumactl`.
+{% endtip %}
+
+
+## Next steps
+{% if_version gte:2.6.x %}
+* [Complete quickstart](/docs/{{ page.version }}/quickstart/universal-demo/) to set up a zone control plane with demo application
+{% endif_version %}
+{% if_version lte:2.5.x %}
+After you've installed `kumactl`, you can deploy {{site.mesh_product_name}} in standalone or multi-zone mode in either Kubernetes or Universal.
+{% endif_version %}

--- a/app/_src/production/dp-config/cni.md
+++ b/app/_src/production/dp-config/cni.md
@@ -19,8 +19,9 @@ writes executables to the host filesystem as `root`.
 {% endtip %}
 
 Install the CNI using either
-{% if_version lte:2.1.x %}[`kumactl`](/docs/{{ page.version }}/installation/kubernetes) or [Helm](/docs/{{ page.version }}/installation/helm){% endif_version %}
-{% if_version gte:2.2.x %}[`kumactl`](/docs/{{ page.version }}/production/install-kumactl/) or [Helm](/docs/{{ page.version }}/production/install-kumactl/){% endif_version %}.
+{% if_version lte:2.1.x %}[kumactl](/docs/{{ page.version }}/installation/kubernetes) or [Helm](/docs/{{ page.version }}/installation/helm){% endif_version %}
+{% if_version gte:2.2.x %}{% if_version lte:2.8.x %}[kumactl](/docs/{{ page.version }}/production/install-kumactl/) or [Helm]https://helm.sh/){% endif_version %}{% endif_version %}
+{% if_version gte:2.9.x %}[kumactl](/docs/{{ page.version }}/introduction/install-kuma/) or [Helm](https://helm.sh/){% endif_version %}.
 The default settings are tuned for OpenShift with Multus.
 To use it in other environments, set the relevant configuration parameters.
 

--- a/app/_src/production/index.md
+++ b/app/_src/production/index.md
@@ -36,7 +36,8 @@ The following table describes some common use cases and the deployment modes you
 
 ### kumactl
 
-The first step after you pick your deployment mode is to [install `kumactl`](/docs/{{ page.version }}/production/install-kumactl/). `kumactl` is a CLI tool that you can use to access {{site.mesh_product_name}}. It can do the following:
+The first step after you pick your deployment mode is to {% if_version lte:2.8.x %}[install `kumactl`](/docs/{{ page.version }}/production/install-kumactl/){% endif_version %}{% if_version gte:2.9.x %}[install `kumactl`](/docs/{{ page.version }}/introduction/install-kuma/){% endif_version %}. 
+`kumactl` is a CLI tool that you can use to access {{site.mesh_product_name}}. It can do the following:
 
 * Perform read-only operations on {{site.mesh_product_name}} resources on Kubernetes.
 * Read and create resources in {{site.mesh_product_name}} in Universal mode.

--- a/app/_src/production/use-mesh.md
+++ b/app/_src/production/use-mesh.md
@@ -4,13 +4,26 @@ title: Use Kuma
 
 After {{site.mesh_product_name}} is installed, you can access the control plane via the following methods:
 
+
+{% if_version lte:2.8.x %}
 | Access method | Mode | Permissions |
 | ---- | ---- | ----- |
 | [{{site.mesh_product_name}} GUI](/docs/{{ page.version }}/production/gui/) | Kubernetes and Universal | Read-only |
 | HTTP API | Kubernetes and Universal | Read-only |
-| [`kumactl`](/docs/{{ page.version }}/production/install-kumactl/) | Kubernetes | Read-only |
-| [`kumactl`](/docs/{{ page.version }}/production/install-kumactl/) | Universal | Read and write |
+| [kumactl](/docs/{{ page.version }}/production/install-kumactl/) | Kubernetes | Read-only |
+| [kumactl](/docs/{{ page.version }}/production/install-kumactl/) | Universal | Read and write |
 | `kubectl` | Kubernetes | Read and write |
+{% endif_version %}
+{% if_version gte:2.9.x %}
+| Access method | Mode | Permissions |
+| ---- | ---- | ----- |
+| [{{site.mesh_product_name}} GUI](/docs/{{ page.version }}/production/gui/) | Kubernetes and Universal | Read-only |
+| HTTP API | Kubernetes and Universal | Read-only |
+| [kumactl](/docs/{{ page.version }}/introduction/install-kuma/) | Kubernetes | Read-only |
+| [kumactl](/docs/{{ page.version }}/introduction/install-kuma/) | Universal | Read and write |
+| `kubectl` | Kubernetes | Read and write |
+{% endif_version %}
+
 
 By accessing the control plane using one of these methods, you can see the current {{site.mesh_product_name}} configuration or with some methods, you can edit the configuration.
 

--- a/app/index.md
+++ b/app/index.md
@@ -91,7 +91,7 @@ Built for the enterprise, Kuma ships with the most scalable multi-zone connectiv
 
 {% contentfor tab-kubernetes %}
 
-[Install Kuma](/install/) via an available distribution:
+[Install Kuma](/docs/latest/introduction/install-kuma) via an available distribution:
 
 ```sh
 kumactl install control-plane \
@@ -112,7 +112,7 @@ Navigate to [127.0.0.1:5681/gui](http://127.0.0.1:5681/gui) to see the GUI.
 {% contentfor tab-openshift %}
 
 
-[Install Kuma](/install/) via an available distribution:
+[Install Kuma](/docs/latest/introduction/install-kuma) via an available distribution:
 
 ```sh
 kumactl install control-plane \
@@ -132,7 +132,7 @@ Navigate to [127.0.0.1:5681/gui](http://127.0.0.1:5681/gui) to see the GUI.
 
 {% contentfor tab-universal %}
 
-[Install Kuma](/install/) via an available distribution:
+[Install Kuma](/docs/latest/introduction/install-kuma) via an available distribution:
 
 ```sh
 kuma-cp run


### PR DESCRIPTION
I've rewritten and simplified our installation guide. I've put in an `introduction` section so it should be easier to find for new users, also I've linked it across the project.