### PR TITLE
docs(federation): add missing namespace on federation guide

### DIFF
--- a/app/_src/guides/federate-kv.md
+++ b/app/_src/guides/federate-kv.md
@@ -143,6 +143,12 @@ You should eventually see
 
 ### Apply policy on global control plane
 
+First we need to create a namespace on global control plane to match the namespace of demo application in zone control plane:
+
+```sh
+kubectl --context mesh-global create namespace kuma-demo
+```
+
 We can check policy synchronization from global control plane to zone control plane by applying a policy on global control plane:
 
 ```sh


### PR DESCRIPTION
We were missing a namespace and you get then:

```
Error from server (NotFound): error when creating "STDIN": namespaces "kuma-demo" not found
```

because we never created this NS on global (see guide up until the change).

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
