### PR TITLE
style: adjust h4 and h5 sizes for better readability

### DIFF
--- a/app/_assets/styles/vuepress-core/index.scss
+++ b/app/_assets/styles/vuepress-core/index.scss
@@ -164,6 +164,15 @@ h3 {
   font-size: 1.35rem;
 }
 
+h4 {
+  font-size: 1.15rem;
+}
+
+.content__default h5 {
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
 a.header-anchor {
   font-size: 0.85em;
   float: left;


### PR DESCRIPTION
- Increased h4 and h5 sizes to improve readability
- Fixed cases where headers appeared smaller than section content
- Ensured better visual hierarchy in documentation

---

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr>
<td><img width="253" alt="Screenshot 2025-03-06 at 12 43 21" src="https://github.com/user-attachments/assets/fa382cc0-c6a7-4b27-b263-6cdf9cafd6a3" /></td>
<td>
<img width="253" alt="Screenshot 2025-03-06 at 12 43 39" src="https://github.com/user-attachments/assets/16f0b85e-4936-4b72-b3e5-c52769d6bb6c" /></td>
</tr>
</tbody>
</table>

---

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
