### PR TITLE
feat(mlbs): fix support matrix for MeshLoadBalancingStrategy policy

### DIFF
--- a/app/_src/policies/meshloadbalancingstrategy.md
+++ b/app/_src/policies/meshloadbalancingstrategy.md
@@ -14,10 +14,18 @@ When using this policy, the [localityAwareLoadBalancing](/docs/{{ page.version }
 {% if_version gte:2.6.x %}
 {% tabs targetRef useUrlFragment=false %}
 {% tab targetRef Sidecar %}
+{% if_version lte:2.8.x %}
 | `targetRef`           | Allowed kinds                                            |
 | --------------------- | -------------------------------------------------------- |
 | `targetRef.kind`      | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
 | `to[].targetRef.kind` | `Mesh`, `MeshService`                                    |
+{% endif_version %}
+{% if_version gte:2.9.x %}
+| `targetRef`           | Allowed kinds                                            |
+| --------------------- | -------------------------------------------------------- |
+| `targetRef.kind`      | `Mesh`, `MeshSubset`                                     |
+| `to[].targetRef.kind` | `Mesh`, `MeshService`                                    |
+{% endif_version %}
 {% endtab %}
 
 {% tab targetRef Builtin Gateway %}
@@ -28,10 +36,18 @@ When using this policy, the [localityAwareLoadBalancing](/docs/{{ page.version }
 {% endtab %}
 
 {% tab targetRef Delegated Gateway %}
+{% if_version lte:2.8.x %}
 | `targetRef`           | Allowed kinds                                            |
 | --------------------- | -------------------------------------------------------- |
 | `targetRef.kind`      | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
 | `to[].targetRef.kind` | `Mesh`, `MeshService`                                    |
+{% endif_version %}
+{% if_version gte:2.9.x %}
+| `targetRef`           | Allowed kinds                                            |
+| --------------------- | -------------------------------------------------------- |
+| `targetRef.kind`      | `Mesh`, `MeshSubset`                                     |
+| `to[].targetRef.kind` | `Mesh`, `MeshService`                                    |
+{% endif_version %}
 {% endtab %}
 
 {% endtabs %}


### PR DESCRIPTION
We've deprecated MeshService from topLevel targetRef in 2.9.x. We should remove it from policy support matrix to not encourage users to use it.