### PR TITLE
chore(dev): fix small issuse with netlify conf and cleanup make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ build: ruby-version-check
 # troubleshoot build issues.
 clean:
 	-rm -rf dist
-	-rm -rf app/.jekyll-cache
-	-rm -rf app/.jekyll-metadata
-	-rm -rf .jekyll-cache/vite
+	-rm -rf .netlify
+	-rm -rf .jekyll-cache
+	-rm -rf app/.jekyll-{cache,metadata}
 
 kill-ports:
 	@echo '[DEPRECATED]: This target is deprecated because the "run" target now correctly handles kill signals, closing these ports automatically.'

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,11 @@
 [build]
   publish = "dist"
   command = "bundle exec jekyll build --config jekyll.yml"
-  environment = { JEKYLL_ENV = "development", BUNDLE_WITHOUT = "development", NODE_OPTIONS = "--max_old_space_size=8192" }
+
+[build.environment]
+  JEKYLL_ENV = "development"
+  BUNDLE_WITHOUT = "development"
+  NODE_OPTIONS = "--max_old_space_size=8192"
 
 [context.production.environment]
   JEKYLL_ENV = "production"
@@ -14,12 +18,6 @@
   # is vite
   autoLaunch = false
   targetPort = 4000
-
-[[redirects]]
-from = "/vite-dev/*"
-to = "http://localhost:3036/vite-dev/:splat"
-force = true
-status = 301
 
 [[redirects]]
   from = "/fixtures/*"


### PR DESCRIPTION
1. Removed redirection for `/vite-dev/*` in `netlify.toml` because it was unnecessary and it was causing that during `make run` vite-related scripts were loaded twice, so you could see in the console it was connecting to vite's websocket server twice
2. Updated `clean` make target, so it currently cleans up all build-related files and directories
3. Small improvement if formatting of `netlify.toml` file

---

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
