### PR TITLE
fix: reachable backend Kubernetes examples

### DIFF
--- a/app/_src/production/dp-config/transparent-proxying.md
+++ b/app/_src/production/dp-config/transparent-proxying.md
@@ -289,6 +289,8 @@ spec:
   ...
   template:
     metadata:
+      ...
+      annotations:
         kuma.io/reachable-backends: |
           refs:
           - kind: MeshService


### PR DESCRIPTION
Example was missing `annotations` field

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
