### PR TITLE
docs(dp-auth): add note for dataplane token revocation

### DIFF
--- a/app/_src/production/secure-deployment/dp-auth.md
+++ b/app/_src/production/secure-deployment/dp-auth.md
@@ -92,7 +92,9 @@ The control plane will then verify the data plane proxy resources that are conne
 
 {{site.mesh_product_name}} does not keep the list of issued tokens. Whenever the single token is compromised, we can add it to revocation list so it's no longer valid.
 
+{% if_version gte:2.10.x %}
 Authentication between the control plane and dataplanes is only checked at connection start. This means that when revoking a token after the dataplane connects, the connection won't stop. The recommended action on token revocation is to either restart the control plane or the concerned dataplanes.
+{% endif_version %}
 
 Every token has its own ID which is available in payload under `jti` key. You can extract ID from token using jwt.io or [`jwt-cli`](https://www.npmjs.com/package/jwt-cli) tool. Here is example of `jti`
 

--- a/app/_src/production/secure-deployment/dp-auth.md
+++ b/app/_src/production/secure-deployment/dp-auth.md
@@ -93,7 +93,7 @@ The control plane will then verify the data plane proxy resources that are conne
 {{site.mesh_product_name}} does not keep the list of issued tokens. Whenever the single token is compromised, we can add it to revocation list so it's no longer valid.
 
 {% if_version gte:2.10.x %}
-Authentication between the control plane and data planes is only checked at connection start. This means that when revoking a token after the dataplane connects, the connection won't stop. The recommended action on token revocation is to either restart the control plane or the concerned data planes.
+Authentication between the control plane and data planes is only checked at connection start. This means that when revoking a token after the data plane connects, the connection won't stop. The recommended action on token revocation is to either restart the control plane or the concerned data planes.
 {% endif_version %}
 
 Every token has its own ID which is available in payload under `jti` key. You can extract ID from token using jwt.io or [`jwt-cli`](https://www.npmjs.com/package/jwt-cli) tool. Here is example of `jti`

--- a/app/_src/production/secure-deployment/dp-auth.md
+++ b/app/_src/production/secure-deployment/dp-auth.md
@@ -92,6 +92,8 @@ The control plane will then verify the data plane proxy resources that are conne
 
 {{site.mesh_product_name}} does not keep the list of issued tokens. Whenever the single token is compromised, we can add it to revocation list so it's no longer valid.
 
+Authentication between the control plane and dataplanes is only checked at connection start. This means that when revoking a token after the dataplane connects, the connection won't stop. The recommended action on token revocation is to either restart the control plane or the concerned dataplanes.
+
 Every token has its own ID which is available in payload under `jti` key. You can extract ID from token using jwt.io or [`jwt-cli`](https://www.npmjs.com/package/jwt-cli) tool. Here is example of `jti`
 
 ```

--- a/app/_src/production/secure-deployment/dp-auth.md
+++ b/app/_src/production/secure-deployment/dp-auth.md
@@ -93,7 +93,7 @@ The control plane will then verify the data plane proxy resources that are conne
 {{site.mesh_product_name}} does not keep the list of issued tokens. Whenever the single token is compromised, we can add it to revocation list so it's no longer valid.
 
 {% if_version gte:2.10.x %}
-Authentication between the control plane and dataplanes is only checked at connection start. This means that when revoking a token after the dataplane connects, the connection won't stop. The recommended action on token revocation is to either restart the control plane or the concerned dataplanes.
+Authentication between the control plane and data planes is only checked at connection start. This means that when revoking a token after the dataplane connects, the connection won't stop. The recommended action on token revocation is to either restart the control plane or the concerned data planes.
 {% endif_version %}
 
 Every token has its own ID which is available in payload under `jti` key. You can extract ID from token using jwt.io or [`jwt-cli`](https://www.npmjs.com/package/jwt-cli) tool. Here is example of `jti`


### PR DESCRIPTION
A followup of changes in Kuma. Recent Kuma PRs introduced a change to the DP authentication that impacts the behaviour of Universal zones.

Kuma PRs:
* https://github.com/kumahq/kuma/pull/12788
* https://github.com/kumahq/kuma/pull/12828

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)
* Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
* Yes