### PR TITLE
docs(explore,reference): add description and keywords metadata

### DIFF
--- a/app/_src/explore/cli.md
+++ b/app/_src/explore/cli.md
@@ -1,5 +1,9 @@
 ---
 title: CLI
+description: Learn about the CLI executables bundled with the service mesh, including kuma-cp, kuma-dp, envoy, and kumactl for managing your mesh.
+keywords:
+  - kumactl
+  - CLI
 ---
 
 {{site.mesh_product_name}} ships in a bundle that includes a few executables:

--- a/app/_src/explore/gateway-api.md
+++ b/app/_src/explore/gateway-api.md
@@ -1,5 +1,9 @@
 ---
 title: Kubernetes Gateway API
+description: Configure builtin gateways and service-to-service routing using Kubernetes Gateway API resources like Gateway, HTTPRoute, and GatewayClass.
+keywords:
+  - Gateway API
+  - HTTPRoute
 ---
 
 {{site.mesh_product_name}} supports [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/)

--- a/app/_src/explore/gateway.md
+++ b/app/_src/explore/gateway.md
@@ -1,5 +1,9 @@
 ---
 title: Gateway
+description: Route traffic from outside a mesh to services inside the mesh using delegated or builtin gateways with MeshGateway and MeshGatewayRoute resources.
+keywords:
+  - gateway
+  - ingress
 ---
 
 When services need to receive traffic from the outside, commonly called North/South, the {{site.mesh_product_name}} Gateway enables routing network traffic from outside a {{site.mesh_product_name}} mesh to services inside the mesh. The gateway is also responsible for security at the entrance of the Mesh.

--- a/app/_src/explore/inspect-api.md
+++ b/app/_src/explore/inspect-api.md
@@ -1,5 +1,9 @@
 ---
 title: Inspect API
+description: Debug policies and data plane proxies using the Inspect API to view matched policies, affected proxies, and Envoy configuration dumps.
+keywords:
+  - inspect
+  - debugging
 ---
 
 Starting with version 1.5.0, {{site.mesh_product_name}} offers the Inspect API to improve the policy debugging experience.

--- a/app/_src/explore/observability.md
+++ b/app/_src/explore/observability.md
@@ -1,5 +1,10 @@
 ---
 title: Observability
+description: Configure observability tools like Prometheus, Grafana, Jaeger, Loki, and Datadog to collect metrics, traces, and logs from your mesh.
+keywords:
+  - observability
+  - metrics
+  - tracing
 ---
 
 This page will describe how to configure different observability tools to work with {{site.mesh_product_name}}.

--- a/app/_src/reference/data-collection.md
+++ b/app/_src/reference/data-collection.md
@@ -1,5 +1,9 @@
 ---
 title: Kuma data collection
+description: Enable anonymous data collection to help improve the product. Learn what data is collected including version, deployment mode, and mesh statistics.
+keywords:
+  - telemetry
+  - data collection
 ---
 
 {{site.mesh_product_name}} can collect information about your deployment to continuously improve the product and gather anonymous feedback. The collected data is sent to Kong servers securely for storage and aggregation.

--- a/app/_src/reference/http-api.md
+++ b/app/_src/reference/http-api.md
@@ -1,5 +1,9 @@
 ---
 title: HTTP API
+description: Reference documentation for the RESTful HTTP API to retrieve and manage mesh configuration, policies, data planes, and resources.
+keywords:
+  - HTTP API
+  - REST API
 ---
 
 {{site.mesh_product_name}} ships with a RESTful HTTP interface that you can use to retrieve the state of your configuration and policies on every environment, and when running on Universal mode it will also allow to make changes to the state. On Kubernetes, you will use native CRDs to change the state in order to be consistent with Kubernetes best practices.

--- a/app/_src/reference/kubernetes-annotations.md
+++ b/app/_src/reference/kubernetes-annotations.md
@@ -1,6 +1,10 @@
 ---
 title: Kubernetes annotations and labels
 content-type: reference
+description: Complete reference for Kubernetes annotations and labels to configure sidecar injection, mesh assignment, transparent proxying, and metrics.
+keywords:
+  - annotations
+  - labels
 ---
 
 This page provides a complete list of all the annotations you can specify when you run {{site.mesh_product_name}} in Kubernetes mode.

--- a/app/_src/reference/kuma-cp.md
+++ b/app/_src/reference/kuma-cp.md
@@ -1,5 +1,9 @@
 ---
 title: kuma-cp configuration reference
+description: Reference documentation for control plane configuration options including the full kuma-cp.yaml and Helm values.yaml files.
+keywords:
+  - kuma-cp
+  - configuration
 ---
 
 ## Kuma CP configuration

--- a/app/_src/reference/proxy-template.md
+++ b/app/_src/reference/proxy-template.md
@@ -1,5 +1,9 @@
 ---
 title: Proxy Template
+description: Customize low-level Envoy configuration using ProxyTemplate to modify listeners, clusters, network filters, HTTP filters, and virtual hosts.
+keywords:
+  - ProxyTemplate
+  - Envoy
 ---
 
 The proxy template provides configuration options for [low-level Envoy resources](https://www.envoyproxy.io/docs/envoy/latest/api-v3/api) that {{site.mesh_product_name}} policies do not directly expose.


### PR DESCRIPTION
## Motivation

Add SEO-friendly metadata (description and keywords) to explore/ and reference/ docs pages as part of Phase 2.2 page metadata initiative.

## Implementation information

Added `description:` and `keywords:` frontmatter to 10 files:
- explore/cli.md
- explore/gateway-api.md
- explore/gateway.md
- explore/inspect-api.md
- explore/observability.md
- reference/data-collection.md
- reference/http-api.md
- reference/kubernetes-annotations.md
- reference/kuma-cp.md
- reference/proxy-template.md

## Supporting documentation

Part of frontmatter_plan.md PR 4