### PR TITLE
feat(guides): move guides to use new MeshService by default

### DIFF
--- a/app/_src/guides/consumer-producer-policies.md
+++ b/app/_src/guides/consumer-producer-policies.md
@@ -15,30 +15,13 @@ This guide will help you get comfortable with producer consumer model.
 ## Basic setup
 
 In order to be able to fully utilize namespace scoped policies you need to use [MeshService](/docs/{{ page.version }}/networking/meshservice). 
-To enable MeshService resource generation on Mesh level we need to run:
-
-```shell
-echo "apiVersion: kuma.io/v1alpha1
-kind: Mesh
-metadata:
-  name: default
-spec:
-  meshServices:
-    mode: Exclusive
-  mtls:
-    enabledBackend: ca-1
-    backends:
-    - name: ca-1
-      type: builtin" | kubectl apply -f -
-```
-
 To make sure that traffic works in our examples let's configure MeshTrafficPermission to allow all traffic:
 
 ```shell
 echo "apiVersion: kuma.io/v1alpha1
 kind: MeshTrafficPermission
 metadata:
-  namespace: kuma-system
+  namespace: kuma-demo
   name: mtp
 spec:
   targetRef:

--- a/app/_src/guides/federate.md
+++ b/app/_src/guides/federate.md
@@ -131,6 +131,7 @@ You should eventually see
 
 We can check policy synchronization from global control plane to zone control plane by applying a policy on global control plane:
 
+{% if_version lte:2.8.x %}
 ```sh
 echo "apiVersion: kuma.io/v1alpha1
 kind: MeshCircuitBreaker
@@ -154,6 +155,33 @@ spec:
         maxRetries: 2
         maxRequests: 2" | kubectl --context=mesh-global apply -f -
 ```
+{% endif_version %}
+{% if_version gte:2.9.x %}
+```sh
+echo "apiVersion: kuma.io/v1alpha1
+kind: MeshCircuitBreaker
+metadata:
+  name: demo-app-to-redis
+  namespace: kuma-demo
+  labels:
+    kuma.io/mesh: default
+spec:
+  targetRef:
+    kind: MeshSubset
+    tags:
+      app: demo-app
+  to:
+  - targetRef:
+      kind: MeshService
+      name: redis
+    default:
+      connectionLimits:
+        maxConnections: 2
+        maxPendingRequests: 8
+        maxRetries: 2
+        maxRequests: 2" | kubectl --context=mesh-global apply -f -
+```
+{% endif_version %}
 
 If we execute the following command:
 ```sh

--- a/app/_src/guides/gateway-api.md
+++ b/app/_src/guides/gateway-api.md
@@ -33,7 +33,7 @@ To install Gateway API please refer to [official installation instruction](https
 
 You also need to manually install {{site.mesh_product_name}} [GatewayClass](https://gateway-api.sigs.k8s.io/api-types/gatewayclass/):
 
-```shell
+```sh
 echo "apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
@@ -45,7 +45,7 @@ spec:
 At this moment, when you install Gateway API CRDs after installing {{site.mesh_product_name}} control plane you need to restart
 it to start Gateway API controller. To do this run: 
 
-```shell
+```sh
 kubectl rollout restart deployment {{site.mesh_product_name_path}}-control-plane -n {{ site.mesh_namespace }}
 ```
 
@@ -54,7 +54,7 @@ kubectl rollout restart deployment {{site.mesh_product_name_path}}-control-plane
 The [Gateway](https://gateway-api.sigs.k8s.io/api-types/gateway/) resource represents the proxy instance that handles
 traffic for a set of Gateway API routes. You can create gateway with a single listener on port 8080 by running:
 
-```shell
+```sh
 echo "apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -78,11 +78,11 @@ One option for `kind` is [kubernetes-sigs/cloud-provider-kind](https://github.co
 {% endwarning %}
 
 You can now check if the gateway is running in the demo app `kuma-demo` namespace:
-```shell
+```sh
 kubectl get pods -n kuma-demo
 ```
 Observe the gateway pod:
-```shell
+```sh
 NAME                       READY   STATUS    RESTARTS   AGE
 demo-app-d8d8bdb97-vhgc8   2/2     Running   0          5m
 kuma-cfcccf8c7-hlqz5       1/1     Running   0          20s
@@ -90,18 +90,18 @@ redis-5484ddcc64-6gbbx     2/2     Running   0          5m
 ```
 
 Retrieve the public URL for the gateway with:
-```shell
+```sh
 export PROXY_IP=$(kubectl get svc --namespace kuma-demo kuma -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 echo $PROXY_IP
 ```
 
 Check the gateway is running:
-```shell
+```sh
 curl -v ${PROXY_IP}:8080
 ```
 
 Which outputs:
-```shell
+```sh
 *   Trying 127.0.0.1:8080...
 * Connected to 35.226.116.24 (35.226.116.24) port 8080
 > GET / HTTP/1.1
@@ -151,12 +151,12 @@ spec:
 ```
 
 Now try to reach our gateway again:
-```shell
+```sh
 curl -v ${PROXY_IP}:8080
 ```
 
 which outputs:
-```shell
+```sh
 *   Trying 127.0.0.1:8080...
 * Connected to 127.0.0.1 (127.0.0.1) port 8080
 > GET / HTTP/1.1
@@ -181,7 +181,7 @@ Therefore, the gateway doesn't have permissions to talk to the demo-app service.
 
 To fix this, add a [`MeshTrafficPermission`](/docs/{{ page.version }}/policies/meshtrafficpermission):
 
-```shell
+```sh
 echo "apiVersion: kuma.io/v1alpha1
 kind: MeshTrafficPermission
 metadata:
@@ -202,12 +202,12 @@ spec:
 ```
 
 Check it works with:
-```shell
+```sh
 curl -XPOST -v ${PROXY_IP}:8080/increment
 ```
 
 Now it returns a 200 OK response:
-```shell
+```sh
 *   Trying 127.0.0.1:8080...
 * Connected to 127.0.0.1 (127.0.0.1) port 8080
 > POST /increment HTTP/1.1
@@ -237,13 +237,13 @@ We will now add TLS to our endpoint.
 
 Create a self-signed certificate:
 
-```shell
+```sh
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout tls.key -out tls.crt -subj "/CN=${PROXY_IP}"
 ```
 
 Create Kubernetes secret with generated certificate:
 
-```shell
+```sh
 echo "apiVersion: v1
 kind: Secret
 metadata:
@@ -257,7 +257,7 @@ data:
 
 Now update the gateway to use this certificate:
 
-```shell
+```sh
 echo "apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -275,12 +275,12 @@ spec:
 ```
 
 Check the call to the gateway:
-```shell
+```sh
 curl -X POST -v --insecure https://${PROXY_IP}:8080/increment
 ```
 
 Which should output a successful call and indicate TLS is being used:
-```shell
+```sh
 *   Trying 127.0.0.1:8080...
 * Connected to 127.0.0.1 (127.0.0.1) port 8080
 * ALPN: curl offers h2,http/1.1

--- a/app/_src/guides/gateway-api.md
+++ b/app/_src/guides/gateway-api.md
@@ -55,7 +55,7 @@ The [Gateway](https://gateway-api.sigs.k8s.io/api-types/gateway/) resource repre
 traffic for a set of Gateway API routes. You can create gateway with a single listener on port 8080 by running:
 
 ```shell
-echo" apiVersion: gateway.networking.k8s.io/v1
+echo "apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: kuma
@@ -182,8 +182,7 @@ Therefore, the gateway doesn't have permissions to talk to the demo-app service.
 To fix this, add a [`MeshTrafficPermission`](/docs/{{ page.version }}/policies/meshtrafficpermission):
 
 ```shell
-echo "
-apiVersion: kuma.io/v1alpha1
+echo "apiVersion: kuma.io/v1alpha1
 kind: MeshTrafficPermission
 metadata:
   namespace: kuma-demo 

--- a/app/_src/guides/gateway-delegated.md
+++ b/app/_src/guides/gateway-delegated.md
@@ -46,40 +46,40 @@ The Kong Ingress controller was installed outside the mesh.
 For it to work as a delegated gateway restart it with [sidecar injection enabled](/docs/{{ page.version }}/production/dp-config/dpp-on-kubernetes/):
 
 Add the label:
-```shell
+```sh
 kubectl label namespace kong kuma.io/sidecar-injection=enabled
 ```
 
 Restart both the controller and the gateway to leverage sidecar injection:
-```shell
+```sh
 kubectl rollout restart -n kong deployment kong-gateway kong-controller
 ```
 
 Wait until pods are fully rolled out and look at them:
-```shell
+```sh
 kubectl get pods -n kong
 ```
 
 It is now visible that both pods have 2 containers, one for the application and one for the sidecar.
-```shell
+```sh
 NAME                              READY   STATUS    RESTARTS      AGE
 kong-controller-675d48d48-vqllj   2/2     Running   2 (69s ago)   72s
 kong-gateway-674c44c5c4-cvsr8     2/2     Running   0             72s
 ```
 
 Retrieve the public URL for the gateway with:
-```shell
+```sh
 export PROXY_IP=$(kubectl get svc --namespace kong kong-gateway-proxy -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 echo $PROXY_IP
 ```
 
 Verify the gateway still works:
-```shell
+```sh
 curl -i $PROXY_IP
 ```
 
 which outputs that there are no routes defined:
-```shell
+```sh
 HTTP/1.1 404 Not Found
 Date: Fri, 09 Feb 2024 15:25:45 GMT
 Content-Type: application/json; charset=utf-8
@@ -98,16 +98,15 @@ X-Kong-Request-Id: e7dfe659c9e46639a382f82c16d9582f
 ## Add a route to our `demo-app`
 
 Patch our gateway to allow routes in any namespace:
-```shell
+```sh
 kubectl patch --type=json gateways.gateway.networking.k8s.io kong -p='[{"op":"replace","path": "/spec/listeners/0/allowedRoutes/namespaces/from","value":"All"}]'
 ```
 This is required because in the Kong ingress controller tutorial the gateway is created in the `default` namespace.
 To do this the Gateway API spec requires to explicitly allow routes from different namespaces.
 
 Now add the gateway route in our `kuma-demo` namespace which binds to the gateway `kong` defined in the `default` namespace:
-```shell
-echo "
-apiVersion: gateway.networking.k8s.io/v1
+```sh
+echo "apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: demo-app
@@ -124,8 +123,7 @@ spec:
     backendRefs:
     - name: demo-app
       kind: Service
-      port: 5000 
-" | kubectl apply -f -
+      port: 5000 " | kubectl apply -f -
 ```
 
 {% warning %}
@@ -133,12 +131,12 @@ This route is managed by the Kong ingress controller and not by Kuma.
 {% endwarning %}
 
 Now call the gateway: 
-```shell
+```sh
 curl -i $PROXY_IP/
 ```
 
 Which outputs:
-```shell
+```sh
 HTTP/1.1 403 Forbidden
 Content-Type: text/plain; charset=UTF-8
 Content-Length: 19
@@ -159,9 +157,10 @@ This is because the quickstart has very restrictive permissions as defaults.
 Therefore, the gateway doesn't have permissions to talk to the demo-app service.
 
 To fix this, add a [`MeshTrafficPermission`](/docs/{{ page.version }}/policies/meshtrafficpermission):
-```shell
-echo "
-apiVersion: kuma.io/v1alpha1
+
+{% if_version lte:2.8.x %}
+```sh
+echo "apiVersion: kuma.io/v1alpha1
 kind: MeshTrafficPermission
 metadata:
   namespace: {{ site.mesh_namespace }} 
@@ -177,17 +176,39 @@ spec:
           app.kubernetes.io/name: gateway
           k8s.kuma.io/namespace: kong
       default:
-        action: Allow
-" | kubectl apply -f -
+        action: Allow" | kubectl apply -f -
 ```
+{% endif_version %}
+{% if_version gte:2.9.x %}
+```sh
+echo "apiVersion: kuma.io/v1alpha1
+kind: MeshTrafficPermission
+metadata:
+  namespace: kuma-demo 
+  name: demo-app
+spec:
+  targetRef:
+    kind: MeshSubset
+    tags:
+      app: demo-app
+  from:
+    - targetRef:
+        kind: MeshSubset
+        tags:
+          app.kubernetes.io/name: gateway
+          k8s.kuma.io/namespace: kong
+      default:
+        action: Allow" | kubectl apply -f -
+```
+{% endif_version %}
 
 Call the gateway again:
-```shell
+```sh
 curl -i $PROXY_IP/increment -XPOST
 ```
 
 Notice that the call succeeds:
-```shell
+```sh
 
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8


### PR DESCRIPTION
We've discussed that for version newer than 2.9.x We should push new users to use new MeshService. This pr updated and fixes guides to work with MeshService mode `Exclusive`
