### PR TITLE
docs(MeshTrafficPermission): Add a note to enable mTLS to make mtp works

### DIFF
--- a/app/_src/policies/meshtrafficpermission.md
+++ b/app/_src/policies/meshtrafficpermission.md
@@ -8,7 +8,7 @@ Do **not** combine with [TrafficPermission](/docs/{{ page.release }}/policies/tr
 {% endwarning %}
 
 {% tip %}
-Remember [Mutual TLS](/docs/{{ page.release }}/policies/mutual-tls) has to be enabled to make MeshTrafficPermission works.
+[Mutual TLS](/docs/{{ page.release }}/policies/mutual-tls) has to be enabled to make MeshTrafficPermission work.
 {% endtip %}
 
 The `MeshTrafficPermission` policy provides access control within the [Mesh](/docs/{{ page.release }}/production/mesh/).

--- a/app/_src/policies/meshtrafficpermission.md
+++ b/app/_src/policies/meshtrafficpermission.md
@@ -5,8 +5,14 @@ title: MeshTrafficPermission
 {% warning %}
 This policy uses new policy matching algorithm.
 Do **not** combine with [TrafficPermission](/docs/{{ page.release }}/policies/traffic-permissions).
-Also remember [Mutual TLS](/docs/{{ page.release }}/policies/mutual-tls) has to be enabled to make MeshTrafficPermission works.
 {% endwarning %}
+
+{% tip %}
+Remember [Mutual TLS](/docs/{{ page.release }}/policies/mutual-tls) has to be enabled to make MeshTrafficPermission works.
+{% endtip %}
+
+The `MeshTrafficPermission` policy provides access control within the [Mesh](/docs/{{ page.release }}/production/mesh/).
+It allows you to define granular rules about which services can communicate with each other.
 
 ## TargetRef support matrix
 

--- a/app/_src/policies/meshtrafficpermission.md
+++ b/app/_src/policies/meshtrafficpermission.md
@@ -5,6 +5,7 @@ title: MeshTrafficPermission
 {% warning %}
 This policy uses new policy matching algorithm.
 Do **not** combine with [TrafficPermission](/docs/{{ page.release }}/policies/traffic-permissions).
+Also remember [Mutual TLS](/docs/{{ page.release }}/policies/mutual-tls) has to be enabled to make MeshTrafficPermission works.
 {% endwarning %}
 
 ## TargetRef support matrix


### PR DESCRIPTION
When I went through the MeshTrafficPermission source codes and found we need to enable the mTLS then the MTP policy works.

https://github.com/kumahq/kuma/blob/2.9.2/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go#L51-L56


Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
