### PR TITLE
chore: fix broken datadog agent links

### DIFF
--- a/app/_src/explore/observability.md
+++ b/app/_src/explore/observability.md
@@ -296,7 +296,7 @@ The [Datadog agent docs](https://docs.datadoghq.com/agent/kubernetes/installatio
 {% endtab %}
 
 {% tab datadog Universal %}
-Checkout the [Datadog agent docs](https://docs.datadoghq.com/agent/basic_agent_usage).
+Checkout the [Datadog agent docs](https://docs.datadoghq.com/agent).
 {% endtab %}
 {% endtabs %}
 
@@ -349,7 +349,7 @@ if it did adjust accordingly.
 {% endtab %}
 
 {% tab tracing Universal %}
-Checkout the [Datadog agent docs](https://docs.datadoghq.com/agent/basic_agent_usage)
+Checkout the [Datadog agent docs](https://docs.datadoghq.com/agent)
 {% endtab %}
 {% endtabs %}
 


### PR DESCRIPTION
It seems datadog changed the docs structure and https://docs.datadoghq.com/agent/basic_agent_usage is no longer a valid link

---

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
