### PR TITLE
feat(policy): move healthyPanicThreshold field from MeshHealthCheck to MeshCircuitBreaker

### DIFF
--- a/app/_src/policies/meshcircuitbreaker.md
+++ b/app/_src/policies/meshcircuitbreaker.md
@@ -130,6 +130,11 @@ For **gRPC** requests, the outlier detection will use the HTTP status mapped fro
   account: `detectors.localOriginFailures.consecutive`.
 - **`detectors`** - Contains configuration for supported outlier detectors. At least one detector needs to be configured
   when policy is configured for outlier detection.
+{% if_version gte:2.10.x %}
+- **`healthyPanicThreshold`** - (optional) Allows to configure panic threshold for Envoy cluster. If not specified,
+  the default is 50%. To disable panic mode, set to 0%.
+{% endif_version %}
+
 
 #### Detectors configuration
 

--- a/app/_src/policies/meshhealthcheck.md
+++ b/app/_src/policies/meshhealthcheck.md
@@ -281,7 +281,7 @@ spec:
 - **`intervalJitterPercent`** - (optional) if specified, during every interval Envoy will add `intervalJitter` *
   `intervalJitterPercent` / 100 to the wait time. If `intervalJitter` and
   `intervalJitterPercent` are both set, both of them will be used to increase the wait time.
-{% if_version lte:2.10.x %}
+{% if_version lte:2.9.x %}
 - **`healthyPanicThreshold`** - (optional) allows to configure panic threshold for Envoy clusters. If not specified,
   the default is 50%. To disable panic mode, set to 0%.
 {% endif_version %}

--- a/app/_src/policies/meshhealthcheck.md
+++ b/app/_src/policies/meshhealthcheck.md
@@ -281,8 +281,14 @@ spec:
 - **`intervalJitterPercent`** - (optional) if specified, during every interval Envoy will add `intervalJitter` *
   `intervalJitterPercent` / 100 to the wait time. If `intervalJitter` and
   `intervalJitterPercent` are both set, both of them will be used to increase the wait time.
+{% if_version lte:2.10.x %}
+- **`healthyPanicThreshold`** - allows to configure panic threshold for Envoy cluster. If not specified,
+  the default is 50%. To disable panic mode, set to 0%.
+{% endif_version %}
+{% if_version gte:2.10.x %}
 - **`healthyPanicThreshold`** - allows to configure panic threshold for Envoy cluster. If not specified,
   the default is 50%. To disable panic mode, set to 0%. ⚠️This is deprecated from version 2.10.x and has moved to [MeshCircuitBreaker](/docs/{{ page.release }}/policies/meshcircuitbreaker).⚠️
+{% endif_version %}
 - **`failTrafficOnPanic`** - (optional) if set to true, Envoy will not consider any hosts when the cluster is in
   'panic mode'. Instead, the cluster will fail all requests as if all hosts are unhealthy.
   This can help avoid potentially overwhelming a failing service.

--- a/app/_src/policies/meshhealthcheck.md
+++ b/app/_src/policies/meshhealthcheck.md
@@ -282,12 +282,12 @@ spec:
   `intervalJitterPercent` / 100 to the wait time. If `intervalJitter` and
   `intervalJitterPercent` are both set, both of them will be used to increase the wait time.
 {% if_version lte:2.10.x %}
-- **`healthyPanicThreshold`** - allows to configure panic threshold for Envoy cluster. If not specified,
+- **`healthyPanicThreshold`** - (optional) allows to configure panic threshold for Envoy clusters. If not specified,
   the default is 50%. To disable panic mode, set to 0%.
 {% endif_version %}
 {% if_version gte:2.10.x %}
-- **`healthyPanicThreshold`** - allows to configure panic threshold for Envoy cluster. If not specified,
-  the default is 50%. To disable panic mode, set to 0%. ⚠️This is deprecated from version 2.10.x and has moved to [MeshCircuitBreaker](/docs/{{ page.release }}/policies/meshcircuitbreaker).⚠️
+- **`healthyPanicThreshold`** - (optional) allows to configure panic threshold for Envoy clusters. If not specified,
+  the default is 50%. To disable panic mode, set to 0%. ⚠️This is deprecated from version 2.10.x and has been moved to [MeshCircuitBreaker](/docs/{{ page.release }}/policies/meshcircuitbreaker).⚠️
 {% endif_version %}
 - **`failTrafficOnPanic`** - (optional) if set to true, Envoy will not consider any hosts when the cluster is in
   'panic mode'. Instead, the cluster will fail all requests as if all hosts are unhealthy.

--- a/app/_src/policies/meshhealthcheck.md
+++ b/app/_src/policies/meshhealthcheck.md
@@ -282,7 +282,7 @@ spec:
   `intervalJitterPercent` / 100 to the wait time. If `intervalJitter` and
   `intervalJitterPercent` are both set, both of them will be used to increase the wait time.
 - **`healthyPanicThreshold`** - allows to configure panic threshold for Envoy cluster. If not specified,
-  the default is 50%. To disable panic mode, set to 0%.
+  the default is 50%. To disable panic mode, set to 0%. ⚠️This is deprecated from version 2.10.x and has moved to [MeshCircuitBreaker](/docs/{{ page.release }}/policies/meshcircuitbreaker).⚠️
 - **`failTrafficOnPanic`** - (optional) if set to true, Envoy will not consider any hosts when the cluster is in
   'panic mode'. Instead, the cluster will fail all requests as if all hosts are unhealthy.
   This can help avoid potentially overwhelming a failing service.


### PR DESCRIPTION
In Kuma `2.10.*` , the `healthyPanicThreshold` field will be deprecated in `MeshHealthCheck` policy, and the setting has been moved to `MeshCircuitBreaker` policy. Please use `MeshCircuitBreaker` policy instead. 

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
