### PR TITLE
fix(mesh): rename config to conf

### DIFF
--- a/app/_src/policies/mutual-tls.md
+++ b/app/_src/policies/mutual-tls.md
@@ -325,7 +325,7 @@ spec:
     backends:
       - name: ca-1
         type: provided
-        config:
+        conf:
           cert:
             inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
           key:
@@ -346,7 +346,7 @@ mtls:
   backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:

--- a/app/docs/1.3.x/policies/mutual-tls.md
+++ b/app/docs/1.3.x/policies/mutual-tls.md
@@ -307,7 +307,7 @@ spec:
     backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:
@@ -328,7 +328,7 @@ mtls:
   backends:
   - name: ca-1
     type: provided
-    config:
+    conf:
       cert:
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
       key:

--- a/app/docs/1.4.x/policies/mutual-tls.md
+++ b/app/docs/1.4.x/policies/mutual-tls.md
@@ -307,7 +307,7 @@ spec:
     backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:
@@ -328,7 +328,7 @@ mtls:
   backends:
   - name: ca-1
     type: provided
-    config:
+    conf:
       cert:
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
       key:

--- a/app/docs/1.5.x/policies/mutual-tls.md
+++ b/app/docs/1.5.x/policies/mutual-tls.md
@@ -307,7 +307,7 @@ spec:
     backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:
@@ -328,7 +328,7 @@ mtls:
   backends:
   - name: ca-1
     type: provided
-    config:
+    conf:
       cert:
         inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
       key:

--- a/app/docs/1.6.x/policies/mutual-tls.md
+++ b/app/docs/1.6.x/policies/mutual-tls.md
@@ -313,7 +313,7 @@ spec:
     backends:
       - name: ca-1
         type: provided
-        config:
+        conf:
           cert:
             inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
           key:
@@ -334,7 +334,7 @@ mtls:
   backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:

--- a/app/docs/1.7.x/policies/mutual-tls.md
+++ b/app/docs/1.7.x/policies/mutual-tls.md
@@ -313,7 +313,7 @@ spec:
     backends:
       - name: ca-1
         type: provided
-        config:
+        conf:
           cert:
             inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
           key:
@@ -334,7 +334,7 @@ mtls:
   backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:

--- a/app/docs/1.8.x/policies/mutual-tls.md
+++ b/app/docs/1.8.x/policies/mutual-tls.md
@@ -313,7 +313,7 @@ spec:
     backends:
       - name: ca-1
         type: provided
-        config:
+        conf:
           cert:
             inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
           key:
@@ -334,7 +334,7 @@ mtls:
   backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:

--- a/app/docs/2.0.x/policies/mutual-tls.md
+++ b/app/docs/2.0.x/policies/mutual-tls.md
@@ -313,7 +313,7 @@ spec:
     backends:
       - name: ca-1
         type: provided
-        config:
+        conf:
           cert:
             inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
           key:
@@ -334,7 +334,7 @@ mtls:
   backends:
     - name: ca-1
       type: provided
-      config:
+      conf:
         cert:
           inline: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3S... # cert in Base64
         key:


### PR DESCRIPTION
Because the actual field is `conf` - https://github.com/kumahq/kuma/blob/f8179d7a8d0348a67ac7e7983e6d65c1fee339ed/api/mesh/v1alpha1/mesh.pb.go#L281

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
