### PR TITLE
fix: typo in word "across"

### DIFF
--- a/app/_data/docs_nav_kuma_2.10.x.yml
+++ b/app/_data/docs_nav_kuma_2.10.x.yml
@@ -120,7 +120,7 @@ items:
             url: /production/secure-deployment/dp-auth/
           - text: Configure data plane proxy membership
             url: /production/secure-deployment/dp-membership/
-          - text: Secure access accross services
+          - text: Secure access across services
             url: /production/secure-deployment/certificates/
       - text: Kuma user interface
         url: /production/gui/
@@ -500,7 +500,7 @@ items:
         url: /guides/otel-metrics/
       - text: Migration to the new policies
         url: /guides/migration-to-the-new-policies/
-      - text: Progressively rolling in strict MTLS
+      - text: Progressively rolling in strict mTLS
         url: /guides/progressively-rolling-in-strict-mtls/
       - text: Producer and consumer policies
         url: /guides/consumer-producer-policies

--- a/app/_data/docs_nav_kuma_2.2.x.yml
+++ b/app/_data/docs_nav_kuma_2.2.x.yml
@@ -93,7 +93,7 @@ items:
             url: /production/secure-deployment/dp-auth/
           - text: Configure data plane proxy membership
             url: /production/secure-deployment/dp-membership/
-          - text: Secure access accross services
+          - text: Secure access across services
             url: /production/secure-deployment/certificates/
       - text: Kuma user interface
         url: /production/gui/

--- a/app/_data/docs_nav_kuma_2.3.x.yml
+++ b/app/_data/docs_nav_kuma_2.3.x.yml
@@ -91,7 +91,7 @@ items:
             url: /production/secure-deployment/dp-auth/
           - text: Configure data plane proxy membership
             url: /production/secure-deployment/dp-membership/
-          - text: Secure access accross services
+          - text: Secure access across services
             url: /production/secure-deployment/certificates/
       - text: Kuma user interface
         url: /production/gui/

--- a/app/_data/docs_nav_kuma_2.4.x.yml
+++ b/app/_data/docs_nav_kuma_2.4.x.yml
@@ -93,7 +93,7 @@ items:
             url: /production/secure-deployment/dp-auth/
           - text: Configure data plane proxy membership
             url: /production/secure-deployment/dp-membership/
-          - text: Secure access accross services
+          - text: Secure access across services
             url: /production/secure-deployment/certificates/
       - text: Kuma user interface
         url: /production/gui/

--- a/app/_data/docs_nav_kuma_2.5.x.yml
+++ b/app/_data/docs_nav_kuma_2.5.x.yml
@@ -93,7 +93,7 @@ items:
             url: /production/secure-deployment/dp-auth/
           - text: Configure data plane proxy membership
             url: /production/secure-deployment/dp-membership/
-          - text: Secure access accross services
+          - text: Secure access across services
             url: /production/secure-deployment/certificates/
       - text: Kuma user interface
         url: /production/gui/

--- a/app/_data/docs_nav_kuma_2.6.x.yml
+++ b/app/_data/docs_nav_kuma_2.6.x.yml
@@ -118,7 +118,7 @@ items:
             url: /production/secure-deployment/dp-auth/
           - text: Configure data plane proxy membership
             url: /production/secure-deployment/dp-membership/
-          - text: Secure access accross services
+          - text: Secure access across services
             url: /production/secure-deployment/certificates/
       - text: Kuma user interface
         url: /production/gui/

--- a/app/_data/docs_nav_kuma_2.7.x.yml
+++ b/app/_data/docs_nav_kuma_2.7.x.yml
@@ -120,7 +120,7 @@ items:
             url: /production/secure-deployment/dp-auth/
           - text: Configure data plane proxy membership
             url: /production/secure-deployment/dp-membership/
-          - text: Secure access accross services
+          - text: Secure access across services
             url: /production/secure-deployment/certificates/
       - text: Kuma user interface
         url: /production/gui/

--- a/app/_data/docs_nav_kuma_2.8.x.yml
+++ b/app/_data/docs_nav_kuma_2.8.x.yml
@@ -120,7 +120,7 @@ items:
             url: /production/secure-deployment/dp-auth/
           - text: Configure data plane proxy membership
             url: /production/secure-deployment/dp-membership/
-          - text: Secure access accross services
+          - text: Secure access across services
             url: /production/secure-deployment/certificates/
       - text: Kuma user interface
         url: /production/gui/

--- a/app/_data/docs_nav_kuma_2.9.x.yml
+++ b/app/_data/docs_nav_kuma_2.9.x.yml
@@ -122,7 +122,7 @@ items:
             url: /production/secure-deployment/dp-auth/
           - text: Configure data plane proxy membership
             url: /production/secure-deployment/dp-membership/
-          - text: Secure access accross services
+          - text: Secure access across services
             url: /production/secure-deployment/certificates/
       - text: Kuma user interface
         url: /production/gui/
@@ -502,7 +502,7 @@ items:
         url: /guides/otel-metrics/
       - text: Migration to the new policies
         url: /guides/migration-to-the-new-policies/
-      - text: Progressively rolling in strict MTLS
+      - text: Progressively rolling in strict mTLS
         url: /guides/progressively-rolling-in-strict-mtls/
       - text: Producer and consumer policies
         url: /guides/consumer-producer-policies

--- a/app/_src/production/secure-deployment/certificates.md
+++ b/app/_src/production/secure-deployment/certificates.md
@@ -1,5 +1,5 @@
 ---
-title: Secure access accross services
+title: Secure access across services
 content_type: how-to
 ---
 


### PR DESCRIPTION
Fixed typo in word `across` (`accross` -> `across`)

---

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
