### PR TITLE
docs(cilium): add info about kubeProxyReplacement false

### DIFF
--- a/app/_src/production/cp-deployment/kubernetes.md
+++ b/app/_src/production/cp-deployment/kubernetes.md
@@ -106,3 +106,8 @@ gcloud beta container \
   --cluster-ipv4-cidr=/20 \
   --workload-policies=allow-net-admin
 ```
+
+## Cilium
+
+By default, Cilium replaces kube-proxy and changes the way ClusterIP routing works.
+In order to not break {{site.mesh_product_name}} routing please use `kubeProxyReplacement: false` in your Cilium configuration.


### PR DESCRIPTION
Otherwise running cilium + kuma + mTLS (strict) breaks routing and you always get "Empty reply from the server".

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
