### PR TITLE
docs(direct-access): add info about policies not working when direct-access is used

### DIFF
--- a/app/_src/production/dp-config/dpp-on-kubernetes.md
+++ b/app/_src/production/dp-config/dpp-on-kubernetes.md
@@ -586,6 +586,10 @@ kuma.io/direct-access-services: *
 Using `*` to directly access every service is a resource intensive operation, so we must use it carefully.
 {% endwarning %}
 
+{% warning %}
+Accessing services by using `kuma.io/direct-access-services` annotation means any policies applied to the service will **not** take effect.
+{% endwarning %}
+
 ### Schema
 
 {% json_schema kuma.io_containerpatches type=crd %}


### PR DESCRIPTION
It's not mentioned in the docs that policies don't work when you use direct-access

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
