### PR TITLE
fix(install): move install page to not have Kuma

### DIFF
--- a/app/_data/docs_nav_kuma_2.10.x.yml
+++ b/app/_data/docs_nav_kuma_2.10.x.yml
@@ -20,8 +20,8 @@ items:
             url: "/introduction/how-kuma-works/#kuma-vs-xyz"
       - text: Architecture
         url: /introduction/architecture/
-      - text: Install Kuma
-        url: /introduction/install-kuma/
+      - text: Install
+        url: /introduction/install/
       - text: Concepts
         url: /introduction/concepts/
       - text: Kuma requirements

--- a/app/_data/docs_nav_kuma_2.9.x.yml
+++ b/app/_data/docs_nav_kuma_2.9.x.yml
@@ -20,8 +20,8 @@ items:
             url: "/introduction/how-kuma-works/#kuma-vs-xyz"
       - text: Architecture
         url: /introduction/architecture/
-      - text: Install Kuma
-        url: /introduction/install-kuma/
+      - text: Install
+        url: /introduction/install/
       - text: Concepts
         url: /introduction/concepts/
       - text: Kuma requirements

--- a/app/_data/navigation.yml
+++ b/app/_data/navigation.yml
@@ -14,5 +14,5 @@
   url: "/enterprise/"
   key: "enterprise"
 - text: "Install"
-  url: "/docs/latest//introduction/install-kuma/"
+  url: "/docs/latest/introduction/install/"
   key: "install"

--- a/app/_src/guides/federate.md
+++ b/app/_src/guides/federate.md
@@ -15,7 +15,7 @@ This way you can:
 - Have [kumactl installed and in your path](/docs/{{ page.release }}/production/install-kumactl)
 {% endif_version %}
 {% if_version gte:2.9.x %}
-- Have [kumactl installed and in your path](/docs/{{ page.release }}/introduction/install-kuma/)
+- Have [kumactl installed and in your path](/docs/{{ page.release }}/introduction/install/)
 {% endif_version %}
 
 ## Start a global control plane

--- a/app/_src/index.md
+++ b/app/_src/index.md
@@ -36,7 +36,7 @@ The core maintainer of Kuma is **Kong**, the maker of the popular open-source Ko
 [Install Kuma](/install/latest/)
 {% endif_version %}
 {% if_version gte:2.9.x %}
-[Install Kuma](/docs/{{ page.release }}/introduction/install-kuma)
+[Install Kuma](/docs/{{ page.release }}/introduction/install)
 {% endif_version %}
 
 {% if_version gte:2.6.x %}[Jump to quickstart](/docs/{{ page.release }}/quickstart/kubernetes-demo/){% endif_version %}{% if_version lte:2.5.x %}[Jump to quickstart](/docs/{{ page.release }}/quickstart/kubernetes/){% endif_version %}

--- a/app/_src/introduction/how-kuma-works.md
+++ b/app/_src/introduction/how-kuma-works.md
@@ -76,7 +76,7 @@ Out of the box, {{site.mesh_product_name}} ships with a bundled [Envoy](https://
 [Install {{site.mesh_product_name}}](/install/) and follow the instructions to get up and running in a few steps.
 {% endif_version %}
 {% if_version gte:2.9.x %}
-[Install {{site.mesh_product_name}}](/docs/{{ page.release }}/introduction/install-kuma/) and follow the instructions to get up and running in a few steps.
+[Install {{site.mesh_product_name}}](/docs/{{ page.release }}/introduction/install/) and follow the instructions to get up and running in a few steps.
 {% endif_version %}
 
 ## VM and K8s support

--- a/app/_src/introduction/install.md
+++ b/app/_src/introduction/install.md
@@ -1,5 +1,5 @@
 ---
-title: Install Kuma
+title: Install
 content_type: how-to
 ---
 

--- a/app/_src/production/dp-config/cni.md
+++ b/app/_src/production/dp-config/cni.md
@@ -21,7 +21,7 @@ writes executables to the host filesystem as `root`.
 Install the CNI using either
 {% if_version lte:2.1.x %}[kumactl](/docs/{{ page.release }}/installation/kubernetes) or [Helm](/docs/{{ page.release }}/installation/helm){% endif_version %}
 {% if_version gte:2.2.x %}{% if_version lte:2.8.x %}[kumactl](/docs/{{ page.release }}/production/install-kumactl/) or [Helm]https://helm.sh/){% endif_version %}{% endif_version %}
-{% if_version gte:2.9.x %}[kumactl](/docs/{{ page.release }}/introduction/install-kuma/) or [Helm](https://helm.sh/){% endif_version %}.
+{% if_version gte:2.9.x %}[kumactl](/docs/{{ page.release }}/introduction/install/) or [Helm](https://helm.sh/){% endif_version %}.
 The default settings are tuned for OpenShift with Multus.
 To use it in other environments, set the relevant configuration parameters.
 

--- a/app/_src/production/index.md
+++ b/app/_src/production/index.md
@@ -36,7 +36,7 @@ The following table describes some common use cases and the deployment modes you
 
 ### kumactl
 
-The first step after you pick your deployment mode is to {% if_version lte:2.8.x %}[install `kumactl`](/docs/{{ page.release }}/production/install-kumactl/){% endif_version %}{% if_version gte:2.9.x %}[install `kumactl`](/docs/{{ page.release }}/introduction/install-kuma/){% endif_version %}. 
+The first step after you pick your deployment mode is to {% if_version lte:2.8.x %}[install `kumactl`](/docs/{{ page.release }}/production/install-kumactl/){% endif_version %}{% if_version gte:2.9.x %}[install `kumactl`](/docs/{{ page.release }}/introduction/install/){% endif_version %}. 
 `kumactl` is a CLI tool that you can use to access {{site.mesh_product_name}}. It can do the following:
 
 * Perform read-only operations on {{site.mesh_product_name}} resources on Kubernetes.

--- a/app/_src/production/use-mesh.md
+++ b/app/_src/production/use-mesh.md
@@ -19,8 +19,8 @@ After {{site.mesh_product_name}} is installed, you can access the control plane 
 | ---- | ---- | ----- |
 | [{{site.mesh_product_name}} GUI](/docs/{{ page.release }}/production/gui/) | Kubernetes and Universal | Read-only |
 | HTTP API | Kubernetes and Universal | Read-only |
-| [kumactl](/docs/{{ page.release }}/introduction/install-kuma/) | Kubernetes | Read-only |
-| [kumactl](/docs/{{ page.release }}/introduction/install-kuma/) | Universal | Read and write |
+| [kumactl](/docs/{{ page.release }}/introduction/install/) | Kubernetes | Read-only |
+| [kumactl](/docs/{{ page.release }}/introduction/install/) | Universal | Read and write |
 | `kubectl` | Kubernetes | Read and write |
 {% endif_version %}
 

--- a/app/index.md
+++ b/app/index.md
@@ -91,7 +91,7 @@ Built for the enterprise, Kuma ships with the most scalable multi-zone connectiv
 
 {% contentfor tab-kubernetes %}
 
-[Install Kuma](/docs/latest/introduction/install-kuma) via an available distribution:
+[Install Kuma](/docs/latest/introduction/install) via an available distribution:
 
 ```sh
 kumactl install control-plane \
@@ -112,7 +112,7 @@ Navigate to [127.0.0.1:5681/gui](http://127.0.0.1:5681/gui) to see the GUI.
 {% contentfor tab-openshift %}
 
 
-[Install Kuma](/docs/latest/introduction/install-kuma) via an available distribution:
+[Install Kuma](/docs/latest/introduction/install) via an available distribution:
 
 ```sh
 kumactl install control-plane \
@@ -132,7 +132,7 @@ Navigate to [127.0.0.1:5681/gui](http://127.0.0.1:5681/gui) to see the GUI.
 
 {% contentfor tab-universal %}
 
-[Install Kuma](/docs/latest/introduction/install-kuma) via an available distribution:
+[Install Kuma](/docs/latest/introduction/install) via an available distribution:
 
 ```sh
 kuma-cp run


### PR DESCRIPTION
Kuma in page names is problematic with the entreprise version of docs.
