### PR TITLE
feat(mrl): fix support matrix for MeshRateLimit policy

### DIFF
--- a/app/_src/policies/meshratelimit.md
+++ b/app/_src/policies/meshratelimit.md
@@ -25,10 +25,18 @@ Rate limiting supports an [ExternalService](/docs/{{ page.version }}/policies/ex
 {% if_version gte:2.6.x %}
 {% tabs targetRef useUrlFragment=false %}
 {% tab targetRef Sidecar %}
+{% if_version lte:2.8.x %}
 | `targetRef`             | Allowed kinds                                            |
 | ----------------------- | -------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
 | `from[].targetRef.kind` | `Mesh`                                                   |
+{% endif_version %}
+{% if_version gte:2.9.x %}
+| `targetRef`             | Allowed kinds                                            |
+| ----------------------- | -------------------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `MeshSubset`                                     |
+| `from[].targetRef.kind` | `Mesh`                                                   |
+{% endif_version %}
 {% endtab %}
 
 {% tab targetRef Builtin Gateway %}


### PR DESCRIPTION
We've deprecated `MeshService` from topLevel targetRef in 2.9.x. We should remove it from policy support matrix to not encourage users to use it.
