### PR TITLE
fix: invalid link to dev in drowndown sidebar

### DIFF
--- a/app/_includes/sidebar.html
+++ b/app/_includes/sidebar.html
@@ -4,7 +4,6 @@
   {% if page.doc -%}
   <div class="sidebar-top-section">
     <form class="version-nav">
-      <label for="doc-version-selector">Version</label>
       {% include version_selector.html name="doc-version-selector" %}
     </form>
 

--- a/app/_includes/version_selector.html
+++ b/app/_includes/version_selector.html
@@ -1,16 +1,13 @@
 {% assign current_release = page.release %}
 
+<label for="version-selector">Version</label>
 <select name="{{ include.name }}" class="version-selector" id="version-selector">
   {% for version in site.data.versions %}
-    {% assign option_value = version.release %}
-    <option value="{{ option_value }}" {% if version.release == current_release %} selected {% endif %}>
-      {% if version.label %}
-        {{ version.label }}
-      {% else %}
-        {{ version.release }}
-        {% if version == site.data.latest_version %}
-          (latest)
-        {% endif %}
+    {% assign option_value = version.label | default: version.release %}
+    <option id="doc-version-selector" value="{{ option_value }}" {% if version.release == current_release %} selected {% endif %}>
+      {{ option_value }}
+      {% if version == site.data.latest_version %}
+        (latest)
       {% endif %}
     </option>
   {% endfor %}


### PR DESCRIPTION
We were not using the label so the link was using the version number instead of `dev`