### PR TITLE
docs(production): fix installer link in doc 'install-kumactl'

### DIFF
--- a/app/_src/production/install-kumactl.md
+++ b/app/_src/production/install-kumactl.md
@@ -24,7 +24,7 @@ Make sure you have tar and gzip installed.
 Run the following script to automatically detect the operating system and download Kuma:
 
 <div class="language-sh">
-  <pre class="no-line-numbers"><code>curl -L {{site.links.web}}{% if page.edition %}/{{page.edition}}{% endif %}/installer.sh | VERSION={{ page.version_data.version }} sh -</code></pre>
+  <pre class="no-line-numbers"><code>curl -L {{site.links.web}}{% if page.edition != "kuma" %}/{{page.edition}}{% endif %}/installer.sh | VERSION={{ page.version_data.version }} sh -</code></pre>
 </div>
 
 You can omit the `VERSION` variable to install the latest version.


### PR DESCRIPTION
A supplement to https://github.com/kumahq/kuma-website/pull/2107

Preview link: https://deploy-preview-2109--kuma.netlify.app/docs/2.8.x/production/install-kumactl/#install-kumactl

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)
* Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
* Yes
