### PR TITLE
feat(quickstart): add links to single and multi-zone cp deployment

### DIFF
--- a/app/_src/quickstart/kubernetes-demo.md
+++ b/app/_src/quickstart/kubernetes-demo.md
@@ -193,5 +193,6 @@ However, the traffic to `redis` from any other service than `demo-app` is not al
 * Add Kong as gateway to access the demo from the outside by following the [delegated gateway guide](/docs/{{ page.release }}/guides/gateway-delegated/).
 * [Federate](/docs/{{ page.release }}/guides/federate) zone into a multizone deployment.
 * Learn more about what you can do with the [GUI](/docs/{{ page.release }}/production/gui).
+* Explore further installation strategies for [single-zone](/docs/{{ page.release }}/production/cp-deployment/single-zone) and [multi-zone](/docs/{{ page.release }}/production/cp-deployment/multi-zone) environments.
 * Read the [full documentation](/docs/{{ page.release }}/) to learn about all the capabilities of {{site.mesh_product_name}}.
 {% if site.mesh_product_name == "Kuma" %}* Chat with us at the official [Kuma Slack](/community) for questions or feedback.{% endif %}

--- a/app/_src/quickstart/universal-demo.md
+++ b/app/_src/quickstart/universal-demo.md
@@ -247,5 +247,6 @@ However, the traffic to `redis` from any other service than `demo-app` is not al
 
 * Explore the [Features](/features) available to govern and orchestrate your service traffic.
 * Learn more about what you can do with the [GUI](/docs/{{ page.release }}/production/gui).
+* Explore further installation strategies for [single-zone](/docs/{{ page.release }}/production/cp-deployment/single-zone) and [multi-zone](/docs/{{ page.release }}/production/cp-deployment/multi-zone) environments.
 * Read the [full documentation](/docs/{{ page.release }}/) to learn about all the capabilities of {{site.mesh_product_name}}.
 {% if site.mesh_product_name == "Kuma" %}* Chat with us at the official [Kuma Slack](/community) for questions or feedback.{% endif %}


### PR DESCRIPTION
After finishing the quickstart, I thought it would be nice to add links to the docs for single and multi-zone deployments. These also show how to use `kumactl` for cp deployments.
