### PR TITLE
fix(lint): exclude jwt.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
             --exclude https://coredns.io \
             --exclude 'https://argo-cd.readthedocs.io/en/stable/' \
             --exclude 'https://docs.cilium.io/en/v1.14/operations/upgrade/' \
+            --exclude 'https://jwt.io/' \
             --max-connections-per-host=8 \
             --max-response-body-size 100000000 \
             --rate-limit 50 \
@@ -82,6 +83,7 @@ jobs:
             --exclude https://coredns.io \
             --exclude 'https://argo-cd.readthedocs.io/en/stable/' \
             --exclude 'https://docs.cilium.io/en/v1.14/operations/upgrade/' \
+            --exclude 'https://jwt.io/' \
             --max-connections-per-host=8 \
             --max-response-body-size 100000000 \
             --rate-limit 50 \


### PR DESCRIPTION
https://jwt.io/ is clearly blocking GH requests - it works normally from a browser, we need to exclude it to make the link checker pass

![image](https://github.com/user-attachments/assets/eb9d69c2-55cb-440d-9e02-3a4270fef18e)

https://github.com/kumahq/kuma-website/actions/runs/13179405471/job/36786218554?pr=2165#step:6:27

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
