### PR TITLE
fix(ci): skip all checks of kuma changelog in ci/check-links job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             --exclude 'https://github.com/(/)?kumahq/kuma/pull/.*' \
             --exclude 'https://github.com/.*/.*/blob/.*#.*' \
             --exclude 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md.*' \
-            --exclude 'https://github.com/kumahq/kuma/blob/master/CHANGELOG.md' \
+            --exclude 'https://github.com/kumahq/kuma/blob/.*/CHANGELOG.md' \
             --exclude ${URL}/docs/1. \
             --exclude 127.0.0.1 \
             --exclude https://cloudsmith.io/~kong/repos \
@@ -75,7 +75,7 @@ jobs:
             --exclude 'https://github.com/(/)?kumahq/kuma/pull/.*' \
             --exclude 'https://github.com/.*/.*/blob/.*#.*' \
             --exclude 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md.*' \
-            --exclude 'https://github.com/kumahq/kuma/blob/master/CHANGELOG.md' \
+            --exclude 'https://github.com/kumahq/kuma/blob/.*/CHANGELOG.md' \
             --exclude 127.0.0.1 \
             --exclude https://cloudsmith.io/~kong/repos \
             --exclude https://linux.die.net \


### PR DESCRIPTION
Skip all queries to Kuma changelog, as it is causing rate-limiting issues with GitHub. Example fails: https://github.com/kumahq/kuma-website/actions/runs/14966874656/job/42042584006 

We know that changelog is always present in Kuma