### PR TITLE
docs(guides): add description and keywords metadata

### DIFF
--- a/app/_src/guides/meshidentity-spire-guide.md
+++ b/app/_src/guides/meshidentity-spire-guide.md
@@ -1,5 +1,10 @@
 ---
 title: Issuing Identity with MeshIdentity Spire provider
+description: Configure MeshIdentity with Spire provider to issue SPIFFE identities and encrypt mesh traffic using mTLS.
+keywords:
+  - MeshIdentity
+  - Spire
+  - mTLS
 ---
 
 {% assign kuma = site.mesh_install_archive_name | default: "kuma" %}

--- a/app/_src/guides/migration-to-the-new-policies.md
+++ b/app/_src/guides/migration-to-the-new-policies.md
@@ -1,5 +1,10 @@
 ---
 title: Migration to the new policies
+description: Migrate from legacy source/destination policies to new targetRef-based policies using shadow mode.
+keywords:
+  - policy migration
+  - targetRef
+  - shadow mode
 ---
 
 {{site.mesh_product_name}} provides two set of policies to configure proxies.

--- a/app/_src/guides/otel-metrics.md
+++ b/app/_src/guides/otel-metrics.md
@@ -1,5 +1,10 @@
 ---
-title: Collect metrics with OpenTelemetry  
+title: Collect metrics with OpenTelemetry
+description: Push data plane proxy metrics to OpenTelemetry collector and visualize them in Grafana dashboards.
+keywords:
+  - OpenTelemetry
+  - metrics
+  - MeshMetric
 ---
 
 {% assign kuma = site.mesh_install_archive_name | default: "kuma" %}

--- a/app/_src/guides/progressively-rolling-in-strict-mtls-kv.md
+++ b/app/_src/guides/progressively-rolling-in-strict-mtls-kv.md
@@ -1,5 +1,10 @@
 ---
 title: Progressively rolling in strict mTLS
+description: Use MeshTLS policy to gradually migrate services to mutual TLS without dropping traffic.
+keywords:
+  - MeshTLS
+  - mTLS
+  - permissive mode
 ---
 
 {% assign kuma = site.mesh_install_archive_name | default: "kuma" %}

--- a/app/_src/guides/progressively-rolling-in-strict-mtls.md
+++ b/app/_src/guides/progressively-rolling-in-strict-mtls.md
@@ -1,5 +1,10 @@
 ---
 title: Progressively rolling in strict mTLS
+description: Use MeshTLS policy to gradually migrate services to mutual TLS without dropping traffic.
+keywords:
+  - MeshTLS
+  - mTLS
+  - permissive mode
 ---
 
 The [MeshTLS](/docs/{{ page.release }}/policies/meshtls/) policy allows you to gradually migrate services to mutual TLS without dropping a packet.

--- a/app/_src/guides/progressively-rolling-out-unified-resource-naming.md
+++ b/app/_src/guides/progressively-rolling-out-unified-resource-naming.md
@@ -1,6 +1,11 @@
 ---
 title: Progressively rolling out unified resource naming
 content_type: tutorial
+description: Enable unified resource naming for predictable Envoy stats that map directly to mesh resources.
+keywords:
+  - unified naming
+  - observability
+  - Envoy stats
 ---
 
 {% capture docs %}/docs/{{ page.release }}{% endcapture %}

--- a/app/_src/guides/restrict-permissions-to-selected-namespaces-on-kubernetes.md
+++ b/app/_src/guides/restrict-permissions-to-selected-namespaces-on-kubernetes.md
@@ -1,6 +1,11 @@
 ---
 title: Restrict permissions to selected namespaces on Kubernetes
 content_type: tutorial
+description: Limit control plane access to specific Kubernetes namespaces for enhanced security.
+keywords:
+  - namespace restrictions
+  - Kubernetes security
+  - RBAC
 ---
 
 {% capture docs %}/docs/{{ page.release }}{% endcapture %}

--- a/app/_src/guides/rules-kv.md
+++ b/app/_src/guides/rules-kv.md
@@ -1,5 +1,10 @@
 ---
 title: Configuring inbound traffic with rules API
+description: Apply policies to data plane inbounds using the rules API with Dataplane targetRef kind.
+keywords:
+  - rules API
+  - inbound traffic
+  - Dataplane targetRef
 ---
 
 {% assign kuma = site.mesh_install_archive_name | default: "kuma" %}

--- a/app/_src/guides/rules.md
+++ b/app/_src/guides/rules.md
@@ -1,5 +1,10 @@
 ---
 title: Configuring inbound traffic with rules API
+description: Apply policies to data plane inbounds using the rules API with Dataplane targetRef kind.
+keywords:
+  - rules API
+  - inbound traffic
+  - Dataplane targetRef
 ---
 
 Using `Rules API` combined with targetRef `Dataplane` kind in {{site.mesh_product_name}} you can easily apply configuration to [data plane](/docs/{{ page.release }}/introduction/concepts/#data-plane)

--- a/app/_src/guides/targeting-meshhttproutes-in-supported-policies.md
+++ b/app/_src/guides/targeting-meshhttproutes-in-supported-policies.md
@@ -1,6 +1,11 @@
 ---
 title: Targeting MeshHTTPRoutes in supported policies
 content_type: tutorial
+description: Apply MeshTimeout, MeshRetry, and MeshAccessLog policies to specific MeshHTTPRoutes for fine-grained traffic control.
+keywords:
+  - MeshHTTPRoute
+  - policy targeting
+  - traffic control
 ---
 
 {% capture docs %}/docs/{{ page.release }}{% endcapture %}

--- a/app/_src/guides/upgrading-transparent-proxy.md
+++ b/app/_src/guides/upgrading-transparent-proxy.md
@@ -1,6 +1,11 @@
 ---
 title: Upgrading Transparent Proxy
 content_type: tutorial
+description: Clean up existing iptables rules and reinstall the transparent proxy on Universal environments.
+keywords:
+  - transparent proxy
+  - iptables
+  - upgrade
 ---
 
 {% capture docs %}/docs/{{ page.release }}{% endcapture %}


### PR DESCRIPTION
## Motivation

Add `description:` and `keywords:` frontmatter to guides pages for SEO/search optimization (PR 8 of metadata plan).

## Implementation information

Added frontmatter to 11 guides files:
- meshidentity-spire-guide.md
- migration-to-the-new-policies.md
- otel-metrics.md
- progressively-rolling-in-strict-mtls-kv.md
- progressively-rolling-in-strict-mtls.md
- progressively-rolling-out-unified-resource-naming.md
- restrict-permissions-to-selected-namespaces-on-kubernetes.md
- rules-kv.md
- rules.md
- targeting-meshhttproutes-in-supported-policies.md
- upgrading-transparent-proxy.md

## Supporting documentation

Part of Phase 2.2 page metadata plan.