### PR TITLE
ci(checklinks): exclude external website from checklinks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
             --exclude https://packages.konghq.com \
             --exclude https://twitter.com \
             --exclude https://coredns.io \
+            --exclude 'https://argo-cd.readthedocs.io/en/stable/' \
+            --exclude 'https://docs.cilium.io/en/v1.14/operations/upgrade/' \
             --max-connections-per-host=8 \
             --max-response-body-size 100000000 \
             --rate-limit 50 \
@@ -78,6 +80,8 @@ jobs:
             --exclude https://packages.konghq.com \
             --exclude https://twitter.com \
             --exclude https://coredns.io \
+            --exclude 'https://argo-cd.readthedocs.io/en/stable/' \
+            --exclude 'https://docs.cilium.io/en/v1.14/operations/upgrade/' \
             --max-connections-per-host=8 \
             --max-response-body-size 100000000 \
             --rate-limit 50 \


### PR DESCRIPTION
I got some checklinks failure but it did works from my PC:

```text
https://deploy-preview-2114--kuma.netlify.app/docs/2.9.x/production/dp-config/cni/
	403	https://docs.cilium.io/en/v1.14/operations/upgrade/#id2
https://deploy-preview-2114--kuma.netlify.app/docs/2.9.x/production/cp-deployment/kubernetes/
	403	https://argo-cd.readthedocs.io/en/stable/
https://deploy-preview-2114--kuma.netlify.app/docs/2.7.x/production/dp-config/cni/
	403	https://docs.cilium.io/en/v1.14/operations/upgrade/#id2
https://deploy-preview-2114--kuma.netlify.app/docs/2.7.x/production/cp-deployment/kubernetes/
	403	https://argo-cd.readthedocs.io/en/stable/
https://deploy-preview-2114--kuma.netlify.app/docs/2.8.x/production/dp-config/cni/
	403	https://docs.cilium.io/en/v1.14/operations/upgrade/#id2
https://deploy-preview-2114--kuma.netlify.app/docs/2.8.x/production/cp-deployment/kubernetes/
	403	https://argo-cd.readthedocs.io/en/stable/
Error: Process completed with exit code 1.
```

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
