### PR TITLE
feat(dataplane): use dataplane kind in policy examples

### DIFF
--- a/app/_src/policies/meshaccesslog.md
+++ b/app/_src/policies/meshaccesslog.md
@@ -614,7 +614,7 @@ Apply the configuration with `kumactl apply -f [..]` or with the [HTTP API](/doc
 {% endtabs %}
 {% endif_version %}
 
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 {% policy_yaml usage-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshAccessLog
@@ -624,6 +624,34 @@ spec:
   targetRef:
     kind: MeshSubset
     tags:
+      app: frontend
+      version: canary
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        sectionName: http
+        _port: 8080
+      default:
+        backends:
+          - type: File
+            file:
+              path: /dev/stdout
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml usage-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshAccessLog
+name: frontend-to-backend
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: frontend
       version: canary
   to:

--- a/app/_src/policies/meshcircuitbreaker.md
+++ b/app/_src/policies/meshcircuitbreaker.md
@@ -512,7 +512,8 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml usage-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshCircuitBreaker
@@ -522,6 +523,34 @@ spec:
   targetRef:
     kind: MeshSubset
     tags:
+      app: web
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        sectionName: http
+        _port: 8080
+      default:
+        connectionLimits:
+          maxConnections: 2
+          maxPendingRequests: 8
+          maxRetries: 2
+          maxRequests: 2
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml usage-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshCircuitBreaker
+name: web-to-backend-circuit-breaker
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: web
   to:
     - targetRef:
@@ -580,7 +609,8 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml protocol-29x namespace=kuma-demo %}
 ```yaml
 type: MeshCircuitBreaker
@@ -590,6 +620,46 @@ spec:
   targetRef:
     kind: MeshSubset
     tags:
+      app: web
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        outlierDetection:
+          interval: 5s
+          baseEjectionTime: 30s
+          maxEjectionPercent: 20
+          splitExternalAndLocalErrors: true
+          detectors:
+          detectors:
+            totalFailures:
+              consecutive: 10
+            gatewayFailures:
+              consecutive: 10
+            localOriginFailures:
+              consecutive: 10
+            successRate:
+              minimumHosts: 5
+              requestVolume: 10
+              standardDeviationFactor: 1.9
+            failurePercentage:
+              requestVolume: 10
+              minimumHosts: 5
+              threshold: 85
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml protocol-210x namespace=kuma-demo %}
+```yaml
+type: MeshCircuitBreaker
+name: backend-inbound-outlier-detection
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: web
   from:
     - targetRef:

--- a/app/_src/policies/meshfaultinjection.md
+++ b/app/_src/policies/meshfaultinjection.md
@@ -173,6 +173,7 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
+
 {% if_version gte:2.6.x %}
 {% if_version lte:2.8.x %}
 {% policy_yaml meshfaultinjection-backend-to-frontend-simple-26x %}
@@ -200,7 +201,8 @@ spec:
 {% endpolicy_yaml %}
 {% endif_version %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml meshfaultinjection-backend-to-frontend-simple-29x namespace=kuma-demo %}
 ```yaml
 type: MeshFaultInjection
@@ -211,6 +213,31 @@ spec:
     kind: MeshSubset
     proxyTypes: ["Sidecar"]
     tags:
+      app: backend
+  from:
+    - targetRef:
+        kind: MeshSubset
+        tags:
+          kuma.io/service: frontend
+      default:
+        http:
+          - abort:
+              httpStatus: 500
+              percentage: 50
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml meshfaultinjection-backend-to-frontend-simple-210x namespace=kuma-demo %}
+```yaml
+type: MeshFaultInjection
+mesh: default
+name: default-fault-injection
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: backend
   from:
     - targetRef:
@@ -277,7 +304,8 @@ spec:
 {% endpolicy_yaml %}
 {% endif_version %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml meshfaultinjection-from-all-29x namespace=kuma-demo useUrlFragment %}
 ```yaml
 type: MeshFaultInjection
@@ -288,6 +316,30 @@ spec:
     kind: MeshSubset
     proxyTypes: ["Sidecar"]
     tags:
+      app: backend
+  from:
+    - targetRef:
+        kind: Mesh
+        name: default
+      default:
+        http:
+          - delay:
+              percentage: "50.5"
+              value: 5s
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml meshfaultinjection-from-all-210x namespace=kuma-demo useUrlFragment %}
+```yaml
+type: MeshFaultInjection
+mesh: default
+name: default-fault-injection
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: backend
   from:
     - targetRef:
@@ -367,7 +419,8 @@ spec:
 {% endpolicy_yaml %}
 {% endif_version %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml meshfaultinjection-list-of-faults-29x namespace=kuma-demo useUrlFragment %}
 ```yaml
 type: MeshFaultInjection
@@ -378,6 +431,37 @@ spec:
     kind: MeshSubset
     proxyTypes: ["Sidecar"]
     tags:
+      app: backend
+  from:
+    - targetRef:
+        kind: MeshSubset
+        tags:
+          kuma.io/service: frontend
+      default:
+        http:
+          - abort:
+              httpStatus: 500
+              percentage: "2.5"
+          - abort:
+              httpStatus: 500
+              percentage: 10
+          - delay:
+              value: 5s
+              percentage: 5
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml meshfaultinjection-list-of-faults-210x namespace=kuma-demo useUrlFragment %}
+```yaml
+type: MeshFaultInjection
+mesh: default
+name: default-fault-injection
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: backend
   from:
     - targetRef:

--- a/app/_src/policies/meshhealthcheck.md
+++ b/app/_src/policies/meshhealthcheck.md
@@ -127,7 +127,8 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml usage-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshHealthCheck
@@ -138,6 +139,36 @@ spec:
     kind: MeshSubset
     tags:
       kuma.io/service: web
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        sectionName: http
+        _port: 3001
+      default:
+        interval: 10s
+        timeout: 2s
+        unhealthyThreshold: 3
+        healthyThreshold: 1
+        http:
+          path: /health
+          expectedStatuses: [200, 201]
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml usage-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshHealthCheck
+name: web-to-backend-check
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      app: web
   to:
     - targetRef:
         kind: MeshService
@@ -187,7 +218,8 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml protocol-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshHealthCheck
@@ -216,6 +248,37 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml protocol-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshHealthCheck
+name: web-to-backend-check
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      app: web
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        sectionName: http
+        _port: 3001
+      default:
+        interval: 10s
+        timeout: 2s
+        unhealthyThreshold: 3
+        healthyThreshold: 1
+        tcp: {} # http has "disabled=true" so TCP (a more general protocol) is used as a fallback
+        http:
+          disabled: true
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
 
 #### gRPC health check from cart to payment service
 
@@ -246,7 +309,8 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml grpc-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshHealthCheck
@@ -257,6 +321,35 @@ spec:
     kind: MeshSubset
     tags:
       kuma.io/service: web
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        sectionName: http
+        _port: 3001
+      default:
+        interval: 15s
+        timeout: 5s
+        unhealthyThreshold: 3
+        healthyThreshold: 2
+        grpc:
+          serviceName: "grpc.health.v1.CustomHealth"
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml grpc-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshHealthCheck
+name: web-to-backend-check
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      app: web
   to:
     - targetRef:
         kind: MeshService

--- a/app/_src/policies/meshhttproute.md
+++ b/app/_src/policies/meshhttproute.md
@@ -280,6 +280,7 @@ If we want to split traffic between `v1` and `v2` versions of the same service,
 first we have to create MeshServices `backend-v1` and `backend-v2` that select 
 backend application instances according to the version.
 
+{% if_version eq:2.9.x %}
 {% policy_yaml traffic-split namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshHTTPRoute
@@ -318,6 +319,48 @@ spec:
                 weight: 10
 ```
 {% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml traffic-split-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshHTTPRoute
+name: http-split
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      app: frontend
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        sectionName: http
+        _port: 3001
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+          default:
+            backendRefs:
+              - kind: MeshService
+                name: backend
+                namespace: kuma-demo
+                port: 3001
+                _version: v1
+                weight: 90
+              - kind: MeshService
+                name: backend
+                namespace: kuma-demo
+                port: 3001
+                _version: v2
+                weight: 10
+```
+{% endpolicy_yaml %}
+{% endif_version %}
 
 {% endif_version %}
 
@@ -363,7 +406,7 @@ spec:
 {% endpolicy_yaml %}
 {% endif_version %}
 
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 {% policy_yaml traffic-modification-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshHTTPRoute
@@ -373,6 +416,40 @@ spec:
   targetRef:
     kind: MeshSubset
     tags:
+      app: frontend
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        sectionName: http
+        _port: 3001
+      rules:
+        - matches:
+            - path:
+                type: Exact
+                value: /
+          default:
+            filters:
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  set:
+                    - name: x-custom-header
+                      value: xyz
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml traffic-modification-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshHTTPRoute
+name: http-route-1
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: frontend
   to:
     - targetRef:
@@ -448,7 +525,7 @@ spec:
 {% endpolicy_yaml %}
 {% endif_version %}
 
-{% if_version gte:2.9.x %}
+{% if_version eq:2.9.x %}
 {% policy_yaml traffic-mirror-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshHTTPRoute
@@ -458,6 +535,50 @@ spec:
   targetRef:
     kind: MeshSubset
     tags:
+      app: frontend
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        sectionName: http 
+        _port: 3001
+      rules:
+        - matches:
+            - headers:
+                - type: Exact
+                  name: mirror-this-request
+                  value: "true"
+          default:
+            filters:
+              - type: RequestMirror
+                requestMirror:
+                  percentage: 30
+                  backendRef:
+                    kind: MeshService
+                    name: backend
+                    namespace: kuma-demo
+                    port: 3001
+                    _version: v1-experimental
+            backendRefs:
+              - kind: MeshService
+                name: backend
+                namespace: kuma-demo
+                port: 3001
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml traffic-mirror-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshHTTPRoute
+name: http-route-1
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: frontend
   to:
     - targetRef:

--- a/app/_src/policies/meshloadbalancingstrategy.md
+++ b/app/_src/policies/meshloadbalancingstrategy.md
@@ -261,7 +261,8 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml ring-hash-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshLoadBalancingStrategy
@@ -271,6 +272,36 @@ spec:
   targetRef:
     kind: MeshSubset
     tags:
+      app: frontend
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        _port: 8080
+        sectionName: http
+      default:
+        loadBalancer:
+          type: RingHash
+          ringHash:
+            hashPolicies:
+              - type: Header
+                header:
+                  name: x-header
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml ring-hash-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshLoadBalancingStrategy
+name: ring-hash
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: frontend
   to:
     - targetRef:
@@ -316,6 +347,7 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
+
 {% if_version gte:2.9.x %}
 {% policy_yaml disable-la-to-backend-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml

--- a/app/_src/policies/meshpassthrough.md
+++ b/app/_src/policies/meshpassthrough.md
@@ -66,7 +66,8 @@ The following describes the default configuration settings of the `MeshPassthrou
 Currently, support for partial subdomain matching is not implemented. For example, a match for `*w.example.com` will be rejected.
 {% endwarning %}
 
-{% policy_yaml wildcard %}
+{% if_version eq:2.9.x %}
+{% policy_yaml wildcard-29x %}
 ```yaml
 type: MeshPassthrough
 name: wildcard-passthrough
@@ -84,6 +85,27 @@ spec:
       port: 443
 ```
 {% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml wildcard-210x %}
+```yaml
+type: MeshPassthrough
+name: wildcard-passthrough
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+  default:
+    passthroughMode: Matched
+    appendMatch:
+    - type: Domain
+      value: '*.cluster-1.kafka.aws.us-east-2.com'
+      protocol: tls
+      port: 443
+```
+{% endpolicy_yaml %}
+{% endif_version %}
 
 ### Security
 
@@ -107,7 +129,8 @@ If you rely on tags in the top-level `targetRef` you might consider securing the
 
 ### Disable passthrough for all sidecars
 
-{% policy_yaml example1 %}
+{% if_version eq:2.9.x %}
+{% policy_yaml example1-29x %}
 ```yaml
 type: MeshPassthrough
 name: disable-passthrough
@@ -120,10 +143,27 @@ spec:
     passthroughMode: None
 ```
 {% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml example1-210x %}
+```yaml
+type: MeshPassthrough
+name: disable-passthrough
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+  default:
+    passthroughMode: None
+```
+{% endpolicy_yaml %}
+{% endif_version %}
 
 ### Enable passthrough for a subset of sidecars
 
-{% policy_yaml example2 %}
+{% if_version eq:2.9.x %}
+{% policy_yaml example2-29x %}
 ```yaml
 type: MeshPassthrough
 name: enable-passthrough
@@ -138,10 +178,29 @@ spec:
     passthroughMode: All
 ```
 {% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml example2-210x %}
+```yaml
+type: MeshPassthrough
+name: enable-passthrough
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      app: demo-app
+  default:
+    passthroughMode: All
+```
+{% endpolicy_yaml %}
+{% endif_version %}
 
 ### Allow a subset of services to communicate with specific external endpoints
 
-{% policy_yaml example3 %}
+{% if_version eq:2.9.x %}
+{% policy_yaml example3-29x %}
 ```yaml
 type: MeshPassthrough
 name: allow-some-passthrough
@@ -177,6 +236,45 @@ spec:
       port: 80
 ```
 {% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml example3-210x %}
+```yaml
+type: MeshPassthrough
+name: allow-some-passthrough
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      app: demo-app
+  default:
+    passthroughMode: Matched
+    appendMatch:
+    - type: Domain
+      value: httpbin.org
+      protocol: tls
+      port: 443
+    - type: IP
+      value: 10.240.15.39
+      protocol: tcp
+      port: 8888
+    - type: CIDR
+      value: 10.250.0.0/16
+      protocol: tcp
+      port: 10000
+    - type: Domain
+      value: '*.wikipedia.org'
+      protocol: tls
+      port: 443
+    - type: Domain
+      value: httpbin.dev
+      protocol: http
+      port: 80
+```
+{% endpolicy_yaml %}
+{% endif_version %}
 
 ## All policy options
 

--- a/app/_src/policies/meshratelimit.md
+++ b/app/_src/policies/meshratelimit.md
@@ -141,6 +141,7 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
+
 {% if_version gte:2.6.x %}
 {% if_version lte:2.8.x %}
 {% policy_yaml http-rate-limit-26x %}
@@ -173,8 +174,9 @@ spec:
 {% endpolicy_yaml %}
 {% endif_version %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
-{% policy_yaml http-rate-limit-namespaced namespace=kuma-demo %}
+
+{% if_version eq:2.9.x %}
+{% policy_yaml http-rate-limit-namespaced-29x namespace=kuma-demo %}
 ```yaml
 type: MeshRateLimit
 mesh: default
@@ -184,6 +186,36 @@ spec:
     kind: MeshSubset
     proxyTypes: ["Sidecar"]
     tags:
+      app: backend
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        local:
+          http:
+            requestRate:
+              num: 5
+              interval: 10s
+            onRateLimit:
+              status: 423
+              headers:
+                set:
+                  - name: "x-kuma-rate-limited"
+                    value: "true"
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml http-rate-limit-namespaced-210x namespace=kuma-demo %}
+```yaml
+type: MeshRateLimit
+mesh: default
+name: backend-rate-limit
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: backend
   from:
     - targetRef:
@@ -229,6 +261,7 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
+
 {% if_version gte:2.6.x %}
 {% if_version lte:2.8.x %}
 {% policy_yaml from-backend-26x %}
@@ -255,8 +288,9 @@ spec:
 {% endpolicy_yaml %}
 {% endif_version %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
-{% policy_yaml from-backend-namespaced namespace=kuma-demo %}
+
+{% if_version eq:2.9.x %}
+{% policy_yaml from-backend-namespaced-29x namespace=kuma-demo %}
 ```yaml
 type: MeshRateLimit
 name: backend-rate-limit
@@ -266,6 +300,30 @@ spec:
     kind: MeshSubset
     proxyTypes: ["Sidecar"]
     tags:
+      app: backend
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        local:
+          tcp:
+            connectionRate:
+              num: 5
+              interval: 10s
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml from-backend-namespaced-210x namespace=kuma-demo %}
+```yaml
+type: MeshRateLimit
+name: backend-rate-limit
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: backend
   from:
     - targetRef:

--- a/app/_src/policies/meshretry.md
+++ b/app/_src/policies/meshretry.md
@@ -251,7 +251,8 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml meshretry-http-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshRetry
@@ -280,6 +281,37 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml meshretry-http-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshRetry
+name: frontend-to-backend-retry-http
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      app: frontend
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        sectionName: http
+        _port: 8080
+      default:
+        http:
+          numRetries: 10
+          backOff:
+            baseInterval: 15s
+            maxInterval: 20m
+          retryOn:
+            - "5xx"
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
 
 ### gRPC frontend to backend on DeadlineExceeded
 
@@ -310,7 +342,8 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml meshretry-grpc-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshRetry
@@ -319,6 +352,36 @@ mesh: default
 spec:
   targetRef:
     kind: MeshSubset
+    tags:
+      app: frontend
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        sectionName: http
+        _port: 8080
+      default:
+        grpc:
+          numRetries: 5
+          backOff:
+            baseInterval: 5s
+            maxInterval: 1m
+          retryOn:
+            - "DeadlineExceeded"
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml meshretry-grpc-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshRetry
+name: frontend-to-backend-retry-grpc
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
     tags:
       app: frontend
   to:
@@ -364,7 +427,8 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml meshretry-tcp-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshRetry
@@ -374,6 +438,31 @@ spec:
   targetRef:
     kind: MeshSubset
     tags:
+      app: frontend
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        sectionName: http
+        _port: 8080
+      default:
+        tcp:
+          maxConnectAttempt: 5
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml meshretry-tcp-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshRetry
+name: frontend-to-backend-retry-tcp
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: frontend
   to:
     - targetRef:

--- a/app/_src/policies/meshtcproute.md
+++ b/app/_src/policies/meshtcproute.md
@@ -86,6 +86,7 @@ so the policy structure looks like the following:
 
 [//]: # (TODO: https://github.com/kumahq/kuma-website/issues/2020)
 
+{% if_version lte:2.8.x %}
 ```yaml
 spec:
   targetRef: # top-level targetRef selects a group of proxies to configure
@@ -98,6 +99,37 @@ spec:
         - default: # configuration applied for the matched TCP traffic
             backendRefs: [...]
 ```
+{% endif_version %}
+
+{% if_version eq:2.9.x %}
+```yaml
+spec:
+  targetRef: # top-level targetRef selects a group of proxies to configure
+    kind: Mesh|MeshSubset 
+  to:
+    - targetRef: # targetRef selects a destination (outbound listener)
+        kind: MeshService
+        name: backend
+      rules:
+        - default: # configuration applied for the matched TCP traffic
+            backendRefs: [...]
+```
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+```yaml
+spec:
+  targetRef: # top-level targetRef selects a group of proxies to configure
+    kind: Mesh|Dataplane 
+  to:
+    - targetRef: # targetRef selects a destination (outbound listener)
+        kind: MeshService
+        name: backend
+      rules:
+        - default: # configuration applied for the matched TCP traffic
+            backendRefs: [...]
+```
+{% endif_version %}
 
 ### Default configuration
 
@@ -183,6 +215,7 @@ If we want to split traffic between `v1` and `v2` versions of the same service,
 first we have to create MeshServices `backend-v1` and `backend-v2` that select
 backend application instances according to the version.
 
+{% if_version eq:2.9.x %}
 {% policy_yaml traffic-split-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshTCPRoute
@@ -217,6 +250,45 @@ spec:
                 weight: 10
 ```
 {% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml traffic-split-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshTCPRoute
+name: tcp-route-1
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      app: frontend
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        _port: 3001
+        sectionName: http
+      rules:
+        - default:
+            backendRefs:
+              - kind: MeshService
+                name: backend
+                namespace: kuma-demo
+                port: 3001
+                _version: v0
+                weight: 90
+              - kind: MeshService
+                name: backend
+                namespace: kuma-demo
+                port: 3001
+                _version: v1
+                weight: 10
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
 {% endif_version %}
 
 ### Traffic redirection
@@ -256,7 +328,8 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml modifications-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshTCPRoute
@@ -266,6 +339,36 @@ spec:
   targetRef:
     kind: MeshSubset
     tags:
+      app: frontend
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        _port: 3001
+        sectionName: http
+      rules:
+        - default:
+            backendRefs:
+              - kind: MeshService
+                name: external-backend
+                namespace: kuma-demo
+                port: 8080
+                _port: 8080
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml modifications-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshTCPRoute
+name: tcp-route-1
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: frontend
   to:
     - targetRef:
@@ -335,7 +438,8 @@ to:
               name: other-http-backend_kuma-demo_svc_8080
 ```
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml collision-tcp-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshHTTPRoute
@@ -372,6 +476,67 @@ spec:
   targetRef:
     kind: MeshSubset
     tags:
+      app: frontend
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        _port: 3001
+        sectionName: http
+      rules:
+        - matches:
+          path:
+              type: PathPrefix
+              value: "/"
+          default:
+            backendRefs:
+              - kind: MeshService
+                name: other-http-backend
+                namespace: kuma-demo
+                port: 8080
+                _port: 8080
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml collision-tcp-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshHTTPRoute
+name: simple-http
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      app: frontend
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        _port: 3001
+        sectionName: http
+      rules:
+        - default:
+            backendRefs:
+              - kind: MeshService
+                name: other-tcp-backend
+                namespace: kuma-demo
+                port: 8080
+                _port: 8080
+```
+{% endpolicy_yaml %}
+{% policy_yaml collision-http-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshHTTPRoute
+name: simple-http
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: frontend
   to:
     - targetRef:

--- a/app/_src/policies/meshtimeout.md
+++ b/app/_src/policies/meshtimeout.md
@@ -265,7 +265,8 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml example3-29x namespace=kuma-demo %}
 ```yaml
 type: MeshTimeout
@@ -275,6 +276,27 @@ spec:
   targetRef:
     kind: MeshSubset
     tags:
+      app: backend
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        idleTimeout: 20s
+        connectionTimeout: 2s
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml example3-210x namespace=kuma-demo %}
+```yaml
+type: MeshTimeout
+name: inbound-timeout
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: backend
   from:
     - targetRef:
@@ -330,7 +352,8 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml example4-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshTimeout
@@ -340,6 +363,47 @@ spec:
   targetRef:
     kind: MeshSubset
     tags:
+      app: frontend
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        idleTimeout: 60s
+        connectionTimeout: 2s
+        http:
+          requestTimeout: 10s
+          streamIdleTimeout: 1h
+          maxStreamDuration: 30m
+          maxConnectionDuration: 30m
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        _port: 3001
+        sectionName: http
+      default:
+        idleTimeout: 60s
+        connectionTimeout: 1s
+        http:
+          requestTimeout: 5s
+          streamIdleTimeout: 1h
+          maxStreamDuration: 30m
+          maxConnectionDuration: 30m
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml example4-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshTimeout
+name: inbound-timeout
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: frontend
   from:
     - targetRef:
@@ -413,7 +477,8 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml example5-29x namespace=kuma-demo use_meshservice=true %}
 ```yaml
 type: MeshHTTPRoute
@@ -423,6 +488,39 @@ spec:
   targetRef:
     kind: MeshSubset
     tags:
+      app: frontend
+  to:
+    - targetRef:
+        kind: MeshService
+        name: backend
+        namespace: kuma-demo
+        _port: 3001
+        sectionName: http
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /v2
+          default:
+            backendRefs:
+              - kind: MeshService
+                name: backend-v2
+                namespace: kuma-demo
+                port: 3001
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml example5-210x namespace=kuma-demo use_meshservice=true %}
+```yaml
+type: MeshHTTPRoute
+name: route-to-backend-v2
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       app: frontend
   to:
     - targetRef:
@@ -467,6 +565,7 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
+
 {% if_version gte:2.9.x %}
 {% policy_yaml example6-29x namespace=kuma-demo %}
 ```yaml

--- a/app/_src/policies/meshtls.md
+++ b/app/_src/policies/meshtls.md
@@ -73,7 +73,8 @@ spec:
 
 ### Enable strict mode on specific subset
 
-{% policy_yaml example2 %}
+{% if_version eq:2.9.x %}
+{% policy_yaml example2-29x %}
 ```yaml
 type: MeshTLS
 name: strict-mode
@@ -90,6 +91,27 @@ spec:
         mode: Strict
 ```
 {% endpolicy_yaml %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml example2-210x %}
+```yaml
+type: MeshTLS
+name: strict-mode
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      app: redis
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        mode: Strict
+```
+{% endpolicy_yaml %}
+{% endif_version %}
 
 ## All policy options
 

--- a/app/_src/policies/meshtrace.md
+++ b/app/_src/policies/meshtrace.md
@@ -682,6 +682,7 @@ spec:
 {% endif_version %}
 
 {% if_version gte:2.3.x %}
+{% if_version lte:2.9.x %}
 West only policy:
 
 {% policy_yaml west-only-23x %}
@@ -713,6 +714,48 @@ spec:
   targetRef:
     kind: MeshSubset
     tags:
+      kuma.io/zone: east
+  default:
+    backends:
+      - zipkin:
+          url: http://east.zipkincollector:9411/api/v2/spans
+```
+{% endpolicy_yaml %}
+{% endif_version %}
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+West only policy:
+
+{% policy_yaml west-only-210x %}
+```yaml
+type: MeshTrace
+name: trace-west
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      kuma.io/zone: west
+  default:
+    backends:
+      - type: Zipkin
+        zipkin:
+          url: http://west.zipkincollector:9411/api/v2/spans
+```
+{% endpolicy_yaml %}
+
+East only policy:
+
+{% policy_yaml east-only-210x %}
+```yaml
+type: MeshTrace
+name: trace-east
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
       kuma.io/zone: east
   default:
     backends:

--- a/app/_src/policies/meshtrafficpermission.md
+++ b/app/_src/policies/meshtrafficpermission.md
@@ -104,8 +104,38 @@ spec:
         action: Allow
 ```
 {% endpolicy_yaml %}
+
+#### Explanation
+
+1. Top level `targetRef` selects data plane proxies that implement `payments` service.
+   MeshTrafficPermission `allow-orders` will be configured on these proxies.
+
+    ```yaml
+    targetRef: # 1
+      kind: MeshService
+      name: payments
+    ```
+
+2. `TargetRef` inside the `from` array selects proxies that implement `order` service.
+   These proxies will be subjected to the action from `default.action`.
+
+    ```yaml
+    - targetRef: # 2
+        kind: MeshSubset
+        tags: 
+          kuma.io/service: orders
+    ```
+
+3. The action is `Allow`. All requests from service `orders` will be allowed on service `payments`.
+
+    ```yaml
+    default: # 3
+      action: Allow
+    ```
+
 {% endif_version %}
-{% if_version gte:2.9.x %}
+
+{% if_version eq:2.9.x %}
 {% policy_yaml allow-orders-29x namespace=kuma-demo %}
 ```yaml
 type: MeshTrafficPermission
@@ -125,21 +155,21 @@ spec:
         action: Allow
 ```
 {% endpolicy_yaml %}
-{% endif_version %}
 
 #### Explanation
 
-1. Top level `targetRef` selects data plane proxies that implement `payments` service.
-    MeshTrafficPermission `allow-orders` will be configured on these proxies.
+1. Top level `targetRef` selects data plane proxies that have `app: payments` tag.
+   MeshTrafficPermission `allow-orders` will be configured on these proxies.
 
     ```yaml
     targetRef: # 1
-      kind: MeshService
-      name: payments
+      kind: MeshSubset
+      tags:
+        app: payments
     ```
 
 2. `TargetRef` inside the `from` array selects proxies that implement `order` service.
-    These proxies will be subjected to the action from `default.action`.
+   These proxies will be subjected to the action from `default.action`.
 
     ```yaml
     - targetRef: # 2
@@ -154,6 +184,60 @@ spec:
     default: # 3
       action: Allow
     ```
+
+{% endif_version %}
+
+{% if_version gte:2.10.x %}
+{% policy_yaml allow-orders-210x namespace=kuma-demo %}
+```yaml
+type: MeshTrafficPermission
+name: allow-orders
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      app: payments
+  from:
+    - targetRef:
+        kind: MeshSubset
+        tags: 
+          kuma.io/service: orders
+      default:
+        action: Allow
+```
+{% endpolicy_yaml %}
+
+#### Explanation
+
+1. Top level `targetRef` selects data plane proxies that have `app: payments` label.
+   MeshTrafficPermission `allow-orders` will be configured on these proxies.
+
+    ```yaml
+    targetRef: # 1
+      kind: Dataplane
+      labels:
+        app: payments
+    ```
+
+2. `TargetRef` inside the `from` array selects proxies that implement `order` service.
+   These proxies will be subjected to the action from `default.action`.
+
+    ```yaml
+    - targetRef: # 2
+        kind: MeshSubset
+        tags: 
+          kuma.io/service: orders
+    ```
+
+3. The action is `Allow`. All requests from service `orders` will be allowed on service `payments`.
+
+    ```yaml
+    default: # 3
+      action: Allow
+    ```
+
+{% endif_version %}
 
 ### Deny all
 
@@ -173,22 +257,6 @@ spec:
         action: Deny
 ```
 {% endpolicy_yaml %}
-{% endif_version %}
-{% if_version gte:2.9.x %}
-{% policy_yaml deny-all-29x namespace=kuma-demo %}
-```yaml
-type: MeshTrafficPermission
-name: deny-all
-mesh: default
-spec:
-  from:
-    - targetRef: # 2
-        kind: Mesh
-      default: # 3
-        action: Deny
-```
-{% endpolicy_yaml %}
-{% endif_version %}
 
 #### Explanation
 
@@ -213,6 +281,42 @@ spec:
       action: Deny
     ```
 
+{% endif_version %}
+
+{% if_version gte:2.9.x %}
+{% policy_yaml deny-all-29x namespace=kuma-demo %}
+```yaml
+type: MeshTrafficPermission
+name: deny-all
+mesh: default
+spec:
+  from:
+    - targetRef: # 2
+        kind: Mesh
+      default: # 3
+        action: Deny
+```
+{% endpolicy_yaml %}
+
+#### Explanation
+
+1. Since top level `targetRef` is empty it selects all proxies in the mesh.
+2. `TargetRef` inside the `from` array selects all clients.
+
+    ```yaml
+    - targetRef: # 2
+        kind: Mesh
+    ```
+
+3. The action is `Deny`. All requests from all services will be denied on all proxies in the `default` mesh.
+
+    ```yaml
+    default: # 3
+      action: Deny
+    ```
+
+{% endif_version %}
+
 ### Allow all
 
 {% if_version lte:2.8.x %}
@@ -231,22 +335,6 @@ spec:
         action: Allow
 ```
 {% endpolicy_yaml %}
-{% endif_version %}
-{% if_version gte:2.9.x %}
-{% policy_yaml allow-all-29x namespace=kuma-demo %}
-```yaml
-type: MeshTrafficPermission
-name: allow-all
-mesh: default
-spec:
-  from:
-    - targetRef: # 2
-        kind: Mesh
-      default: # 3
-        action: Allow
-```
-{% endpolicy_yaml %}
-{% endif_version %}
 
 #### Explanation
 
@@ -270,6 +358,42 @@ spec:
     default: # 3
       action: Allow
     ```
+
+{% endif_version %}
+
+{% if_version gte:2.9.x %}
+{% policy_yaml allow-all-29x namespace=kuma-demo %}
+```yaml
+type: MeshTrafficPermission
+name: allow-all
+mesh: default
+spec:
+  from:
+    - targetRef: # 2
+        kind: Mesh
+      default: # 3
+        action: Allow
+```
+{% endpolicy_yaml %}
+
+#### Explanation
+
+1. Since top level `targetRef` is empty it selects all proxies in the mesh.
+2. `targetRef` inside the element of the `from` array selects all clients within the mesh.
+
+    ```yaml
+    - targetRef: # 2
+        kind: Mesh
+    ```
+
+3. The action is `Allow`. All requests from all services will be allow on all proxies in the `default` mesh.
+
+    ```yaml
+    default: # 3
+      action: Allow
+    ```
+
+{% endif_version %}
 
 ### Allow requests from zone 'us-east', deny requests from 'dev' environment
 
@@ -298,6 +422,7 @@ spec:
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
+
 {% if_version gte:2.9.x %}
 {% policy_yaml tags-29x namespace=kuma-demo %}
 ```yaml
@@ -322,6 +447,7 @@ spec:
 {% endpolicy_yaml %}
 {% endif_version %}
 
+{% if_version lte:2.8.x %}
 #### Explanation
 
 1. Top level `targetRef` selects all proxies in the mesh.
@@ -364,6 +490,46 @@ spec:
     default: # 5
       action: Deny
     ```
+{% endif_version %}
+
+{% if_version gte:2.9.x %}
+#### Explanation
+
+1. Since top level `targetRef` is empty it selects all proxies in the mesh.
+2. `TargetRef` inside the `from` array selects proxies that have label `kuma.io/zone: us-east`.
+   These proxies will be subjected to the action from `default.action`.
+
+    ```yaml
+    - targetRef: # 2
+        kind: MeshSubset
+        tags:
+          kuma.io/zone: us-east
+    ```
+
+3. The action is `Allow`. All requests from the zone `us-east` will be allowed on all proxies.
+
+    ```yaml
+    default: # 3
+      action: Allow
+    ```
+
+4. `TargetRef` inside the `from` array selects proxies that have tags `kuma.io/zone: us-east`.
+   These proxies will be subjected to the action from `default.action`.
+
+    ```yaml
+    - targetRef: # 4
+        kind: MeshSubset
+        tags:
+          env: dev
+    ```
+
+5. The action is `Deny`. All requests from the env `dev` will be denied on all proxies.
+
+    ```yaml
+    default: # 5
+      action: Deny
+    ```
+{% endif_version %}
 
 {% tip %}
 Order of rules inside the `from` array matters. 


### PR DESCRIPTION
We've added new kind Dataplane we should use it in policies examples in favour of deprecated MeshSubset