### PR TITLE
feat(meshtimeout): update MeshTimeout examples to use demo app

### DIFF
--- a/app/_src/policies/meshtimeout.md
+++ b/app/_src/policies/meshtimeout.md
@@ -295,7 +295,7 @@ spec:
   targetRef:
     kind: Dataplane
     labels:
-      app: backend
+      app: demo-app
   rules:
     - default:
         idleTimeout: 60s
@@ -310,7 +310,7 @@ spec:
 {% endif_version %}
 
 {% if_version gte:2.10.x %}
-#### Configuration for a single inbound port named `tcp-port`
+#### Configuration for a single inbound port named `http`
 
 {% policy_yaml namespace=kuma-demo %}
 ```yaml
@@ -321,8 +321,8 @@ spec:
   targetRef:
     kind: Dataplane
     labels:
-      app: backend
-    sectionName: tcp-port
+      app: demo-app
+    sectionName: http
   rules:
     - default:
         idleTimeout: 1h


### PR DESCRIPTION
This changes MeshTimeout policy examples to use demo-app. Thanks to this, you can just copy and paste them when running demo