### PR TITLE
fix(merging): removing a property using `null` does not work

### DIFF
--- a/app/_src/policies/introduction.md
+++ b/app/_src/policies/introduction.md
@@ -774,7 +774,6 @@ default:
 default:
   sub:
     array: [ ]
-    other: null
     other-array: [ 5, 6 ]
     extra: 2
 ```
@@ -786,6 +785,7 @@ default:
   conf: 1
   sub:
     array: [ ]
+    other: 50
     other-array: [ 5, 6 ]
     extra: 2
 ```
@@ -820,7 +820,6 @@ default:
 default:
   sub:
     array: []
-    other: null
     other-array: [5, 6]
     extra: 2
 ```
@@ -832,6 +831,7 @@ default:
   conf: 1
   sub:
     array: []
+    other: 50
     other-array: [5, 6]
     extra: 2
 ```

--- a/app/_src/policies/targetref.md
+++ b/app/_src/policies/targetref.md
@@ -302,7 +302,6 @@ default:
 default:
   sub:
     array: []
-    other: null
     other-array: [5, 6]
     extra: 2
 ```
@@ -314,6 +313,7 @@ default:
   conf: 1
   sub:
     array: []
+    other: 50
     other-array: [5, 6]
     extra: 2
 ```


### PR DESCRIPTION
Removing a property using null does not work because of go serialization. I fixed the docs to reflect that.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
