### PR TITLE
docs(policies): added note that old policies are not created by default

### DIFF
--- a/app/_src/policies/timeout.md
+++ b/app/_src/policies/timeout.md
@@ -65,7 +65,12 @@ Envoy conf: [Cluster](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/
 
 ## Default general-purpose Timeout policy
 
+{% if_version gte:2.6.x %}
+Since {{site.mesh_product_name}} version 2.6.x, the control plane no longer creates a default `Timeout`. If you want to use the previous default behavior, create the following Timeout policy:
+{% endif_version %}
+{% if_version lte:2.5.x %}
 By default, {{site.mesh_product_name}} creates the following Timeout policy:
+{% endif_version %}
 
 {% tabs timeout-policy useUrlFragment=false %}
 {% tab timeout-policy Kubernetes %}

--- a/app/_src/policies/traffic-permissions.md
+++ b/app/_src/policies/traffic-permissions.md
@@ -16,7 +16,12 @@ This policy provides access control rules to define the traffic that is allowed 
 
 Traffic permissions requires [Mutual TLS](/docs/{{ page.release }}/policies/mutual-tls) enabled on the [Mesh](/docs/{{ page.release }}/production/mesh/). Mutual TLS is required for {{site.mesh_product_name}} to validate the service identity with data plane proxy certificates. If Mutual TLS is disabled, {{site.mesh_product_name}} allows all service traffic. 
 
+{% if_version gte:2.6.x %}
+Since {{site.mesh_product_name}} version 2.6.x, the control plane no longer creates a default `TrafficPermission`. The default `TrafficPermission` allows all communication between all services in the new `Mesh`. Make sure to configure your policies to allow appropriate access to each of the services in your mesh.
+{% endif_version %}
+{% if_version lte:2.5.x %}
 The default `TrafficPermission` policy that {{site.mesh_product_name}} creates when you install allows all communication between all services in the new `Mesh`. Make sure to configure your policies to allow appropriate access to each of the services in your mesh.
+{% endif_version %}
 
 As of version 1.2.0, traffic permissions support the `ExternalService` resource. This lets you configure access control for traffic to services outside the mesh.
 

--- a/app/_src/policies/traffic-route.md
+++ b/app/_src/policies/traffic-route.md
@@ -24,7 +24,12 @@ Note the following:
 
 ### Default TrafficRoute
 
+{% if_version gte:2.6.x %}
+Since {{site.mesh_product_name}} version 2.6.x, the control plane no longer creates a default `TrafficRoute`. The default TrafficRoute previously enabled traffic between all services in the mesh, so you now need to create it manually.
+{% endif_version %}
+{% if_version lte:2.5.x %}
 The control plane creates a default `TrafficRoute` every time a new `Mesh` is created. The default `TrafficRoute` enables the traffic between all the services in the mesh. 
+{% endif_version %}
 
 {% tabs traffic-route useUrlFragment=false %}
 {% tab traffic-route Kubernetes %}


### PR DESCRIPTION
Since {{site.mesh_product_name}} version 2.6.x, default legacy policies are no longer created when a new mesh is created. I've added a note about this change.