### PR TITLE
chore(ruby): pin ruby gems to specific version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,13 @@
 source 'https://rubygems.org'
 
 gem 'jekyll', '~> 4.2'
-gem 'liquid-c'
+gem 'liquid-c', '4.0.1'
 gem 'rouge', '3.30.0'
-gem 'jekyll-generator-single-source'
+gem 'jekyll-generator-single-source', '0.0.15'
 
-gem 'jekyll-paginate-v2'
-gem 'jekyll-last-modified-at'
-gem 'jekyll-contentblocks'
+gem 'jekyll-paginate-v2', '3.0.0'
+gem 'jekyll-last-modified-at', '1.3.2'
+gem 'jekyll-contentblocks', '1.2.0'
 gem 'jekyll-vite', '3.0.4'
 gem 'vite_ruby', '3.9.2'
 gem 'jekyll-kuma-plugins', path: './jekyll-kuma-plugins'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,9 +49,8 @@ GEM
     jekyll-generator-single-source (0.0.15)
       i18n (~> 1)
       jekyll (>= 4.2, < 5.0)
-    jekyll-last-modified-at (1.3.0)
+    jekyll-last-modified-at (1.3.2)
       jekyll (>= 3.7, < 5.0)
-      posix-spawn (~> 0.3.9)
     jekyll-paginate-v2 (3.0.0)
       jekyll (>= 3.0, < 5.0)
     jekyll-sass-converter (3.0.0)
@@ -77,7 +76,6 @@ GEM
     mutex_m (0.3.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    posix-spawn (0.3.15)
     public_suffix (6.0.1)
     rack (3.0.16)
     rack-proxy (0.7.7)
@@ -128,13 +126,13 @@ DEPENDENCIES
   diff-lcs
   foreman
   jekyll (~> 4.2)
-  jekyll-contentblocks
-  jekyll-generator-single-source
+  jekyll-contentblocks (= 1.2.0)
+  jekyll-generator-single-source (= 0.0.15)
   jekyll-kuma-plugins!
-  jekyll-last-modified-at
-  jekyll-paginate-v2
+  jekyll-last-modified-at (= 1.3.2)
+  jekyll-paginate-v2 (= 3.0.0)
   jekyll-vite (= 3.0.4)
-  liquid-c
+  liquid-c (= 4.0.1)
   rouge (= 3.30.0)
   rspec
   vite_ruby (= 3.9.2)


### PR DESCRIPTION
We want more control over gem versions and update them with dependabot/renovate not just rely on latest

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
