### PR TITLE
chore(ruby): move ruby management to mise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: jdx/mise-action@156251fcc627ac4e26cb0f93dd47d1d4979abf24 # v3.3.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - name: Install dependencies
+        run: make install
       - working-directory: jekyll-kuma-plugins
         run: bundle install
       - working-directory: jekyll-kuma-plugins

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ define newline
 endef
 
 MISE := $(shell which mise)
-YARN := $(shell $(MISE) which yarn)
-BUNDLE := $(shell $(MISE) which bundle)
+YARN=$(shell $(MISE) which yarn)
+BUNDLE=$(shell $(MISE) which bundle)
 MUFFET=$(shell $(MISE) which muffet)
 
 LINK_CHECK_TARGET ?= http://localhost:7777


### PR DESCRIPTION
Moving ruby version control to mise to simplify dependency management

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
