### PR TITLE
chore(deps): get rid of express

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "anchor-js": "^4.3.1",
     "animejs": "^3.1.0",
     "braces": "3.0.3",
-    "express": "4.21.0",
     "jquery": "^3.5.1",
     "netlify-headers-parser": "^7.1.4",
     "netlify-redirect-parser": "^14.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2464,7 +2464,7 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
 
-cookie@0.6.0, cookie@0.7.1, cookie@0.7.2, cookie@^0.7.0, cookie@^0.7.1:
+cookie@0.7.1, cookie@0.7.2, cookie@^0.7.0, cookie@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
@@ -3190,43 +3190,6 @@ express-logging@1.1.1:
   integrity sha512-1KboYwxxCG5kwkJHR5LjFDTD1Mgl8n4PIMcCuhhd/1OqaxlC68P3QKbvvAbZVUtVgtlxEdTgSUwf6yxwzRCuuA==
   dependencies:
     on-headers "^1.0.0"
-
-express@4.21.0:
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.21.0.tgz#d57cb706d49623d4ac27833f1cbc466b668eb915"
-  integrity sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==
-  dependencies:
-    accepts "~1.3.8"
-    array-flatten "1.1.1"
-    body-parser "1.20.3"
-    content-disposition "0.5.4"
-    content-type "~1.0.4"
-    cookie "0.6.0"
-    cookie-signature "1.0.6"
-    debug "2.6.9"
-    depd "2.0.0"
-    encodeurl "~2.0.0"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    finalhandler "1.3.1"
-    fresh "0.5.2"
-    http-errors "2.0.0"
-    merge-descriptors "1.0.3"
-    methods "~1.1.2"
-    on-finished "2.4.1"
-    parseurl "~1.3.3"
-    path-to-regexp "0.1.10"
-    proxy-addr "~2.0.7"
-    qs "6.13.0"
-    range-parser "~1.2.1"
-    safe-buffer "5.2.1"
-    send "0.19.0"
-    serve-static "1.16.2"
-    setprototypeof "1.2.0"
-    statuses "2.0.1"
-    type-is "~1.6.18"
-    utils-merge "1.0.1"
-    vary "~1.1.2"
 
 express@4.21.2:
   version "4.21.2"
@@ -5767,11 +5730,6 @@ path-scurry@^1.11.1:
   dependencies:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
-
-path-to-regexp@0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.10.tgz#67e9108c5c0551b9e5326064387de4763c4d5f8b"
-  integrity sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==
 
 path-to-regexp@0.1.12:
   version "0.1.12"


### PR DESCRIPTION
Dependabot is failing because:

```
Dependabot cannot update path-to-regexp to a non-vulnerable version
The latest possible version that can be installed is 0.1.10 because of the following conflicting dependency:

express@4.21.0 requires path-to-regexp@0.1.10
The earliest fixed version is 0.1.12.

[Troubleshoot Dependabot errors](https://docs.github.com/github/managing-security-vulnerabilities/troubleshooting-dependabot-errors)
```

![image](https://github.com/user-attachments/assets/e4eaeca4-b914-4455-b3fa-f6c1a22c0879)

I don't think we're using `express` anywhere - let's see if this builds.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes

Fixes: https://github.com/kumahq/kuma-website/actions/runs/14484310464/job/40627023358#step:3:323
