### PR TITLE
docs(guides): add description and keywords metadata

### DIFF
--- a/app/_src/guides/consumer-producer-policies-kv.md
+++ b/app/_src/guides/consumer-producer-policies-kv.md
@@ -1,5 +1,10 @@
 ---
 title: Producer and Consumer policies
+description: Learn how to use namespace-scoped producer and consumer policies to control traffic and leverage Kubernetes RBAC for policy configuration.
+keywords:
+  - producer consumer
+  - namespace policies
+  - policy roles
 content_type: tutorial
 ---
 

--- a/app/_src/guides/consumer-producer-policies.md
+++ b/app/_src/guides/consumer-producer-policies.md
@@ -1,5 +1,10 @@
 ---
 title: Producer and Consumer policies
+description: Learn how to use namespace-scoped producer and consumer policies to control traffic and leverage Kubernetes RBAC for policy configuration.
+keywords:
+  - producer consumer
+  - namespace policies
+  - policy roles
 ---
 
 With namespace scoped policies in {{site.mesh_product_name}} you can have fine-grained control over policies and how they apply to 

--- a/app/_src/guides/federate-kv.md
+++ b/app/_src/guides/federate-kv.md
@@ -1,5 +1,10 @@
 ---
 title: Federate zone control plane
+description: Learn how to federate a zone control plane to a multi-zone deployment for centralized management, cross-zone connectivity, and global policy distribution.
+keywords:
+  - federation
+  - multi-zone
+  - global control plane
 content_type: tutorial
 ---
 

--- a/app/_src/guides/federate.md
+++ b/app/_src/guides/federate.md
@@ -1,5 +1,10 @@
 ---
 title: Federate zone control plane
+description: Learn how to federate a zone control plane to a multi-zone deployment for centralized management, cross-zone connectivity, and global policy distribution.
+keywords:
+  - federation
+  - multi-zone
+  - global control plane
 ---
 
 With {{site.mesh_product_name}} you can first start with just one zone control plane

--- a/app/_src/guides/gateway-api-kv.md
+++ b/app/_src/guides/gateway-api-kv.md
@@ -1,5 +1,10 @@
 ---
 title: Kubernetes Gateway API
+description: Learn how to use Kubernetes Gateway API to configure a builtin gateway for north-south traffic and expose services with TLS.
+keywords:
+  - Gateway API
+  - ingress
+  - HTTPRoute
 content_type: tutorial
 ---
 

--- a/app/_src/guides/gateway-api.md
+++ b/app/_src/guides/gateway-api.md
@@ -1,5 +1,10 @@
 ---
 title: Kubernetes Gateway API
+description: Learn how to use Kubernetes Gateway API to configure a builtin gateway for north-south traffic and expose services with TLS.
+keywords:
+  - Gateway API
+  - ingress
+  - HTTPRoute
 ---
 
 To get traffic from outside your mesh inside it (North/South) with {{site.mesh_product_name}} you can use

--- a/app/_src/guides/gateway-builtin-kv.md
+++ b/app/_src/guides/gateway-builtin-kv.md
@@ -1,5 +1,10 @@
 ---
-title: Add a builtin gateway 
+title: Add a builtin gateway
+description: Learn how to configure a builtin gateway using MeshGateway and MeshHTTPRoute to expose services externally with TLS support.
+keywords:
+  - builtin gateway
+  - MeshGateway
+  - ingress
 ---
 
 {% assign kuma = site.mesh_install_archive_name | default: "kuma" %}

--- a/app/_src/guides/gateway-builtin.md
+++ b/app/_src/guides/gateway-builtin.md
@@ -1,5 +1,10 @@
 ---
-title: Add a builtin gateway 
+title: Add a builtin gateway
+description: Learn how to configure a builtin gateway using MeshGateway and MeshHTTPRoute to expose services externally with TLS support.
+keywords:
+  - builtin gateway
+  - MeshGateway
+  - ingress
 ---
 
 To get traffic from outside your mesh inside it (North/South) with {{site.mesh_product_name}} you can use 

--- a/app/_src/guides/gateway-delegated-kv.md
+++ b/app/_src/guides/gateway-delegated-kv.md
@@ -1,5 +1,10 @@
 ---
-title: Use Kong as a delegated Gateway 
+title: Use Kong as a delegated Gateway
+description: Learn how to configure Kong Ingress Controller as a delegated gateway with sidecar injection to handle north-south traffic.
+keywords:
+  - delegated gateway
+  - Kong
+  - ingress controller
 ---
 
 {% assign kuma = site.mesh_install_archive_name | default: "kuma" %}

--- a/app/_src/guides/gateway-delegated.md
+++ b/app/_src/guides/gateway-delegated.md
@@ -1,5 +1,10 @@
 ---
-title: Use Kong as a delegated Gateway 
+title: Use Kong as a delegated Gateway
+description: Learn how to configure Kong Ingress Controller as a delegated gateway with sidecar injection to handle north-south traffic.
+keywords:
+  - delegated gateway
+  - Kong
+  - ingress controller
 ---
 
 To get traffic from outside your mesh inside it (North/South) with {{site.mesh_product_name}} you can use 

--- a/app/_src/guides/meshidentity-guide.md
+++ b/app/_src/guides/meshidentity-guide.md
@@ -1,5 +1,10 @@
 ---
 title: Issuing Identity with MeshIdentity bundled provider
+description: Learn how to issue SPIFFE-compliant identities using MeshIdentity with the bundled provider and configure MeshTrafficPermission with spiffeID matching.
+keywords:
+  - MeshIdentity
+  - SPIFFE
+  - identity management
 ---
 
 {% assign kuma = site.mesh_install_archive_name | default: "kuma" %}


### PR DESCRIPTION
## Motivation

Add SEO/search metadata to guides docs (PR 7 of the frontmatter plan).

## Implementation information

Added `description:` and `keywords:` frontmatter to 11 guides files:
- consumer-producer-policies-kv.md
- consumer-producer-policies.md
- federate-kv.md
- federate.md
- gateway-api-kv.md
- gateway-api.md
- gateway-builtin-kv.md
- gateway-builtin.md
- gateway-delegated-kv.md
- gateway-delegated.md
- meshidentity-guide.md

## Supporting documentation

Part of Phase 2.2 page metadata work.