### PR TITLE
chore(mk/run): use npx to execute netlify-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install: ruby-version-check
 	bundle install
 
 run: ruby-version-check
-	netlify dev
+	npx netlify dev
 
 test:
 	bundle exec rspec


### PR DESCRIPTION
In order to use the `netlify-cli` without installing it globally we can use `npx`.

```bash
$ make run
netlify dev
bash: netlify: command not found
make: *** [run] Error 127
```
