### PR TITLE
fix(install): install is showing odd versions

### DIFF
--- a/app/_includes/version_selector.html
+++ b/app/_includes/version_selector.html
@@ -3,13 +3,7 @@
 <select name="{{ include.name }}" class="version-selector" id="version-selector">
   {% for version in site.data.versions %}
     {% assign option_value = version.release %}
-    {% if version == site.data.latest_version %}
-      {% assign option_value = 'latest' %}
-    {% endif %}
-    {% if version.label %}
-      {% assign option_value = version.label %}
-    {% endif %}
-    <option value="{{ option_value }}" {% if version.release == current_release.value %} selected {% endif %}>
+    <option value="{{ option_value }}" {% if version.release == current_release %} selected {% endif %}>
       {% if version.label %}
         {{ version.label }}
       {% else %}

--- a/app/_layouts/install.html
+++ b/app/_layouts/install.html
@@ -15,14 +15,13 @@ layout: default
             <p><a href="/docs/changelog">Changelog</a> • <a href="/docs/{{ page.release }}/production/upgrades-tuning/upgrade-notes">Upgrade Path</a> • <a href="/community">Community</a></p>
           </div>
 
-          {% unless page.release.latest?  %}
+          {% unless page.release == site.data.latest_version.release  %}
             <div class="version-alert">
               <div class="warning custom-block">
                 <p class="custom-block-title">Careful!</p>
                 <p>You are viewing installation instructions for a version of {{ site.title }} that is not the latest release.</p>
                 <p><a href="/install/{{ site.data.latest_version.release }}/">Go here</a>
                 to view installation instructions for the latest version.</p>
-                <p>Looking for even older versions? <a href="{% post_url 2021-04-16-website-reorg %}">Learn more</a>.</p>
               </div>
             </div>
           {% endunless %}

--- a/app/install/latest.md
+++ b/app/install/latest.md
@@ -2,7 +2,6 @@
 layout: install
 title: Install Kuma
 themeContainerClasses: 'no-sidebar'
-foo: bar
 cta:
   - label: Get Started with Kubernetes
     logo: "/assets/images/platforms/logo-kubernetes.png"


### PR DESCRIPTION
Since the move to the latest version of the single page generator we are showing banners when we shouldn't and the dropdown was not picking the right version

Fix #2090 