### PR TITLE
feat(tf): quote slash character in keys

### DIFF
--- a/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/policyyaml.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/policyyaml.rb
@@ -213,7 +213,9 @@ module Jekyll
           end
 
           def convert_to_terraform(key, value, indent_level, is_in_array = false, is_last = false)
+            characters_to_quote = ["/"]
             key = snake_case(key) unless key.empty?
+            key = "\"#{key}\"" if characters_to_quote.any? { |char| key.include?(char) }
             indent = "  " * indent_level
             if value.is_a?(Hash)
               result = is_in_array ? "#{indent}{\n" : "#{indent}#{key} = {\n"

--- a/spec/fixtures/mhr-port.golden.html
+++ b/spec/fixtures/mhr-port.golden.html
@@ -60,6 +60,7 @@
     <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshSubset</span>
     <span class="na">tags</span><span class="pi">:</span>
       <span class="na">app</span><span class="pi">:</span> <span class="s">frontend</span>
+      <span class="na">kuma.io/env</span><span class="pi">:</span> <span class="s">dev</span>
   <span class="na">to</span><span class="pi">:</span>
   <span class="pi">-</span> <span class="na">targetRef</span><span class="pi">:</span>
       <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshService</span>
@@ -97,6 +98,7 @@
     <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshSubset</span>
     <span class="na">tags</span><span class="pi">:</span>
       <span class="na">app</span><span class="pi">:</span> <span class="s">frontend</span>
+      <span class="na">kuma.io/env</span><span class="pi">:</span> <span class="s">dev</span>
   <span class="na">to</span><span class="pi">:</span>
   <span class="pi">-</span> <span class="na">targetRef</span><span class="pi">:</span>
       <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshService</span>
@@ -149,6 +151,7 @@
     <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshSubset</span>
     <span class="na">tags</span><span class="pi">:</span>
       <span class="na">app</span><span class="pi">:</span> <span class="s">frontend</span>
+      <span class="na">kuma.io/env</span><span class="pi">:</span> <span class="s">dev</span>
   <span class="na">to</span><span class="pi">:</span>
   <span class="pi">-</span> <span class="na">targetRef</span><span class="pi">:</span>
       <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshService</span>
@@ -182,6 +185,7 @@
     <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshSubset</span>
     <span class="na">tags</span><span class="pi">:</span>
       <span class="na">app</span><span class="pi">:</span> <span class="s">frontend</span>
+      <span class="na">kuma.io/env</span><span class="pi">:</span> <span class="s">dev</span>
   <span class="na">to</span><span class="pi">:</span>
   <span class="pi">-</span> <span class="na">targetRef</span><span class="pi">:</span>
       <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshService</span>

--- a/spec/fixtures/mhr-port.yaml
+++ b/spec/fixtures/mhr-port.yaml
@@ -6,6 +6,7 @@ spec:
     kind: MeshSubset
     tags:
       app: frontend
+      kuma.io/env: dev
   to:
     - targetRef:
         kind: MeshService

--- a/spec/fixtures/mhr-port_dev.golden.html
+++ b/spec/fixtures/mhr-port_dev.golden.html
@@ -60,6 +60,7 @@
     <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshSubset</span>
     <span class="na">tags</span><span class="pi">:</span>
       <span class="na">app</span><span class="pi">:</span> <span class="s">frontend</span>
+      <span class="na">kuma.io/env</span><span class="pi">:</span> <span class="s">dev</span>
   <span class="na">to</span><span class="pi">:</span>
   <span class="pi">-</span> <span class="na">targetRef</span><span class="pi">:</span>
       <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshService</span>
@@ -97,6 +98,7 @@
     <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshSubset</span>
     <span class="na">tags</span><span class="pi">:</span>
       <span class="na">app</span><span class="pi">:</span> <span class="s">frontend</span>
+      <span class="na">kuma.io/env</span><span class="pi">:</span> <span class="s">dev</span>
   <span class="na">to</span><span class="pi">:</span>
   <span class="pi">-</span> <span class="na">targetRef</span><span class="pi">:</span>
       <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshService</span>
@@ -149,6 +151,7 @@
     <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshSubset</span>
     <span class="na">tags</span><span class="pi">:</span>
       <span class="na">app</span><span class="pi">:</span> <span class="s">frontend</span>
+      <span class="na">kuma.io/env</span><span class="pi">:</span> <span class="s">dev</span>
   <span class="na">to</span><span class="pi">:</span>
   <span class="pi">-</span> <span class="na">targetRef</span><span class="pi">:</span>
       <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshService</span>
@@ -182,6 +185,7 @@
     <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshSubset</span>
     <span class="na">tags</span><span class="pi">:</span>
       <span class="na">app</span><span class="pi">:</span> <span class="s">frontend</span>
+      <span class="na">kuma.io/env</span><span class="pi">:</span> <span class="s">dev</span>
   <span class="na">to</span><span class="pi">:</span>
   <span class="pi">-</span> <span class="na">targetRef</span><span class="pi">:</span>
       <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshService</span>

--- a/spec/fixtures/mhr-port_edition.golden.html
+++ b/spec/fixtures/mhr-port_edition.golden.html
@@ -73,6 +73,7 @@
     <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshSubset</span>
     <span class="na">tags</span><span class="pi">:</span>
       <span class="na">app</span><span class="pi">:</span> <span class="s">frontend</span>
+      <span class="na">kuma.io/env</span><span class="pi">:</span> <span class="s">dev</span>
   <span class="na">to</span><span class="pi">:</span>
   <span class="pi">-</span> <span class="na">targetRef</span><span class="pi">:</span>
       <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshService</span>
@@ -110,6 +111,7 @@
     <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshSubset</span>
     <span class="na">tags</span><span class="pi">:</span>
       <span class="na">app</span><span class="pi">:</span> <span class="s">frontend</span>
+      <span class="na">kuma.io/env</span><span class="pi">:</span> <span class="s">dev</span>
   <span class="na">to</span><span class="pi">:</span>
   <span class="pi">-</span> <span class="na">targetRef</span><span class="pi">:</span>
       <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshService</span>
@@ -162,6 +164,7 @@
     <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshSubset</span>
     <span class="na">tags</span><span class="pi">:</span>
       <span class="na">app</span><span class="pi">:</span> <span class="s">frontend</span>
+      <span class="na">kuma.io/env</span><span class="pi">:</span> <span class="s">dev</span>
   <span class="na">to</span><span class="pi">:</span>
   <span class="pi">-</span> <span class="na">targetRef</span><span class="pi">:</span>
       <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshService</span>
@@ -195,6 +198,7 @@
     <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshSubset</span>
     <span class="na">tags</span><span class="pi">:</span>
       <span class="na">app</span><span class="pi">:</span> <span class="s">frontend</span>
+      <span class="na">kuma.io/env</span><span class="pi">:</span> <span class="s">dev</span>
   <span class="na">to</span><span class="pi">:</span>
   <span class="pi">-</span> <span class="na">targetRef</span><span class="pi">:</span>
       <span class="na">kind</span><span class="pi">:</span> <span class="s">MeshService</span>
@@ -241,6 +245,7 @@
       <span class="nx">kind</span> <span class="p">=</span> <span class="s2">"MeshSubset"</span>
       <span class="nx">tags</span> <span class="p">=</span> <span class="p">{</span>
         <span class="nx">app</span> <span class="p">=</span> <span class="s2">"frontend"</span>
+        <span class="s2">"kuma.io/env"</span> <span class="p">=</span> <span class="s2">"dev"</span>
       <span class="p">}</span>
     <span class="p">}</span>
     <span class="nx">to</span> <span class="p">=</span> <span class="p">[</span>


### PR DESCRIPTION
Otherwise it can create keys like:

```
│ Error: Reference to undeclared resource
│
│   on main.tf line 137, in resource "konnect_mesh_traffic_permission" "example_with_tags":
│  137:             kuma.io/zone = "us-east"
│
│ A managed resource "kuma" "io" has not been declared in the root module.
```

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
