### PR TITLE
fix(js): handle sidebar links without trailing "/" for active link detection

### DIFF
--- a/app/_assets/javascripts/sidebar.js
+++ b/app/_assets/javascripts/sidebar.js
@@ -52,29 +52,39 @@ export default class Sidebar {
     items.classList.toggle('hidden', hide);
   }
 
+  getActiveLink(includeHash = false) {
+    const pathname = window.location.pathname;
+    const path = includeHash ? `${pathname}${window.location.hash}` : pathname;
+
+    let activeLink = this.elem.querySelector(`a[href='${path}']`);
+
+    if (!activeLink && path.endsWith('/')) {
+      const pathWithoutSlash = path.slice(0, -1);
+      activeLink = this.elem.querySelector(`a[href='${pathWithoutSlash}']`);
+    }
+
+    return activeLink;
+  }
+
   expandActiveGroup() {
-    const currentPath = window.location.pathname;
-    const activeLink = this.elem.querySelector(`a[href^='${currentPath}']`);
+    const activeLink = this.getActiveLink();
 
     if (activeLink) {
-      let currentGroup = activeLink.closest('.sidebar-group');
+      let group = activeLink.closest('.sidebar-group');
 
-      // Traverse up and expand each nested group until reaching the top level
-      while (currentGroup) {
-        this.toggleGroup(currentGroup, false);
-        currentGroup = currentGroup.parentNode.closest('.sidebar-group');
+      while (group) {
+        this.toggleGroup(group, false);
+        group = group.parentElement.closest('.sidebar-group');
       }
 
-      this.elem.querySelector('.sidebar-links')?.scroll({ top: activeLink.offsetTop, behavior: 'smooth' });
+      this.elem.querySelector('.sidebar-links')?.scroll({
+        top: activeLink.offsetTop,
+        behavior: 'smooth'
+      });
     }
   }
 
   setActiveLink() {
-    const currentPath = `${window.location.pathname}${window.location.hash || ''}`;
-    const activeLink = this.elem.querySelector(`a[href='${currentPath}']`);
-
-    if (activeLink) {
-      activeLink.classList.add('active');
-    }
+    this.getActiveLink(true)?.classList.add('active')
   }
 }


### PR DESCRIPTION
Jekyll generates our pages with links that always end with a `/` suffix. If a user visits a URL without this suffix, they are redirected to the version with it. For example,
`https://kuma.io/docs/2.9.x/quickstart/universal-demo` redirects to `https://kuma.io/docs/2.9.x/quickstart/universal-demo/`.

Sometimes, the sidebar YAML configuration may mistakenly include URLs without the trailing `/`. This caused an issue where clicking on such a sidebar link wouldn’t mark it as active, and all sidebar groups would collapse. Ideally, sidebar URLs should include the `/` suffix, but mistakes happen.

This change in `sidebar.js` ensures the sidebar correctly identifies links as active, even if the YAML contains a link without the `/` suffix, preventing sidebar collapse in these cases.

---

Before:

https://github.com/user-attachments/assets/efb28806-4ffc-4971-8939-06dd908b05b3

After:

https://github.com/user-attachments/assets/88b49c26-b7bb-4fb7-a108-c8d1de615b81

---

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
