### PR TITLE
feat(concepts): add zone concept definition

### DIFF
--- a/app/_src/introduction/concepts.md
+++ b/app/_src/introduction/concepts.md
@@ -8,6 +8,10 @@ In this page we will introduce concepts that are core to understanding {{ site.m
 
 A mesh is the top-level resource that represents an isolated service mesh deployment. It serves as the parent resource for all policies, services, and data planes, providing a separate domain of configuration and communication.
 
+## Zone
+
+A zone is a deployment unit representing a distinct infrastructure environment—typically a Kubernetes cluster, VPC, or data center. All data plane proxies within a zone must be able to communicate with each other. {{ site.mesh_product_name }} supports [multi-zone deployments](/docs/{{ page.release }}/production/deployment/multi-zone) where zones can span different regions, clouds, or data centers while remaining part of the same mesh. This enables automatic service discovery and fail-over across zones.
+
 ## Control plane
 
 The control plane is the central management layer of {{ site.mesh_product_name }}. It is responsible for configuring and managing the behavior of the data plane,

--- a/app/_src/introduction/overview-of-kuma.md
+++ b/app/_src/introduction/overview-of-kuma.md
@@ -12,7 +12,7 @@ title: Overview of Kuma
 
 {% if_version gte:2.6.x %}
 * **Universal and Kubernetes-native**: Platform-agnostic, can run and operate anywhere.
-* **Single-zone and multi-zone**: Supports multiple clouds, regions, and Kubernetes clusters with native DNS service discovery and ingress capability.
+* **Single-zone and multi-zone**: Supports multiple clouds, regions, and Kubernetes clusters with native DNS service discovery and ingress capability. A [zone](/docs/{{ page.release }}/introduction/concepts#zone) is a deployment unit like a Kubernetes cluster, VPC, or data center.
   * [Read more about single-zone deployments](/docs/{{ page.release }}/production/deployment/single-zone/)
   * [Read more about multi-zone deployments](/docs/{{ page.release }}/production/deployment/multi-zone/)
 * **Multi-mesh**: Supports multiple individual meshes with one control plane, lowering the operational costs of supporting the entire organization.
@@ -24,7 +24,7 @@ title: Overview of Kuma
 
 {% if_version lte:2.5.x %}
 * **Universal and Kubernetes-native**: Platform-agnostic, can run and operate anywhere.
-* **Standalone and multi-zone**: Supports multiple clouds, regions, and Kubernetes clusters with native DNS service discovery and ingress capability.
+* **Standalone and multi-zone**: Supports multiple clouds, regions, and Kubernetes clusters with native DNS service discovery and ingress capability. A [zone](/docs/{{ page.release }}/introduction/concepts#zone) is a deployment unit like a Kubernetes cluster, VPC, or data center.
   * [Read more about standalone deployments](/docs/{{ page.release }}/production/deployment/stand-alone/)
   * [Read more about multi-zone deployments](/docs/{{ page.release }}/production/deployment/multi-zone/)
 * **Multi-mesh**: Supports multiple individual meshes with one control plane, lowering the operational costs of supporting the entire organization.

--- a/app/_src/production/index.md
+++ b/app/_src/production/index.md
@@ -10,8 +10,8 @@ Production deployment of {{site.mesh_product_name}} involves choosing the right 
 Choose the deployment model that fits your infrastructure:
 
 - **[Deployment overview](/docs/{{ page.release }}/production/deployment/)** - Understand deployment modes and when to use each
-- **[Single-zone deployment](/docs/{{ page.release }}/production/deployment/single-zone/)** - Deploy {{site.mesh_product_name}} in a single Kubernetes cluster or data center
-- **[Multi-zone deployment](/docs/{{ page.release }}/production/deployment/multi-zone/)** - Connect multiple zones across regions, clouds, or data centers
+- **[Single-zone deployment](/docs/{{ page.release }}/production/deployment/single-zone/)** - Deploy {{site.mesh_product_name}} in a single Kubernetes cluster or data center ([zone](/docs/{{ page.release }}/introduction/concepts#zone))
+- **[Multi-zone deployment](/docs/{{ page.release }}/production/deployment/multi-zone/)** - Connect multiple [zones](/docs/{{ page.release }}/introduction/concepts#zone) across regions, clouds, or data centers
 
 Common scenarios:
 


### PR DESCRIPTION
## Motivation

Zone is a HIGH priority concept referenced in 97+ files but not defined in concepts.md.

## Implementation information

- Add zone definition to concepts.md (deployment unit: K8s cluster, VPC, data center)
- Link zone concept from overview-of-kuma.md (both version blocks)
- Link zone concept from production/index.md deployment section

## Supporting documentation

Related to concepts-to-add.md tracking doc.