### PR TITLE
docs(policies): add description and keywords metadata

### DIFF
--- a/app/_src/policies/applying-policies.md
+++ b/app/_src/policies/applying-policies.md
@@ -1,5 +1,10 @@
 ---
 title: Applying Policies
+description: Learn how to apply policies in your service mesh using kumactl and kubectl, including multi-zone deployments and shadow mode testing.
+keywords:
+  - policy application
+  - kumactl
+  - shadow mode
 ---
 
 Once installed, {{site.mesh_product_name}} can be configured via its policies. 

--- a/app/_src/policies/general-notes-about-kuma-policies.md
+++ b/app/_src/policies/general-notes-about-kuma-policies.md
@@ -1,5 +1,10 @@
 ---
 title: General notes about Kuma policies
+description: Understand the structure of source/destination policies including sources, destinations, and configuration matching with tags.
+keywords:
+  - legacy policies
+  - source destination
+  - policy structure
 ---
 {% if_version gte:2.6.x %}
 {% warning %}

--- a/app/_src/policies/how-kuma-chooses-the-right-policy-to-apply.md
+++ b/app/_src/policies/how-kuma-chooses-the-right-policy-to-apply.md
@@ -1,5 +1,10 @@
 ---
 title: How Kuma chooses the right policy to apply
+description: Learn how the service mesh selects the most specific policy when multiple policies match, including tag matching and priority rules.
+keywords:
+  - policy selection
+  - policy matching
+  - policy priority
 ---
 
 {% if_version gte:2.6.x %}

--- a/app/_src/policies/index.md
+++ b/app/_src/policies/index.md
@@ -1,6 +1,11 @@
 ---
 title: Policies Overview
 content_type: explanation
+description: Overview of service mesh policies for security, routing, resilience, and observability configuration.
+keywords:
+  - policies overview
+  - service mesh policies
+  - traffic management
 ---
 
 [Policies](/docs/{{ page.release }}/introduction/concepts#policy) in {{site.mesh_product_name}} define how [data plane proxies](/docs/{{ page.release }}/introduction/concepts#data-plane-proxy--sidecar) behave and how traffic flows through your [mesh](/docs/{{ page.release }}/introduction/concepts#mesh). They provide a declarative way to configure security, routing, observability, and resilience features.

--- a/app/_src/policies/introduction.md
+++ b/app/_src/policies/introduction.md
@@ -1,5 +1,10 @@
 ---
 title: Policies
+description: Learn how to write and configure targetRef policies, including metadata, spec structure, merging, and MeshService targeting.
+keywords:
+  - targetRef policies
+  - policy configuration
+  - policy merging
 ---
 {% if_version gte:2.9.x %}
 ## What is a policy?

--- a/app/_src/policies/meshaccesslog.md
+++ b/app/_src/policies/meshaccesslog.md
@@ -1,5 +1,10 @@
 ---
 title: MeshAccessLog
+description: Configure access logging for your service mesh with support for TCP, file, and OpenTelemetry backends using customizable formats.
+keywords:
+  - access logs
+  - observability
+  - logging
 ---
 
 With the MeshAccessLog policy you can easily set up access logs on every data plane proxy in a mesh.

--- a/app/_src/policies/meshcircuitbreaker.md
+++ b/app/_src/policies/meshcircuitbreaker.md
@@ -1,5 +1,10 @@
 ---
 title: MeshCircuitBreaker
+description: Configure circuit breakers to prevent cascading failures with connection limits and outlier detection for unhealthy services.
+keywords:
+  - circuit breaker
+  - outlier detection
+  - resilience
 ---
 
 {% warning %}

--- a/app/_src/policies/meshfaultinjection.md
+++ b/app/_src/policies/meshfaultinjection.md
@@ -1,5 +1,10 @@
 ---
 title: MeshFaultInjection
+description: Test microservice resilience by injecting HTTP errors, response delays, and bandwidth limits into service traffic.
+keywords:
+  - fault injection
+  - chaos testing
+  - resilience testing
 ---
 
 With the MeshFaultInjection policy you can easily test your microservices against resiliency.

--- a/app/_src/policies/meshfaultinjection_experimental.md
+++ b/app/_src/policies/meshfaultinjection_experimental.md
@@ -1,5 +1,10 @@
 ---
 title: MeshFaultInjection
+description: Test microservice resilience by injecting HTTP errors, delays, and bandwidth limits with client-specific fault targeting.
+keywords:
+  - fault injection
+  - chaos testing
+  - resilience testing
 ---
 
 {% tip %}

--- a/app/_src/policies/meshgateway.md
+++ b/app/_src/policies/meshgateway.md
@@ -1,5 +1,10 @@
 ---
 title: MeshGateway
+description: Configure builtin gateway listeners for network ports, protocols, hostnames, and TLS termination with server certificates.
+keywords:
+  - gateway
+  - ingress
+  - TLS termination
 ---
 
 `MeshGateway` is a policy used to configure {% if_version gte:2.6.x %}[{{site.mesh_product_name}}'s builtin gateway](/docs/{{ page.release }}/using-mesh/managing-ingress-traffic/builtin){% endif_version %}{% if_version lte:2.5.x %}[{{site.mesh_product_name}}'s builtin gateway](/docs/{{ page.release }}/explore/gateway#builtin){% endif_version %}.


### PR DESCRIPTION
## Motivation

Add SEO-friendly `description` and `keywords` frontmatter to policies docs for better search indexing.

## Implementation information

Added metadata to 10 policies files:
- applying-policies.md
- general-notes-about-kuma-policies.md
- how-kuma-chooses-the-right-policy-to-apply.md
- index.md
- introduction.md
- meshaccesslog.md
- meshcircuitbreaker.md
- meshfaultinjection_experimental.md
- meshfaultinjection.md
- meshgateway.md

## Supporting documentation

Part of Phase 2.2: Page Metadata initiative.