### PR TITLE
fix(nav): add missing guide to preview navbar

### DIFF
--- a/app/_data/docs_nav_kuma_2.10.x.yml
+++ b/app/_data/docs_nav_kuma_2.10.x.yml
@@ -503,9 +503,9 @@ items:
       - text: Progressively rolling in strict mTLS
         url: /guides/progressively-rolling-in-strict-mtls/
       - text: Producer and consumer policies
-        url: /guides/consumer-producer-policies
+        url: /guides/consumer-producer-policies/
       - text: Configuring inbound traffic with Rules API
-        url: /guides/rules
+        url: /guides/rules/
       - text: Upgrading Transparent Proxy
         url: /guides/upgrading-transparent-proxy/
   - title: Reference

--- a/app/_data/docs_nav_kuma_2.11.x.yml
+++ b/app/_data/docs_nav_kuma_2.11.x.yml
@@ -503,7 +503,9 @@ items:
       - text: Progressively rolling in strict mTLS
         url: /guides/progressively-rolling-in-strict-mtls/
       - text: Producer and consumer policies
-        url: /guides/consumer-producer-policies
+        url: /guides/consumer-producer-policies/
+      - text: Configuring inbound traffic with Rules API
+        url: /guides/rules/
       - text: Upgrading Transparent Proxy
         url: /guides/upgrading-transparent-proxy/
   - title: Reference

--- a/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/jsonschema.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/jsonschema.rb
@@ -26,7 +26,7 @@ module Jekyll
                   <div id="markdown_html"></div>
 
                   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.9.0/showdown.min.js"></script>
-                  <script defer src="https://brianwendt.github.io/json-schema-md-doc/lib/JSONSchemaMarkdown.js"></script>
+                  <script defer src="https://brianwendt.github.io/json-schema-md-doc/json-schema-md-doc.min.js"></script>
                   <script type="text/javascript">
                   const data = #{JSON.dump(data)};
                   document.addEventListener("DOMContentLoaded", function() {


### PR DESCRIPTION
guide added in 2.10.x was missing in preview navbar


Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
