### PR TITLE
docs(networking,using-mesh): add description and keywords metadata

### DIFF
--- a/app/_src/networking/meshmultizoneservice.md
+++ b/app/_src/networking/meshmultizoneservice.md
@@ -1,5 +1,10 @@
 ---
 title: MeshMultiZoneService
+description: Group MeshServices across zones with MeshMultiZoneService for cross-zone load balancing and high availability.
+keywords:
+  - MeshMultiZoneService
+  - cross-zone
+  - load balancing
 ---
 
 The MeshMultiZoneService resource represents a group of MeshServices in a multizone deployment.

--- a/app/_src/networking/meshservice.md
+++ b/app/_src/networking/meshservice.md
@@ -1,5 +1,10 @@
 ---
 title: MeshService
+description: Define service destinations with MeshService for traffic routing, hostname assignment, and policy targeting.
+keywords:
+  - MeshService
+  - service discovery
+  - traffic routing
 ---
 
 {% if_version lte:2.8.x %}

--- a/app/_src/networking/non-mesh-traffic.md
+++ b/app/_src/networking/non-mesh-traffic.md
@@ -1,5 +1,10 @@
 ---
 title: Non-mesh traffic
+description: Configure how traffic flows to and from services outside the mesh, including passthrough mode and external access.
+keywords:
+  - passthrough
+  - external traffic
+  - non-mesh
 ---
 
 ## Incoming

--- a/app/_src/networking/service-discovery.md
+++ b/app/_src/networking/service-discovery.md
@@ -1,5 +1,10 @@
 ---
 title: Service Discovery
+description: Learn how data plane proxies connect to the control plane and discover service endpoints for traffic routing.
+keywords:
+  - service discovery
+  - control plane
+  - data plane
 ---
 
 This page explains how communication between the components of {{site.mesh_product_name}} handles service traffic. Communication is handled between the data plane proxy (`kuma-dp`) and the control plane (`kuma-cp`), and between multiple instances of the data plane proxy.

--- a/app/_src/networking/transparent-proxying.md
+++ b/app/_src/networking/transparent-proxying.md
@@ -1,5 +1,10 @@
 ---
 title: Transparent Proxying
+description: Understand how transparent proxying intercepts and redirects traffic through the sidecar using iptables.
+keywords:
+  - transparent proxy
+  - iptables
+  - traffic interception
 ---
 
 ## What is Transparent Proxying?

--- a/app/_src/using-mesh/index.md
+++ b/app/_src/using-mesh/index.md
@@ -1,6 +1,11 @@
 ---
 title: Using Kuma
 content_type: explanation
+description: Learn how to secure, manage, and observe your service mesh with policies for security, resilience, and traffic control.
+keywords:
+  - service mesh
+  - policies
+  - observability
 ---
 
 {{site.mesh_product_name}} provides comprehensive features for securing, managing, and observing your service [mesh](/docs/{{ page.release }}/introduction/concepts#mesh). This section covers practical guides for implementing common patterns and configuring essential [policies](/docs/{{ page.release }}/introduction/concepts#policy).

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-k8s.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-k8s.md
@@ -1,5 +1,10 @@
 ---
 title: Running built-in gateway pods on Kubernetes
+description: Deploy and configure built-in gateway instances on Kubernetes using MeshGatewayInstance resources.
+keywords:
+  - MeshGatewayInstance
+  - Kubernetes gateway
+  - gateway deployment
 ---
 
 `MeshGatewayInstance` is a Kubernetes-only resource for deploying [{{site.mesh_product_name}}'s builtin gateway](/docs/{{ page.release }}/using-mesh/managing-ingress-traffic/builtin).

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
@@ -1,5 +1,10 @@
 ---
 title: Configuring built-in listeners
+description: Configure gateway listeners with MeshGateway for ports, protocols, TLS termination, and cross-mesh communication.
+keywords:
+  - MeshGateway
+  - listeners
+  - TLS termination
 ---
 
 {% capture k8s_service_selector_suffix %}{% if_version gte:2.7.x inline:true %}_default_svc{% endif_version %}{% endcapture %}

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-routes.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-routes.md
@@ -1,5 +1,10 @@
 ---
 title: Configuring built-in routes
+description: Route traffic from gateway listeners to mesh services using MeshHTTPRoute and MeshTCPRoute policies.
+keywords:
+  - gateway routes
+  - MeshHTTPRoute
+  - MeshTCPRoute
 ---
 
 For configuring how traffic is forwarded from a listener to your mesh services,

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin.md
@@ -1,5 +1,10 @@
 ---
 title: Configure a built-in gateway
+description: Deploy and configure built-in gateways using MeshGateway, MeshHTTPRoute, and MeshTCPRoute for ingress traffic.
+keywords:
+  - builtin gateway
+  - ingress
+  - MeshGateway
 ---
 
 The built-in gateway is configured using a combination of [`MeshGateway`](/docs/{{ page.release }}/using-mesh/managing-ingress-traffic/builtin-listeners), [`MeshHTTPRoute`](/docs/{{ page.release }}/policies/meshhttproute) and [`MeshTCPRoute`](/docs/{{ page.release }}/policies/meshtcproute),

--- a/app/_src/using-mesh/managing-ingress-traffic/delegated.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/delegated.md
@@ -1,5 +1,10 @@
 ---
 title: Delegated gateways
+description: Integrate existing API gateways like Kong into your mesh using delegated gateway mode with Envoy sidecars.
+keywords:
+  - delegated gateway
+  - Kong
+  - API gateway
 ---
 
 Delegated gateways allow you to integrate existing API gateway solutions into your mesh.

--- a/app/_src/using-mesh/managing-ingress-traffic/gateway-api.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/gateway-api.md
@@ -1,5 +1,10 @@
 ---
 title: Kubernetes Gateway API
+description: Use Kubernetes Gateway API resources to configure built-in gateways and service-to-service routing with GAMMA.
+keywords:
+  - Gateway API
+  - Kubernetes
+  - GAMMA
 ---
 
 {{site.mesh_product_name}} supports [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/)

--- a/app/_src/using-mesh/managing-ingress-traffic/overview.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/overview.md
@@ -1,5 +1,10 @@
 ---
 title: How ingress works
+description: Understand ingress options with delegated gateways for existing proxies or built-in gateways using Envoy.
+keywords:
+  - ingress
+  - gateway
+  - north-south traffic
 ---
 
 {{site.mesh_product_name}} provides two features to manage ingress traffic, also known as north/south traffic.


### PR DESCRIPTION
## Motivation

Add SEO metadata (description and keywords) to networking and using-mesh docs pages per Phase 2.2 plan (PR 6 of 16).

## Implementation information

Added `description:` and `keywords:` frontmatter to 13 files:
- networking/meshmultizoneservice.md
- networking/meshservice.md
- networking/non-mesh-traffic.md
- networking/service-discovery.md
- networking/transparent-proxying.md
- using-mesh/index.md
- using-mesh/managing-ingress-traffic/builtin-k8s.md
- using-mesh/managing-ingress-traffic/builtin-listeners.md
- using-mesh/managing-ingress-traffic/builtin-routes.md
- using-mesh/managing-ingress-traffic/builtin.md
- using-mesh/managing-ingress-traffic/delegated.md
- using-mesh/managing-ingress-traffic/gateway-api.md
- using-mesh/managing-ingress-traffic/overview.md

## Supporting documentation

Part of Phase 2.2: Page Metadata initiative.