### PR TITLE
docs(guide): fix expected output on testing producer policies

### DIFF
--- a/app/_src/guides/consumer-producer-policies.md
+++ b/app/_src/guides/consumer-producer-policies.md
@@ -180,7 +180,7 @@ Consumer policies will override producer policies.
 ## Testing producer policy
 
 To test MeshTimeout that we've applied in previous steps we need to simulate delays on our requests. To do this we need
-add header `x-set-response-delay-ms` to our requests
+add header `x-set-response-delay-ms` to our requests.
 
 We can now make few requests to our demo-app, and we should see timeouts:
 
@@ -191,7 +191,7 @@ kubectl exec -n first-consumer consumer -- curl -s -XPOST demo-app.kuma-demo:500
 Example output:
 
 ```
-{"counter":"3","zone":"local","err":null}
+upstream request timeout
 ```
 
 We should see the same results when making requests from second-consumer namespace:
@@ -203,7 +203,7 @@ kubectl exec -n second-consumer consumer -- curl -s -XPOST demo-app.kuma-demo:50
 Output:
 
 ```
-{"counter":"4","zone":"local","err":null}
+upstream request timeout
 ```
 
 Producer policy will be applied on all traffic to `kuma-demo` as we can see on this diagram: 


### PR DESCRIPTION
if a producer policy has a timeout of 1s and the request takes 2 seconds it should timeout

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
