### PR TITLE
docs(policies): add description and keywords metadata (PR 10)

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -30,6 +30,7 @@ boolean
 camelCase
 CloudFormation
 CLI
+CIDRs?
 CNI|cni
 Cognito
 configs?
@@ -62,6 +63,7 @@ endunless
 endwarning
 enum
 etcd
+failover
 Fargate
 firewalld
 frontmatter
@@ -71,7 +73,7 @@ GitHub
 GKE|gke
 Goroutine
 Grafana
-grpcs?
+g[Rr][Pp][Cc]s?
 hardcod(?:ing|ed)
 hostnames?
 httpbin

--- a/app/_src/policies/meshgatewayinstance.md
+++ b/app/_src/policies/meshgatewayinstance.md
@@ -1,5 +1,10 @@
 ---
 title: MeshGatewayInstance
+description: Deploy and manage builtin gateway instances on Kubernetes with MeshGatewayInstance, including service and pod customization.
+keywords:
+  - gateway deployment
+  - builtin gateway
+  - Kubernetes gateway
 ---
 
 `MeshGatewayInstance` is a Kubernetes-only resource for deploying {% if_version gte:2.6.x %}[{{site.mesh_product_name}}'s builtin gateway](/docs/{{ page.release }}/using-mesh/managing-ingress-traffic/builtin){% endif_version %}{% if_version lte:2.5.x %}[{{site.mesh_product_name}}'s builtin gateway](/docs/{{ page.release }}/explore/gateway#builtin){% endif_version %}.

--- a/app/_src/policies/meshgatewayroute.md
+++ b/app/_src/policies/meshgatewayroute.md
@@ -1,5 +1,10 @@
 ---
 title: MeshGatewayRoute
+description: Configure HTTP routing for builtin gateways using MeshGatewayRoute, including path matching, filters, and traffic routing rules.
+keywords:
+  - gateway routing
+  - HTTP routing
+  - traffic management
 ---
 {% if_version gte:2.6.x %}
 {% warning %}

--- a/app/_src/policies/meshhealthcheck.md
+++ b/app/_src/policies/meshhealthcheck.md
@@ -1,5 +1,10 @@
 ---
 title: Mesh Health Check
+description: Configure active health checks for data plane proxies using MeshHealthCheck, supporting HTTP, TCP, and gRPC protocols.
+keywords:
+  - health check
+  - active health check
+  - service health
 ---
 
 {% warning %}

--- a/app/_src/policies/meshhttproute.md
+++ b/app/_src/policies/meshhttproute.md
@@ -1,5 +1,10 @@
 ---
 title: Mesh HTTP Route
+description: Route and modify HTTP traffic with MeshHTTPRoute, enabling traffic splitting, header modifications, mirroring, and redirects.
+keywords:
+  - HTTP routing
+  - traffic splitting
+  - request modification
 ---
 
 {% warning %}

--- a/app/_src/policies/meshidentity.md
+++ b/app/_src/policies/meshidentity.md
@@ -1,5 +1,10 @@
 ---
 title: MeshIdentity
+description: Define how workloads obtain cryptographic identity with MeshIdentity, supporting SPIFFE IDs and multiple certificate providers.
+keywords:
+  - workload identity
+  - SPIFFE
+  - certificate management
 ---
 
 {% warning %}

--- a/app/_src/policies/meshloadbalancingstrategy.md
+++ b/app/_src/policies/meshloadbalancingstrategy.md
@@ -1,5 +1,10 @@
 ---
 title: MeshLoadBalancingStrategy
+description: Configure load balancing between services with MeshLoadBalancingStrategy, including locality awareness and cross-zone failover.
+keywords:
+  - load balancing
+  - locality awareness
+  - traffic distribution
 ---
 
 {% warning %}

--- a/app/_src/policies/meshmetric.md
+++ b/app/_src/policies/meshmetric.md
@@ -1,5 +1,10 @@
 ---
 title: MeshMetric
+description: Configure metrics collection and exposure with MeshMetric, supporting Prometheus and OpenTelemetry backends with filtering options.
+keywords:
+  - metrics
+  - Prometheus
+  - OpenTelemetry
 ---
 
 {% warning %}

--- a/app/_src/policies/meshpassthrough.md
+++ b/app/_src/policies/meshpassthrough.md
@@ -1,5 +1,10 @@
 ---
 title: MeshPassthrough
+description: Control traffic to external destinations with MeshPassthrough, allowing specific domains, IPs, or CIDRs to bypass mesh routing.
+keywords:
+  - passthrough
+  - external traffic
+  - non-mesh traffic
 ---
 
 {% warning %}

--- a/app/_src/policies/meshproxypatch.md
+++ b/app/_src/policies/meshproxypatch.md
@@ -1,5 +1,10 @@
 ---
 title: MeshProxyPatch
+description: Customize low-level Envoy configuration with MeshProxyPatch, modifying listeners, clusters, filters, and virtual hosts.
+keywords:
+  - Envoy configuration
+  - proxy customization
+  - advanced configuration
 ---
 
 The `MeshProxyPatch` provides configuration options for [low-level Envoy resources](https://www.envoyproxy.io/docs/envoy/latest/api-v3/api) that {{site.mesh_product_name}} policies do not directly expose.

--- a/app/_src/policies/meshratelimit.md
+++ b/app/_src/policies/meshratelimit.md
@@ -1,5 +1,10 @@
 ---
 title: MeshRateLimit
+description: Configure per-instance rate limiting with MeshRateLimit, controlling HTTP request rates and TCP connection limits.
+keywords:
+  - rate limiting
+  - traffic control
+  - request throttling
 ---
 
 {% warning %}


### PR DESCRIPTION
## Motivation

Add `description:` and `keywords:` frontmatter to policy docs for SEO/search optimization (Phase 2.2, PR 10).

## Implementation information

Added metadata to 10 policy files:
- meshgatewayinstance.md
- meshgatewayroute.md
- meshhealthcheck.md
- meshhttproute.md
- meshidentity.md
- meshloadbalancingstrategy.md
- meshmetric.md
- meshpassthrough.md
- meshproxypatch.md
- meshratelimit.md

## Supporting documentation

Part of Phase 2.2: Page Metadata plan