### PR TITLE
fix(ci): exclude kuma.io from link checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
             --exclude 'https://jwt.io/' \
             --exclude 'https://en.wikipedia.org' \
             --exclude 'https://konghq.com' \
+            --exclude 'https://https://kuma.io' \
             --header 'Accept: */*' \
             --max-connections-per-host 8 \
             --max-response-body-size 100000000 \
@@ -90,6 +91,7 @@ jobs:
             --exclude 'https://jwt.io/' \
             --exclude 'https://en.wikipedia.org' \
             --exclude 'https://konghq.com' \
+            --exclude 'https://https://kuma.io' \
             --max-connections-per-host 8 \
             --max-response-body-size 100000000 \
             --skip-tls-verification \


### PR DESCRIPTION
it fails a lot

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
