### PR TITLE
feat(dataplane): add new kind dataplane in policies top level targetRef

### DIFF
--- a/app/_src/policies/meshaccesslog.md
+++ b/app/_src/policies/meshaccesslog.md
@@ -28,12 +28,19 @@ If you haven't, see the [observability docs](/docs/{{ page.release }}/explore/ob
 | `from[].targetRef.kind` | `Mesh`                                                   |
 {% endif_version %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 | `targetRef`             | Allowed kinds                                            |
 | ----------------------- | -------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset`                                     |
 | `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService`             |
 | `from[].targetRef.kind` | `Mesh`                                                   |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`             | Allowed kinds                                |
+| ----------------------- | -------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane`                          |
+| `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService` |
+| `from[].targetRef.kind` | `Mesh`                                       |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshcircuitbreaker.md
+++ b/app/_src/policies/meshcircuitbreaker.md
@@ -48,12 +48,19 @@ target proxies are healthy or not.
 | `to[].targetRef.kind`   | `Mesh`, `MeshService`                                    |
 | `from[].targetRef.kind` | `Mesh`                                                   |
 {% endif_version %}
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 | `targetRef`             | Allowed kinds                                            |
 | ----------------------- | -------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset`                                     |
 | `to[].targetRef.kind`   | `Mesh`, `MeshService`                                    |
 | `from[].targetRef.kind` | `Mesh`                                                   |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`             | Allowed kinds         |
+| ----------------------- | --------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane`   |
+| `to[].targetRef.kind`   | `Mesh`, `MeshService` |
+| `from[].targetRef.kind` | `Mesh`                |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshfaultinjection.md
+++ b/app/_src/policies/meshfaultinjection.md
@@ -20,11 +20,17 @@ Do **not** combine with [FaultInjection](/docs/{{ page.release }}/policies/fault
 | `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
 | `from[].targetRef.kind` | `Mesh`, `MeshSubset`, `MeshServiceSubset`                |
 {% endif_version %}
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 | `targetRef`             | Allowed kinds                                            |
 | ----------------------- | -------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset`                                     |
 | `from[].targetRef.kind` | `Mesh`, `MeshSubset`, `MeshServiceSubset`                |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`             | Allowed kinds                             |
+| ----------------------- | ----------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane`                       |
+| `from[].targetRef.kind` | `Mesh`, `MeshSubset`, `MeshServiceSubset` |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshhealthcheck.md
+++ b/app/_src/policies/meshhealthcheck.md
@@ -33,11 +33,17 @@ This mode generates extra traffic to other proxies and services as described in 
 | `targetRef.kind`      | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
 | `to[].targetRef.kind` | `Mesh`, `MeshService`                                    |
 {% endif_version %}
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 | `targetRef`           | Allowed kinds                                            |
 | --------------------- | -------------------------------------------------------- |
 | `targetRef.kind`      | `Mesh`, `MeshSubset`                                     |
 | `to[].targetRef.kind` | `Mesh`, `MeshService`                                    |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`           | Allowed kinds         |
+| --------------------- | --------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane`   |
+| `to[].targetRef.kind` | `Mesh`, `MeshService` |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshhttproute.md
+++ b/app/_src/policies/meshhttproute.md
@@ -21,11 +21,17 @@ depending on where the request is coming from and where it's going to.
 | `targetRef.kind`      | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
 | `to[].targetRef.kind` | `MeshService`                                            |
 {% endif_version %}
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 | `targetRef`           | Allowed kinds                                            |
 | --------------------- | -------------------------------------------------------- |
 | `targetRef.kind`      | `Mesh`, `MeshSubset`                                     |
 | `to[].targetRef.kind` | `MeshService`                                            |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`           | Allowed kinds       |
+| --------------------- | ------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane` |
+| `to[].targetRef.kind` | `MeshService`       |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshloadbalancingstrategy.md
+++ b/app/_src/policies/meshloadbalancingstrategy.md
@@ -21,11 +21,17 @@ When using this policy, the [localityAwareLoadBalancing](/docs/{{ page.release }
 | `targetRef.kind`      | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
 | `to[].targetRef.kind` | `Mesh`, `MeshService`                                    |
 {% endif_version %}
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 | `targetRef`           | Allowed kinds                                            |
 | --------------------- | -------------------------------------------------------- |
 | `targetRef.kind`      | `Mesh`, `MeshSubset`                                     |
 | `to[].targetRef.kind` | `Mesh`, `MeshService`                                    |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`           | Allowed kinds         |
+| --------------------- | --------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane`   |
+| `to[].targetRef.kind` | `Mesh`, `MeshService` |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshmetric.md
+++ b/app/_src/policies/meshmetric.md
@@ -43,10 +43,15 @@ If you haven't already read the [observability docs](/docs/{{ page.release }}/ex
 | ----------------------- | -------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
 {% endif_version %}
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 | `targetRef`             | Allowed kinds                                            |
 | ----------------------- | -------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset`                                     |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`             | Allowed kinds       |
+| ----------------------- | ------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane` |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshpassthrough.md
+++ b/app/_src/policies/meshpassthrough.md
@@ -13,9 +13,16 @@ When using this policy, the [passthrough mode](/docs/{{ page.release }}/networki
 
 {% tabs targetRef useUrlFragment=false %}
 {% tab targetRef Sidecar %}
+{% if_version lte:2.9.x %}
 | `targetRef`           | Allowed kinds         |
 | --------------------- | --------------------- |
 | `targetRef.kind`      | `Mesh`, `MeshSubset`  |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`           | Allowed kinds        |
+| --------------------- | -------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane`  |
+{% endif_version %}
 {% endtab %}
 {% if_version gte:2.9.x %}
 {% tab targetRef Delegated Gateway %}

--- a/app/_src/policies/meshproxypatch.md
+++ b/app/_src/policies/meshproxypatch.md
@@ -42,10 +42,15 @@ Do **not** combine with [Proxy Template](/docs/{{ page.release }}/policies/proxy
 | --------------------- | -------------------------------------------------------- |
 | `targetRef.kind`      | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
 {% endif_version %}
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 | `targetRef`           | Allowed kinds                                            |
 | --------------------- | -------------------------------------------------------- |
 | `targetRef.kind`      | `Mesh`, `MeshSubset`                                     |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`           | Allowed kinds       |
+| --------------------- | ------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane` |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshratelimit.md
+++ b/app/_src/policies/meshratelimit.md
@@ -31,11 +31,17 @@ Rate limiting supports an [ExternalService](/docs/{{ page.release }}/policies/ex
 | `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
 | `from[].targetRef.kind` | `Mesh`                                                   |
 {% endif_version %}
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 | `targetRef`             | Allowed kinds                                            |
 | ----------------------- | -------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset`                                     |
 | `from[].targetRef.kind` | `Mesh`                                                   |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`             | Allowed kinds       |
+| ----------------------- | ------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane` |
+| `from[].targetRef.kind` | `Mesh`              |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshretry.md
+++ b/app/_src/policies/meshretry.md
@@ -22,11 +22,17 @@ This policy enables {{site.mesh_product_name}} to know how to behave if there ar
 | `to[].targetRef.kind` | `Mesh`, `MeshService`                                    |
 {% endif_version %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 | `targetRef`           | Allowed kinds                                            |
 | --------------------- | -------------------------------------------------------- |
 | `targetRef.kind`      | `Mesh`, `MeshSubset`                                     |
 | `to[].targetRef.kind` | `Mesh`, `MeshService`, `MeshExternalService`             |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`           | Allowed kinds                                |
+| --------------------- | -------------------------------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane`                          |
+| `to[].targetRef.kind` | `Mesh`, `MeshService`, `MeshExternalService` |
 {% endif_version %}
 {% if_version lte:2.5.x %}
 | `targetRef.kind`    | top level | to  | from |

--- a/app/_src/policies/meshtcproute.md
+++ b/app/_src/policies/meshtcproute.md
@@ -27,11 +27,17 @@ depending on where the request is coming from and where it's going to.
 | `targetRef.kind`      | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
 | `to[].targetRef.kind` | `MeshService`                                            |
 {% endif_version %}
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 | `targetRef`           | Allowed kinds                                            |
 | --------------------- | -------------------------------------------------------- |
 | `targetRef.kind`      | `Mesh`, `MeshSubset`                                     |
 | `to[].targetRef.kind` | `MeshService`                                            |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`           | Allowed kinds       |
+| --------------------- | ------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane` |
+| `to[].targetRef.kind` | `MeshService`       |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshtimeout.md
+++ b/app/_src/policies/meshtimeout.md
@@ -21,12 +21,19 @@ Do **not** combine with [Timeout policy](/docs/{{ page.release }}/policies/timeo
 | `from[].targetRef.kind` | `Mesh`                                                                    |
 {% endif_version %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 | `targetRef`             | Allowed kinds                                                             |
 | ----------------------- | ------------------------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshHTTPRoute`                                     |
 | `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService`                              |
 | `from[].targetRef.kind` | `Mesh`                                                                    |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`             | Allowed kinds                                |
+| ----------------------- | -------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane`, `MeshHTTPRoute`         |
+| `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService` |
+| `from[].targetRef.kind` | `Mesh`                                       |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshtls.md
+++ b/app/_src/policies/meshtls.md
@@ -9,10 +9,18 @@ Backends and default mode values are taken from [the Mesh object](/docs/{{ page.
 
 {% tabs targetRef useUrlFragment=false %}
 {% tab targetRef For mode %}
+{% if_version eq:2.9.x %}
 | `targetRef`             | Allowed kinds        |
 | ----------------------- | -------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset` |
 | `from[].targetRef.kind` | `Mesh`               |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`             | Allowed kinds       |
+| ----------------------- | ------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane` |
+| `from[].targetRef.kind` | `Mesh`              |
+{% endif_version %}
 {% endtab %}
 {% tab targetRef For tls ciphers/version %}
 | `targetRef`             | Allowed kinds       |

--- a/app/_src/policies/meshtrace.md
+++ b/app/_src/policies/meshtrace.md
@@ -41,10 +41,15 @@ For HTTP you can also manually forward the following headers:
 | --------------------- | -------------------------------------------------------- |
 | `targetRef.kind`      | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
 {% endif_version %}
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 | `targetRef`           | Allowed kinds                                            |
 | --------------------- | -------------------------------------------------------- |
 | `targetRef.kind`      | `Mesh`, `MeshSubset`                                     |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`           | Allowed kinds       |
+| --------------------- | ------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane` |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshtrafficpermission.md
+++ b/app/_src/policies/meshtrafficpermission.md
@@ -25,11 +25,17 @@ It allows you to define granular rules about which services can communicate with
 | `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
 | `from[].targetRef.kind` | `Mesh`, `MeshSubset`, `MeshServiceSubset`                |
 {% endif_version %}
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 | `targetRef`             | Allowed kinds                                            |
 | ----------------------- | -------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset`                                     |
 | `from[].targetRef.kind` | `Mesh`, `MeshSubset`, `MeshServiceSubset`                |
+{% endif_version %}
+{% if_version gte:2.10.x %}
+| `targetRef`             | Allowed kinds                             |
+| ----------------------- | ----------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane`                       |
+| `from[].targetRef.kind` | `Mesh`, `MeshSubset`, `MeshServiceSubset` |
 {% endif_version %}
 {% endtab %}
 {% tab targetRef27x Builtin Gateway %}


### PR DESCRIPTION
In 2.10 we are adding new top level kind Dataplane. This PR updates targetRef support matrix with new kind

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
