### PR TITLE
feat(jekyll/plugin/rbacresources): support configurable and default search paths for input file

### DIFF
--- a/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/rbacresources.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma-plugins/liquid/tags/rbacresources.rb
@@ -1,8 +1,21 @@
 # This plugin generates tabbed tables for RBAC resources (ClusterRole, ClusterRoleBinding,
-# Role, RoleBinding) from a given YAML file. Each tab corresponds to a resource kind.
-# Each resource is shown in a nested tab with its name and YAML content.
+# Role, RoleBinding) from a given YAML file. Each tab corresponds to a resource kind,
+# and each resource is shown in a nested tab with its name and YAML content.
 #
-# Usage: {% rbacresources filename=path/to/file.yaml %}
+# When no `filename` is provided, the plugin uses `rbac.yaml` by default.
+# The plugin looks for the file using the following logic:
+#
+# 1. It reads the current release from `page.release`.
+# 2. It looks for the file in each path configured in `mesh_raw_generated_paths`
+#    in the site's `_config.yml`. If not set, it defaults to: ['app/assets'].
+# 3. For each base path, it checks if the file exists at:
+#       {{ base_path }}/{{ release }}/raw/{{ filename }}
+# 4. If not found, it falls back to checking if the provided filename is an absolute or relative path.
+# 5. If still not found, the plugin raises an error.
+#
+# Usage examples:
+#   {% rbacresources %}                            # uses default filename `rbac.yaml`
+#   {% rbacresources filename=custom-rbac.yaml %}  # uses a custom filename
 
 require 'yaml'
 
@@ -11,29 +24,25 @@ module Jekyll
     module Liquid
       module Tags
         class RbacResources < ::Liquid::Tag
+          PATHS_CONFIG = 'mesh_raw_generated_paths'
+          DEFAULT_PATHS = ['app/assets']
+          DEFAULT_FILENAME = 'rbac.yaml'
+
           def initialize(tag_name, text, tokens)
             super
             @markup = text.strip
-            @params = { "filename" => nil }
+            @params = { "filename" => DEFAULT_FILENAME }
 
             @markup.split(' ').each do |item|
               key, value = item.split('=')
               @params[key] = value.strip.gsub(/^"+|"+$/, '') if key && value
             end
-
-            unless @params["filename"] && File.exist?(@params["filename"])
-              raise ArgumentError, "Valid 'filename' parameter required for rbacresources tag."
-            end
           end
 
           def render(context)
-            ::Liquid::Template.parse(content).render(context)
-          end
+            filename = resolve_file_path(context)
 
-          private
-
-          def content
-            yaml_content = YAML.load_stream(File.read(@params["filename"]))
+            yaml_content = YAML.load_stream(File.read(filename))
             grouped = yaml_content
               .select { |doc| doc.is_a?(Hash) && %w[ClusterRole ClusterRoleBinding Role RoleBinding].include?(doc["kind"]) }
               .group_by { |doc| doc["kind"] }
@@ -65,11 +74,30 @@ module Jekyll
               TAB
             end.join("\n")
 
-            <<~MARKDOWN
+            ::Liquid::Template.parse(<<~MARKDOWN).render(context)
               {% tabs %}
               #{tab_output}
               {% endtabs %}
             MARKDOWN
+          end
+
+          private
+
+          def resolve_file_path(context)
+            site_config = context.registers[:site].config
+            page_data = context.registers[:page]
+            release = page_data['release'].to_s.strip
+            base_paths = site_config.fetch(PATHS_CONFIG, DEFAULT_PATHS)
+
+            base_paths.each do |base_path|
+              candidate = File.join(base_path, release, "raw", @params["filename"])
+              return candidate if File.exist?(candidate)
+            end
+
+            fallback = @params["filename"]
+            return fallback if File.exist?(fallback)
+
+            raise ArgumentError, "File not found: #{@params["filename"]} (searched in configured paths and as absolute path)"
           end
         end
       end


### PR DESCRIPTION
Add support for locating the input YAML file using a default filename (`rbac.yaml`) and a set of base paths from `mesh_raw_generated_paths` in `jekyll.yml`. The plugin builds the full path using the current `page.release`. Falls back to the given path if not found. Raises an error if the file cannot be located.

---

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
