### PR TITLE
chore(links): change link due to developer.konghq.com migration

### DIFF
--- a/app/_src/explore/gateway.md
+++ b/app/_src/explore/gateway.md
@@ -43,7 +43,7 @@ The `gateway` mode lets you skip exposing inbound listeners so it won't be inter
 {% tab Kubernetes %}
 
 {{site.mesh_product_name}} supports most of the ingress controllers. However, the recommended gateway in Kubernetes is [Kong](https://docs.konghq.com/gateway). You can use [Kong ingress controller for Kubernetes](https://docs.konghq.com/kubernetes-ingress-controller/) to implement authentication, transformations, and other functionalities across Kubernetes clusters with zero downtime.
-Most ingress controllers require an annotation [`ingress.kubernetes.io/service-upstream=true`](https://docs.konghq.com/kubernetes-ingress-controller/3.1.x/reference/annotations/#ingresskubernetesioservice-upstream) on every Kubernetes `Service` to work with {{site.mesh_product_name}}. {{site.mesh_product_name}} automatically injects the annotation for every `Service` in a namespace in a mesh that has `kuma.io/sidecar-injection: enabled` label.
+Most ingress controllers require an annotation [`ingress.kubernetes.io/service-upstream=true`](https://docs.konghq.com/kubernetes-ingress-controller/3.1.x/reference/annotations/#ingress-kubernetes-io-service-upstream) on every Kubernetes `Service` to work with {{site.mesh_product_name}}. {{site.mesh_product_name}} automatically injects the annotation for every `Service` in a namespace in a mesh that has `kuma.io/sidecar-injection: enabled` label.
 
 To use the delegated gateway feature, mark your API Gateway's Pod with the `kuma.io/gateway: enabled` annotation. Control plane automatically generates `Dataplane` objects.
 

--- a/app/_src/using-mesh/managing-ingress-traffic/delegated.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/delegated.md
@@ -37,7 +37,7 @@ Checkout our [guide](/docs/{{ page.release }}/guides/gateway-delegated/) to get 
 Remember that {{ site.mesh_product_name }} takes over from `kube-proxy` when it comes to managing endpoints for `Service` traffic.
 Ingress controllers generally do the same thing for upstream traffic.
 In order for these two functionalities not to conflict with each other, `Services` are required to
-have the [`ingress.kubernetes.io/service-upstream=true`](https://docs.konghq.com/kubernetes-ingress-controller/3.0.x/reference/annotations/#ingresskubernetesioservice-upstream) annotation.
+have the [`ingress.kubernetes.io/service-upstream=true`](https://docs.konghq.com/kubernetes-ingress-controller/3.0.x/reference/annotations/#ingress-kubernetes-io-service-upstream) annotation.
 With this annotation the ingress controller sends traffic to the `Service` IP instead of directly to the endpoints selected by the `Service`.
 {{site.mesh_product_name}} then routes this `Service` traffic to endpoints as configured by the mesh.
 {{site.mesh_product_name}} automatically injects this annotation for every


### PR DESCRIPTION
Seems like anchors have new structure.

We used to link to https://docs.konghq.com/kubernetes-ingress-controller/3.1.x/reference/annotations/#ingresskubernetesioservice-upstream and now the correct link is https://developer.konghq.com/kubernetes-ingress-controller/reference/annotations/#ingress-kubernetes-io-service-upstream (notice new `-`).

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
 