### PR TITLE
feat(mal): fix support matrix for MeshAccessLog policy

### DIFF
--- a/app/_src/policies/meshaccesslog.md
+++ b/app/_src/policies/meshaccesslog.md
@@ -20,10 +20,19 @@ If you haven't, see the [observability docs](/docs/{{ page.version }}/explore/ob
 {% tabs targetRef useUrlFragment=false %}
 {% tab targetRef Sidecar %}
 {% if_version gte:2.4.x %}
+{% if_version lte:2.8.x %}
 | `targetRef`             | Allowed kinds                                            |
 | ----------------------- | -------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
-| `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService`(since 2.9.x)|
+| `to[].targetRef.kind`   | `Mesh`, `MeshService`                                    |
+| `from[].targetRef.kind` | `Mesh`                                                   |
+{% endif_version %}
+{% endif_version %}
+{% if_version gte:2.9.x %}
+| `targetRef`             | Allowed kinds                                            |
+| ----------------------- | -------------------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshServiceSubset`                |
+| `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService`             |
 | `from[].targetRef.kind` | `Mesh`                                                   |
 {% endif_version %}
 {% endtab %}
@@ -47,10 +56,18 @@ If you haven't, see the [observability docs](/docs/{{ page.version }}/explore/ob
 {% if_version gte:2.6.x %}
 {% tab targetRef Delegated Gateway %}
 {% if_version gte:2.6.x %}
+{% if_version lte:2.8.x %}
 | `targetRef`             | Allowed kinds                                            |
 | ----------------------- | -------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
-| `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService`(since 2.9.x)|
+| `to[].targetRef.kind`   | `Mesh`, `MeshService`                                    |
+{% endif_version %}
+{% endif_version %}
+{% if_version gte:2.9.x %}
+| `targetRef`             | Allowed kinds                                            |
+| ----------------------- | -------------------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `MeshSubset`                                     |
+| `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService`             |
 {% endif_version %}
 {% endtab %}
 {% endif_version %}

--- a/app/_src/policies/meshaccesslog.md
+++ b/app/_src/policies/meshaccesslog.md
@@ -712,10 +712,10 @@ spec:
               endpoint: otel-collector:4317
               body:
                 kvlistValue:
-                values:
-                  - key: "mesh"
-                    value:
-                      stringValue: "%KUMA_MESH%"
+                  values:
+                    - key: "mesh"
+                      value:
+                        stringValue: "%KUMA_MESH%"
               attributes:
                 - key: "start_time"
                   value: "%START_TIME%"
@@ -757,10 +757,10 @@ spec:
               endpoint: otel-collector:4317
               body:
                 kvlistValue:
-                values:
-                  - key: "mesh"
-                    value:
-                      stringValue: "%KUMA_MESH%"
+                  values:
+                    - key: "mesh"
+                      value:
+                        stringValue: "%KUMA_MESH%"
               attributes:
                 - key: "start_time"
                   value: "%START_TIME%"


### PR DESCRIPTION
We've deprecated `MeshService` from topLevel targetRef in 2.9.x. We should remove it from policy support matrix to not encourage users to use it.
