### PR TITLE
fix(targetref): add back MeshSubset to targetRef support matrix and mark it as deprecated

### DIFF
--- a/app/_src/policies/meshaccesslog.md
+++ b/app/_src/policies/meshaccesslog.md
@@ -36,10 +36,10 @@ If you haven't, see the [observability docs](/docs/{{ page.release }}/explore/ob
 | `from[].targetRef.kind` | `Mesh`                                                   |
 {% endif_version %}
 {% if_version gte:2.10.x %}
-| `targetRef`             | Allowed kinds                                |
-| ----------------------- | -------------------------------------------- |
-| `targetRef.kind`        | `Mesh`, `Dataplane`                          |
-| `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService` |
+| `targetRef`             | Allowed kinds                                 |
+| ----------------------- | --------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane`, `MeshSubset(deprecated)` |
+| `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService`  |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshcircuitbreaker.md
+++ b/app/_src/policies/meshcircuitbreaker.md
@@ -56,10 +56,10 @@ target proxies are healthy or not.
 | `from[].targetRef.kind` | `Mesh`                                                   |
 {% endif_version %}
 {% if_version gte:2.10.x %}
-| `targetRef`             | Allowed kinds         |
-| ----------------------- | --------------------- |
-| `targetRef.kind`        | `Mesh`, `Dataplane`   |
-| `to[].targetRef.kind`   | `Mesh`, `MeshService` |
+| `targetRef`             | Allowed kinds                                 |
+| ----------------------- | --------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane`, `MeshSubset(deprecated)` |
+| `to[].targetRef.kind`   | `Mesh`, `MeshService`                         |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshfaultinjection.md
+++ b/app/_src/policies/meshfaultinjection.md
@@ -27,10 +27,10 @@ Do **not** combine with [FaultInjection](/docs/{{ page.release }}/policies/fault
 | `from[].targetRef.kind` | `Mesh`, `MeshSubset`, `MeshServiceSubset`                |
 {% endif_version %}
 {% if_version gte:2.10.x %}
-| `targetRef`             | Allowed kinds                             |
-| ----------------------- | ----------------------------------------- |
-| `targetRef.kind`        | `Mesh`, `Dataplane`                       |
-| `from[].targetRef.kind` | `Mesh`, `MeshSubset`, `MeshServiceSubset` |
+| `targetRef`             | Allowed kinds                                 |
+| ----------------------- | --------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane`, `MeshSubset(deprecated)` |
+| `from[].targetRef.kind` | `Mesh`, `MeshSubset`, `MeshServiceSubset`     |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshhealthcheck.md
+++ b/app/_src/policies/meshhealthcheck.md
@@ -40,10 +40,10 @@ This mode generates extra traffic to other proxies and services as described in 
 | `to[].targetRef.kind` | `Mesh`, `MeshService`                                    |
 {% endif_version %}
 {% if_version gte:2.10.x %}
-| `targetRef`           | Allowed kinds         |
-| --------------------- | --------------------- |
-| `targetRef.kind`      | `Mesh`, `Dataplane`   |
-| `to[].targetRef.kind` | `Mesh`, `MeshService` |
+| `targetRef`           | Allowed kinds                                 |
+| --------------------- | --------------------------------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane`, `MeshSubset(deprecated)` |
+| `to[].targetRef.kind` | `Mesh`, `MeshService`                         |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshhttproute.md
+++ b/app/_src/policies/meshhttproute.md
@@ -28,10 +28,10 @@ depending on where the request is coming from and where it's going to.
 | `to[].targetRef.kind` | `MeshService`                                            |
 {% endif_version %}
 {% if_version gte:2.10.x %}
-| `targetRef`           | Allowed kinds       |
-| --------------------- | ------------------- |
-| `targetRef.kind`      | `Mesh`, `Dataplane` |
-| `to[].targetRef.kind` | `MeshService`       |
+| `targetRef`           | Allowed kinds                                 |
+| --------------------- | --------------------------------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane`, `MeshSubset(deprecated)` |
+| `to[].targetRef.kind` | `MeshService`                                 |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshloadbalancingstrategy.md
+++ b/app/_src/policies/meshloadbalancingstrategy.md
@@ -30,7 +30,7 @@ When using this policy, the [localityAwareLoadBalancing](/docs/{{ page.release }
 {% if_version gte:2.10.x %}
 | `targetRef`           | Allowed kinds                                            |
 | --------------------- | -------------------------------------------------------- |
-| `targetRef.kind`      | `Mesh`, `Dataplane`                                      |
+| `targetRef.kind`      | `Mesh`, `Dataplane`, `MeshSubset(deprecated)`            |
 | `to[].targetRef.kind` | `Mesh`, `MeshService`, `MeshMultiZoneService`            |
 {% endif_version %}
 {% endtab %}

--- a/app/_src/policies/meshmetric.md
+++ b/app/_src/policies/meshmetric.md
@@ -49,9 +49,9 @@ If you haven't already read the [observability docs](/docs/{{ page.release }}/ex
 | `targetRef.kind`        | `Mesh`, `MeshSubset`                                     |
 {% endif_version %}
 {% if_version gte:2.10.x %}
-| `targetRef`             | Allowed kinds       |
-| ----------------------- | ------------------- |
-| `targetRef.kind`        | `Mesh`, `Dataplane` |
+| `targetRef`             | Allowed kinds                                 |
+| ----------------------- | --------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane`, `MeshSubset(deprecated)` |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshpassthrough.md
+++ b/app/_src/policies/meshpassthrough.md
@@ -19,9 +19,9 @@ When using this policy, the [passthrough mode](/docs/{{ page.release }}/networki
 | `targetRef.kind`      | `Mesh`, `MeshSubset`  |
 {% endif_version %}
 {% if_version gte:2.10.x %}
-| `targetRef`           | Allowed kinds        |
-| --------------------- | -------------------- |
-| `targetRef.kind`      | `Mesh`, `Dataplane`  |
+| `targetRef`           | Allowed kinds                                 |
+| --------------------- | --------------------------------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane`, `MeshSubset(deprecated)` |
 {% endif_version %}
 {% endtab %}
 {% if_version gte:2.9.x %}

--- a/app/_src/policies/meshproxypatch.md
+++ b/app/_src/policies/meshproxypatch.md
@@ -48,9 +48,9 @@ Do **not** combine with [Proxy Template](/docs/{{ page.release }}/policies/proxy
 | `targetRef.kind`      | `Mesh`, `MeshSubset`                                     |
 {% endif_version %}
 {% if_version gte:2.10.x %}
-| `targetRef`           | Allowed kinds       |
-| --------------------- | ------------------- |
-| `targetRef.kind`      | `Mesh`, `Dataplane` |
+| `targetRef`           | Allowed kinds                                 |
+| --------------------- | --------------------------------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane`, `MeshSubset(deprecated)` |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshratelimit.md
+++ b/app/_src/policies/meshratelimit.md
@@ -38,9 +38,10 @@ Rate limiting supports an [ExternalService](/docs/{{ page.release }}/policies/ex
 | `from[].targetRef.kind` | `Mesh`                                                   |
 {% endif_version %}
 {% if_version gte:2.10.x %}
-| `targetRef`             | Allowed kinds       |
-| ----------------------- | ------------------- |
-| `targetRef.kind`        | `Mesh`, `Dataplane` |
+| `targetRef`             | Allowed kinds                                 |
+| ----------------------- | --------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane`, `MeshSubset(deprecated)` |
+| `from[].targetRef.kind` | `Mesh`                                        |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshretry.md
+++ b/app/_src/policies/meshretry.md
@@ -29,10 +29,10 @@ This policy enables {{site.mesh_product_name}} to know how to behave if there ar
 | `to[].targetRef.kind` | `Mesh`, `MeshService`, `MeshExternalService`             |
 {% endif_version %}
 {% if_version gte:2.10.x %}
-| `targetRef`           | Allowed kinds                                |
-| --------------------- | -------------------------------------------- |
-| `targetRef.kind`      | `Mesh`, `Dataplane`                          |
-| `to[].targetRef.kind` | `Mesh`, `MeshService`, `MeshExternalService` |
+| `targetRef`           | Allowed kinds                                 |
+| --------------------- | --------------------------------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane`, `MeshSubset(deprecated)` |
+| `to[].targetRef.kind` | `Mesh`, `MeshService`, `MeshExternalService`  |
 {% endif_version %}
 {% if_version lte:2.5.x %}
 | `targetRef.kind`    | top level | to  | from |

--- a/app/_src/policies/meshtcproute.md
+++ b/app/_src/policies/meshtcproute.md
@@ -34,10 +34,10 @@ depending on where the request is coming from and where it's going to.
 | `to[].targetRef.kind` | `MeshService`                                            |
 {% endif_version %}
 {% if_version gte:2.10.x %}
-| `targetRef`           | Allowed kinds       |
-| --------------------- | ------------------- |
-| `targetRef.kind`      | `Mesh`, `Dataplane` |
-| `to[].targetRef.kind` | `MeshService`       |
+| `targetRef`           | Allowed kinds                                 |
+| --------------------- | --------------------------------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane`, `MeshSubset(deprecated)` |
+| `to[].targetRef.kind` | `MeshService`                                 |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshtimeout.md
+++ b/app/_src/policies/meshtimeout.md
@@ -29,10 +29,10 @@ Do **not** combine with [Timeout policy](/docs/{{ page.release }}/policies/timeo
 | `from[].targetRef.kind` | `Mesh`                                                                    |
 {% endif_version %}
 {% if_version gte:2.10.x %}
-| `targetRef`             | Allowed kinds                                |
-| ----------------------- | -------------------------------------------- |
-| `targetRef.kind`        | `Mesh`, `Dataplane`, `MeshHTTPRoute`         |
-| `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService` |
+| `targetRef`             | Allowed kinds                                                  |
+| ----------------------- | -------------------------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane`, `MeshHTTPRoute`, `MeshSubset(deprecated)` |
+| `to[].targetRef.kind`   | `Mesh`, `MeshService`, `MeshExternalService`                   |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshtls.md
+++ b/app/_src/policies/meshtls.md
@@ -16,9 +16,9 @@ Backends and default mode values are taken from [the Mesh object](/docs/{{ page.
 | `from[].targetRef.kind` | `Mesh`               |
 {% endif_version %}
 {% if_version gte:2.10.x %}
-| `targetRef`             | Allowed kinds       |
-| ----------------------- | ------------------- |
-| `targetRef.kind`        | `Mesh`, `Dataplane` |
+| `targetRef`             | Allowed kinds                                 |
+| ----------------------- | --------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane`, `MeshSubset(deprecated)` |
 {% endif_version %}
 {% endtab %}
 {% tab targetRef For tls ciphers/version %}

--- a/app/_src/policies/meshtrace.md
+++ b/app/_src/policies/meshtrace.md
@@ -47,9 +47,9 @@ For HTTP you can also manually forward the following headers:
 | `targetRef.kind`      | `Mesh`, `MeshSubset`                                     |
 {% endif_version %}
 {% if_version gte:2.10.x %}
-| `targetRef`           | Allowed kinds       |
-| --------------------- | ------------------- |
-| `targetRef.kind`      | `Mesh`, `Dataplane` |
+| `targetRef`           | Allowed kinds                                 |
+| --------------------- | --------------------------------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane`, `MeshSubset(deprecated)` |
 {% endif_version %}
 {% endtab %}
 

--- a/app/_src/policies/meshtrafficpermission.md
+++ b/app/_src/policies/meshtrafficpermission.md
@@ -32,10 +32,10 @@ It allows you to define granular rules about which services can communicate with
 | `from[].targetRef.kind` | `Mesh`, `MeshSubset`, `MeshServiceSubset`                |
 {% endif_version %}
 {% if_version gte:2.10.x %}
-| `targetRef`             | Allowed kinds                             |
-| ----------------------- | ----------------------------------------- |
-| `targetRef.kind`        | `Mesh`, `Dataplane`                       |
-| `from[].targetRef.kind` | `Mesh`, `MeshSubset`, `MeshServiceSubset` |
+| `targetRef`             | Allowed kinds                                 |
+| ----------------------- | --------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `Dataplane`, `MeshSubset(deprecated)` |
+| `from[].targetRef.kind` | `Mesh`, `MeshSubset`, `MeshServiceSubset`     |
 {% endif_version %}
 {% endtab %}
 {% tab Builtin Gateway %}


### PR DESCRIPTION
Fix: https://github.com/kumahq/kuma-website/issues/2277

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
