### PR TITLE
fix(ci): exclude all external links from link checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             --exclude http://127.0.0.1:7777/docs/1. \
             --exclude 127.0.0.1 \
             --exclude 'http://localhost:7777/vite-dev/*' \
-            --exclude 'https?://(?:\[[0-9A-Fa-f:]+\]|\d{1,3}(?:\.\d{1,3}){3}|[A-Za-z0-9-]+\.[A-Za-z0-9.-]+)(?::\d+)?(?:/[^\s]*)?' \ 
+            --exclude 'https?://(?:\[[0-9A-Fa-f:]+\]|\d{1,3}(?:\.\d{1,3}){3}|[A-Za-z0-9-]+\.[A-Za-z0-9.-]+)(?::\d+)?(?:/[^\s]*)?' \
             --include 'https?://localhost(?::\d+)?(?:/[^\s]*)?' \
             --header 'Accept: */*' \
             --max-connections-per-host 8 \
@@ -64,7 +64,7 @@ jobs:
             --exclude http://127.0.0.1:7777/docs/1. \
             --exclude 127.0.0.1 \
             --exclude 'http://localhost:7777/vite-dev/*' \
-            --exclude 'https?://(?:\[[0-9A-Fa-f:]+\]|\d{1,3}(?:\.\d{1,3}){3}|[A-Za-z0-9-]+\.[A-Za-z0-9.-]+)(?::\d+)?(?:/[^\s]*)?' \ 
+            --exclude 'https?://(?:\[[0-9A-Fa-f:]+\]|\d{1,3}(?:\.\d{1,3}){3}|[A-Za-z0-9-]+\.[A-Za-z0-9.-]+)(?::\d+)?(?:/[^\s]*)?' \
             --include 'https?://localhost(?::\d+)?(?:/[^\s]*)?' \
             --max-connections-per-host 8 \
             --max-response-body-size 100000000 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,35 +39,16 @@ jobs:
           make run &
           # Wait until the dev server is reachable
           npx --yes wait-on --timeout 180000 http://localhost:7777
-      - name: link checker
+      - name: link checker without external links
         run: |
           $(mise which muffet) \
             http://localhost:7777 \
             --buffer-size 8192 \
-            --exclude 'https://github.com/(/)?kumahq/kuma/pull/.*' \
-            --exclude 'https://github.com/.*/.*/blob/.*#.*' \
-            --exclude 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md.*' \
-            --exclude 'https://github.com/kumahq/kuma/blob/master/CHANGELOG.md' \
             --exclude http://127.0.0.1:7777/docs/1. \
             --exclude 127.0.0.1 \
             --exclude 'http://localhost:7777/vite-dev/*' \
-            --exclude https://cloudsmith.io/~kong/repos \
-            --exclude https://linux.die.net \
-            --exclude https://packages.konghq.com \
-            --exclude https://twitter.com \
-            --exclude https://coredns.io \
-            --exclude 'https://argo-cd.readthedocs.io/en/stable/' \
-            --exclude 'https://docs.cilium.io/en/v1.14/operations/upgrade/' \
-            --exclude 'https://jwt.io/' \
-            --exclude 'https://en.wikipedia.org' \
-            --exclude 'https://konghq.com' \
-            --exclude 'https://kuma.io' \
-            --exclude 'https://kubernetes.io' \
-            --exclude 'https://opentelemetry.io' \
-            --exclude 'https://www.envoyproxy.io' \
-            --exclude 'https://developer.konghq.com' \
-            --exclude 'https://minikube.sigs.k8s.io/docs/handbook/host-access/' \
-            --exclude 'https://www.npmjs.com/package/jwt-cli' \
+            --exclude 'https?://(?:\[[0-9A-Fa-f:]+\]|\d{1,3}(?:\.\d{1,3}){3}|[A-Za-z0-9-]+\.[A-Za-z0-9.-]+)(?::\d+)?(?:/[^\s]*)?' \ 
+            --include 'https?://localhost(?::\d+)?(?:/[^\s]*)?' \
             --header 'Accept: */*' \
             --max-connections-per-host 8 \
             --max-response-body-size 100000000 \
@@ -75,35 +56,16 @@ jobs:
             --rate-limit 50 \
             --max-retries 5 \
             --timeout 100
-      - name: link checker dev docs
+      - name: link checker dev without external links
         run: |
           $(mise which muffet) \
             http://localhost:7777/docs/dev \
             --buffer-size 8192 \
-            --exclude 'https://github.com/(/)?kumahq/kuma/pull/.*' \
-            --exclude 'https://github.com/.*/.*/blob/.*#.*' \
-            --exclude 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md.*' \
-            --exclude 'https://github.com/kumahq/kuma/blob/master/CHANGELOG.md' \
             --exclude http://127.0.0.1:7777/docs/1. \
             --exclude 127.0.0.1 \
             --exclude 'http://localhost:7777/vite-dev/*' \
-            --exclude https://cloudsmith.io/~kong/repos \
-            --exclude https://linux.die.net \
-            --exclude https://packages.konghq.com \
-            --exclude https://twitter.com \
-            --exclude https://coredns.io \
-            --exclude 'https://argo-cd.readthedocs.io/en/stable/' \
-            --exclude 'https://docs.cilium.io/en/v1.14/operations/upgrade/' \
-            --exclude 'https://jwt.io/' \
-            --exclude 'https://en.wikipedia.org' \
-            --exclude 'https://konghq.com' \
-            --exclude 'https://kuma.io' \
-            --exclude 'https://kubernetes.io' \
-            --exclude 'https://opentelemetry.io' \
-            --exclude 'https://www.envoyproxy.io' \
-            --exclude 'https://developer.konghq.com' \
-            --exclude 'https://minikube.sigs.k8s.io/docs/handbook/host-access/' \
-            --exclude 'https://www.npmjs.com/package/jwt-cli' \
+            --exclude 'https?://(?:\[[0-9A-Fa-f:]+\]|\d{1,3}(?:\.\d{1,3}){3}|[A-Za-z0-9-]+\.[A-Za-z0-9.-]+)(?::\d+)?(?:/[^\s]*)?' \ 
+            --include 'https?://localhost(?::\d+)?(?:/[^\s]*)?' \
             --max-connections-per-host 8 \
             --max-response-body-size 100000000 \
             --skip-tls-verification \


### PR DESCRIPTION
This fails constantly, we are excluding all external links for now. We will move this functionality either to manual step on release or we will look for alternative

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
