### PR TITLE
fix(guides): move upgrading tproxy guide to proper section

### DIFF
--- a/app/_data/docs_nav_kuma_2.10.x.yml
+++ b/app/_data/docs_nav_kuma_2.10.x.yml
@@ -506,6 +506,8 @@ items:
         url: /guides/consumer-producer-policies
       - text: Configuring inbound traffic with Rules API
         url: /guides/rules
+      - text: Upgrading Transparent Proxy
+        url: /guides/upgrading-transparent-proxy/
   - title: Reference
     group: true
     items:
@@ -519,8 +521,6 @@ items:
         url: /reference/kuma-cp
       - text: Envoy proxy template
         url: /reference/proxy-template/
-      - text: Upgrading Transparent Proxy
-        url: /guides/upgrading-transparent-proxy/
   - title: Community
     group: true
     items:

--- a/app/_data/docs_nav_kuma_2.11.x.yml
+++ b/app/_data/docs_nav_kuma_2.11.x.yml
@@ -504,6 +504,8 @@ items:
         url: /guides/progressively-rolling-in-strict-mtls/
       - text: Producer and consumer policies
         url: /guides/consumer-producer-policies
+      - text: Upgrading Transparent Proxy
+        url: /guides/upgrading-transparent-proxy/
   - title: Reference
     group: true
     items:
@@ -517,8 +519,6 @@ items:
         url: /reference/kuma-cp
       - text: Envoy proxy template
         url: /reference/proxy-template/
-      - text: Upgrading Transparent Proxy
-        url: /guides/upgrading-transparent-proxy/
   - title: Community
     group: true
     items:


### PR DESCRIPTION
Guide was under `references` section in sidebar instead of under `guides` by mistake

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
