### PR TITLE
feat(mfi): fix support matrix for MeshFaultInjection policy

### DIFF
--- a/app/_src/policies/meshfaultinjection.md
+++ b/app/_src/policies/meshfaultinjection.md
@@ -14,10 +14,18 @@ Do **not** combine with [FaultInjection](/docs/{{ page.version }}/policies/fault
 {% if_version gte:2.7.x %}
 {% tabs targetRef27x useUrlFragment=false %}
 {% tab targetRef27x Sidecar %}
+{% if_version lte:2.8.x %}
 | `targetRef`             | Allowed kinds                                            |
 | ----------------------- | -------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
-| `from[].targetRef.kind` | `Mesh`, `MeshSubset`, `MeshServiceSubset` |
+| `from[].targetRef.kind` | `Mesh`, `MeshSubset`, `MeshServiceSubset`                |
+{% endif_version %}
+{% if_version gte:2.9.x %}
+| `targetRef`             | Allowed kinds                                            |
+| ----------------------- | -------------------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `MeshSubset`                                     |
+| `from[].targetRef.kind` | `Mesh`, `MeshSubset`, `MeshServiceSubset`                |
+{% endif_version %}
 {% endtab %}
 
 {% tab targetRef27x Builtin Gateway %}


### PR DESCRIPTION
We've deprecated `MeshService` from topLevel targetRef in 2.9.x. We should remove it from policy support matrix to not encourage users to use it.