### PR TITLE
chore(examples): adjust examples to upgrade.md

### DIFF
--- a/app/_src/policies/meshtrace.md
+++ b/app/_src/policies/meshtrace.md
@@ -154,7 +154,7 @@ you would get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and 
 
 #### Zipkin
 
-In most cases the only field you'll want to set in `url`.
+In most cases the only field you'll want to set is `url`.
 
 Example:
 ```yaml
@@ -193,6 +193,7 @@ spec:
     backends:
       - zipkin:
           url: http://jaeger-collector:9411/api/v2/spans
+          apiVersion: httpJson
 ```
 {% endpolicy_yaml %}
 
@@ -243,6 +244,7 @@ spec:
       - type: Zipkin
         zipkin:
           url: http://jaeger-collector:9411/api/v2/spans
+          apiVersion: httpJson
 ```
 {% endpolicy_yaml %}
 
@@ -292,6 +294,7 @@ spec:
       - type: Zipkin
         zipkin:
           url: http://jaeger-collector:9411/api/v2/spans
+          apiVersion: httpJson
 ```
 {% endpolicy_yaml %}
 
@@ -658,6 +661,7 @@ spec:
     backends:
       - zipkin:
           url: http://west.zipkincollector:9411/api/v2/spans
+          apiVersion: httpJson
 ```
 {% endpolicy_yaml %}
 
@@ -677,6 +681,7 @@ spec:
     backends:
       - zipkin:
           url: http://east.zipkincollector:9411/api/v2/spans
+          apiVersion: httpJson
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
@@ -700,6 +705,7 @@ spec:
       - type: Zipkin
         zipkin:
           url: http://west.zipkincollector:9411/api/v2/spans
+          apiVersion: httpJson
 ```
 {% endpolicy_yaml %}
 
@@ -719,6 +725,7 @@ spec:
     backends:
       - zipkin:
           url: http://east.zipkincollector:9411/api/v2/spans
+          apiVersion: httpJson
 ```
 {% endpolicy_yaml %}
 {% endif_version %}
@@ -742,6 +749,7 @@ spec:
       - type: Zipkin
         zipkin:
           url: http://west.zipkincollector:9411/api/v2/spans
+          apiVersion: httpJson
 ```
 {% endpolicy_yaml %}
 
@@ -761,6 +769,7 @@ spec:
     backends:
       - zipkin:
           url: http://east.zipkincollector:9411/api/v2/spans
+          apiVersion: httpJson
 ```
 {% endpolicy_yaml %}
 {% endif_version %}


### PR DESCRIPTION
closes https://github.com/kumahq/kuma-website/issues/2199

after https://github.com/kumahq/kuma/pull/12895 there's been some changes to properties and if there are people using older versions and use the corrected examples this will minimise the work needed when ugprading

Checked:
- requestRedirect.statusCode - no in examples in docs
- apiVersion - changed in the PR
- MeshMetric's path - all examples have `path`
- passthroughMode - all examples have `passthroughMode`

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
