### PR TITLE
docs(quickstart,networking): add description and keywords metadata

### DIFF
--- a/app/_src/networking/dns.md
+++ b/app/_src/networking/dns.md
@@ -1,5 +1,7 @@
 ---
 title: DNS
+description: Configure DNS resolution and virtual IPs for service-to-service communication within the mesh.
+keywords: DNS, networking, service discovery
 ---
 
 {{site.mesh_product_name}} ships with DNS resolver to provide service naming - a mapping of hostname to Virtual IPs (VIPs) of services registered in {{site.mesh_product_name}}.

--- a/app/_src/networking/hostnamegenerator.md
+++ b/app/_src/networking/hostnamegenerator.md
@@ -1,5 +1,7 @@
 ---
 title: HostnameGenerator
+description: Generate custom DNS hostnames for MeshServices, MeshMultiZoneServices, and MeshExternalServices using templates.
+keywords: hostname, DNS, networking
 ---
 
 {% if_version lte:2.8.x %}

--- a/app/_src/networking/index.md
+++ b/app/_src/networking/index.md
@@ -1,6 +1,8 @@
 ---
 title: Service Discovery & Networking
 content_type: explanation
+description: Overview of service discovery, DNS resolution, traffic routing, and connectivity between services in the mesh.
+keywords: networking, service discovery, dns
 ---
 
 {{site.mesh_product_name}} provides a comprehensive networking layer that handles service discovery, DNS resolution, traffic routing, and connectivity between services in your mesh. This section covers how services communicate with each other and with external systems.

--- a/app/_src/networking/meshexternalservice.md
+++ b/app/_src/networking/meshexternalservice.md
@@ -1,5 +1,7 @@
 ---
 title: MeshExternalService
+description: Define external services for mesh workloads to consume, with support for TLS origination and custom endpoints.
+keywords: MeshExternalService, networking, tls
 ---
 
 {% warning %}

--- a/app/_src/quickstart/kubernetes-demo-kv.md
+++ b/app/_src/quickstart/kubernetes-demo-kv.md
@@ -1,5 +1,7 @@
 ---
 title: Deploy Kuma on Kubernetes
+description: Deploy a demo application with a web app and kv store on Kubernetes to learn how the service mesh works.
+keywords: kubernetes, quickstart, demo
 ---
 
 To start learning how {{site.mesh_product_name}} works, you run and secure a simple demo application that consists of two services:

--- a/app/_src/quickstart/kubernetes-demo.md
+++ b/app/_src/quickstart/kubernetes-demo.md
@@ -1,5 +1,7 @@
 ---
 title: Deploy Kuma on Kubernetes
+description: Deploy a demo application with a web app and Redis on Kubernetes to learn how the service mesh works.
+keywords: kubernetes, quickstart, demo
 ---
 
 To start learning how {{site.mesh_product_name}} works, you run and secure a simple demo application that consists of two services:

--- a/app/_src/quickstart/kubernetes.md
+++ b/app/_src/quickstart/kubernetes.md
@@ -1,5 +1,7 @@
 ---
 title: Explore Kuma with the Kubernetes demo app
+description: Explore service mesh features with the Kubernetes demo app, including traffic metrics, mTLS, and traffic permissions.
+keywords: kubernetes, demo, tutorial
 ---
 
 To start learning how {{site.mesh_product_name}} works, you can download and run a simple demo application that consists of two services:

--- a/app/_src/quickstart/universal-demo.md
+++ b/app/_src/quickstart/universal-demo.md
@@ -1,5 +1,7 @@
 ---
 title: Deploy Kuma on Universal
+description: Run a demo application on Universal mode to learn how the service mesh works with data plane proxies and mTLS.
+keywords: universal, quickstart, demo
 ---
 
 This demo shows how to run {{site.mesh_product_name}} in Universal mode on a single machine.

--- a/app/_src/quickstart/universal-docker-demo.md
+++ b/app/_src/quickstart/universal-docker-demo.md
@@ -1,5 +1,7 @@
 ---
 title: Deploy Kuma on Universal
+description: Run the service mesh in Universal mode using Docker containers with a demo application, data plane proxies, and built-in gateway.
+keywords: universal, docker, quickstart
 ---
 
 {% capture docs %}/docs/{{ page.release }}{% endcapture %}

--- a/app/_src/quickstart/universal.md
+++ b/app/_src/quickstart/universal.md
@@ -1,5 +1,7 @@
 ---
 title: Explore Kuma with the Universal demo app
+description: Explore service mesh features with the Universal demo app, including traffic metrics, mTLS, and traffic permissions.
+keywords: universal, demo, tutorial
 ---
 
 To start learning how {{site.mesh_product_name}} works, you can download and run a simple demo application that consists of two services:


### PR DESCRIPTION
## Motivation

Add SEO metadata to quickstart and networking docs as part of Phase 2.2.

## Implementation information

Add `description:` and `keywords:` frontmatter to 10 files:
- quickstart/kubernetes-demo-kv.md
- quickstart/kubernetes-demo.md
- quickstart/kubernetes.md
- quickstart/universal-demo.md
- quickstart/universal-docker-demo.md
- quickstart/universal.md
- networking/dns.md
- networking/hostnamegenerator.md
- networking/index.md
- networking/meshexternalservice.md

## Supporting documentation

Part of Phase 2.2 page metadata plan.