### PR TITLE
fix: Only render brew install instructions for Kuma

### DIFF
--- a/app/_src/introduction/install.md
+++ b/app/_src/introduction/install.md
@@ -21,10 +21,11 @@ export PATH=$(pwd)/{{site.mesh_product_name_path}}-{{ page.version_data.version 
 ```
 This directory contains binaries for `kuma-dp`, `kuma-cp`, `kumactl`, `envoy` and `coredns`
 
+{% if page.edition = "kuma" %}
 {% tip %}
 If you only need `kumactl` on macOS you can install it via `brew install kumactl`.
 {% endtip %}
-
+{% endif %}
 
 ## Next steps
 * [Complete quickstart](/docs/{{ page.release }}/quickstart/universal-demo/) to set up a zone control plane with demo application


### PR DESCRIPTION
Docs got [feedback ](https://kongstrong.slack.com/archives/CDSTDSG9J/p1738598276786999)that the [current install instructions](https://docs.konghq.com/mesh/latest/introduction/install/) were confusing because the `brew install` note rendered in the Kong Mesh docs, but running `brew install` would install the OSS version. This PR conditionally renders the note so it only displays in the Kuma docs.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? Yes
