### PR TITLE
fix(prod/cp-deployment): typo SNI

### DIFF
--- a/app/_src/production/cp-deployment/zone-ingress.md
+++ b/app/_src/production/cp-deployment/zone-ingress.md
@@ -9,7 +9,7 @@ Zone Ingress can proxy the traffic between all meshes, so we need only one deplo
 All requests that are sent from one zone to another will be directed to the proper instance by the Zone Ingress.
 
 {%tip%}
-Because `ZoneIngress` uses [Service Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) to route traffic, [mTLS](/docs/{{ page.release }}/policies/mutual-tls) is required to do cross zone communication.
+Because `ZoneIngress` uses [Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) to route traffic, [mTLS](/docs/{{ page.release }}/policies/mutual-tls) is required to do cross zone communication.
 {%endtip%}
 
 The `ZoneIngress` entity includes a few sections:

--- a/app/_src/production/cp-deployment/zoneegress.md
+++ b/app/_src/production/cp-deployment/zoneegress.md
@@ -8,7 +8,7 @@ zones or [external services](/docs/{{ page.release }}/policies/external-services
 
 
 {%tip%}
-Because `ZoneEgress` uses [Service Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) to route traffic, [mTLS](/docs/{{ page.release }}/policies/mutual-tls) is required.
+Because `ZoneEgress` uses [Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) to route traffic, [mTLS](/docs/{{ page.release }}/policies/mutual-tls) is required.
 {%endtip%}
 
 This proxy is not attached to any particular workload. In multi-zone the proxy is bound to a specific zone.


### PR DESCRIPTION
Should be `Server Name Indication` instead of `Service Name Indication`.