### PR TITLE
Fix: Broken transparent proxying link in Outbound

### DIFF
--- a/app/_src/production/dp-config/dpp.md
+++ b/app/_src/production/dp-config/dpp.md
@@ -50,7 +50,7 @@ A service is a group of all DPP inbounds that have the same `kuma.io/service` ta
 
 ### Outbounds
 An outbound allows the workload to consume a service in the mesh using a local port.
-This is only useful when not using (/docs/{{ page.release }}/production/dp-config/transparent-proxying/). 
+This is only useful when not using [transparent proxying](/docs/{{ page.release }}/production/dp-config/transparent-proxying/). 
 
 ## `Dataplane` entity
 


### PR DESCRIPTION
<Explain your change!>
Fixed a broken link in the Outbounds section of the [DP proxy page](https://developer.konghq.com/mesh/data-plane-proxy/#outbounds). It was missing link text, so I've added that.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? Yes
