### PR TITLE
docs(production): add description and keywords metadata

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -167,6 +167,7 @@ subgraph
 subproject
 sudo
 Syslog
+systemd
 target[Rr]ef
 tbl
 tcpdump

--- a/app/_src/production/cp-deployment/kubernetes.md
+++ b/app/_src/production/cp-deployment/kubernetes.md
@@ -1,6 +1,11 @@
 ---
 title: Kubernetes
 content_type: how-to
+description: Learn about Kubernetes-specific deployment configurations for the control plane, including Helm charts, Argo CD integration, and platform-specific notes.
+keywords:
+  - kubernetes
+  - helm
+  - argo
 ---
 
 You can find instructions to install on kubernetes for {% if_version gte:2.6.x %}[single-zone](/docs/{{ page.release }}/production/cp-deployment/single-zone){% endif_version %}{% if_version lte:2.5.x %}[standalone](/docs/{{ page.release }}/production/cp-deployment/stand-alone){% endif_version %} or [multi-zone](/docs/{{ page.release }}/production/cp-deployment/multi-zone).

--- a/app/_src/production/cp-deployment/multi-zone.md
+++ b/app/_src/production/cp-deployment/multi-zone.md
@@ -1,6 +1,11 @@
 ---
 title: Deploy a multi-zone global control plane
 content_type: how-to
+description: Set up a multi-zone deployment with global and zone control planes to run your service mesh across multiple clusters, regions, or environments.
+keywords:
+  - multi-zone
+  - global control plane
+  - zone
 ---
 
 ## Prerequisites

--- a/app/_src/production/cp-deployment/single-zone.md
+++ b/app/_src/production/cp-deployment/single-zone.md
@@ -1,6 +1,11 @@
 ---
 title: Deploy a single-zone control plane
 content_type: how-to
+description: Deploy a single-zone control plane for running your service mesh in a single cluster or environment.
+keywords:
+  - single-zone
+  - deployment
+  - control plane
 ---
 
 In order to deploy {{site.mesh_product_name}} in a single-zone deployment, the `kuma-cp` control plane must be started in `zone` mode:

--- a/app/_src/production/cp-deployment/stand-alone.md
+++ b/app/_src/production/cp-deployment/stand-alone.md
@@ -1,6 +1,11 @@
 ---
 title: Deploy a standalone control plane
 content_type: how-to
+description: Deploy a standalone control plane for simple service mesh deployments in a single cluster or environment.
+keywords:
+  - standalone
+  - deployment
+  - control plane
 ---
 
 In order to deploy {{site.mesh_product_name}} in a standalone deployment, the `kuma-cp` control plane must be started in `standalone` mode:

--- a/app/_src/production/cp-deployment/systemd.md
+++ b/app/_src/production/cp-deployment/systemd.md
@@ -1,6 +1,11 @@
 ---
 title: Systemd
 content_type: how-to
+description: Configure systemd unit files to manage the control plane and data plane proxy processes on VMs.
+keywords:
+  - systemd
+  - universal
+  - VMs
 ---
 
 It's recommended to use a process manager like systemd when using {{ site.mesh_product_name }} on VMs. 

--- a/app/_src/production/cp-deployment/zone-ingress.md
+++ b/app/_src/production/cp-deployment/zone-ingress.md
@@ -1,6 +1,11 @@
 ---
 title: Zone Ingress
 content_type: how-to
+description: Configure ZoneIngress proxies to enable cross-zone communication in multi-zone deployments.
+keywords:
+  - ZoneIngress
+  - multi-zone
+  - cross-zone
 ---
 
 To implement cross-zone communication when {{site.mesh_product_name}} is deployed in a [multi-zone](/docs/{{ page.release }}/production/deployment/multi-zone/) mode, there is a new proxy type `ZoneIngress`.

--- a/app/_src/production/cp-deployment/zoneegress.md
+++ b/app/_src/production/cp-deployment/zoneegress.md
@@ -1,6 +1,11 @@
 ---
 title: Zone Egress
 content_type: how-to
+description: Configure ZoneEgress proxies to isolate outgoing traffic to other zones or external services.
+keywords:
+  - ZoneEgress
+  - external services
+  - traffic
 ---
 
 `ZoneEgress` proxy is used when it is required to isolate outgoing traffic (to services in other

--- a/app/_src/production/cp-deployment/zoneproxy-auth.md
+++ b/app/_src/production/cp-deployment/zoneproxy-auth.md
@@ -1,6 +1,11 @@
 ---
 title: Configure zone proxy authentication
 content_type: how-to
+description: Configure authentication for zone proxies using service account tokens or zone tokens for secure control plane communication.
+keywords:
+  - authentication
+  - zone token
+  - security
 ---
 
 To obtain a configuration from the control plane, a zone proxy (zone ingress / zone egress) must

--- a/app/_src/production/deployment/high-availability.md
+++ b/app/_src/production/deployment/high-availability.md
@@ -1,6 +1,11 @@
 ---
 title: High availability
 content_type: explanation
+description: Deploy multiple control plane replicas to ensure high availability and fault tolerance for your service mesh.
+keywords:
+  - high availability
+  - replicas
+  - leader
 ---
 
 In order to ensure high availability (HA) of a control plane, both global and zone,

--- a/app/_src/production/deployment/index.md
+++ b/app/_src/production/deployment/index.md
@@ -1,6 +1,11 @@
 ---
 title: Deployment topologies overview
 content_type: explanation
+description: Overview of deployment topologies including single-zone and multi-zone deployments for various service mesh use cases.
+keywords:
+  - deployment
+  - topology
+  - architecture
 ---
 
 The deployment modes that {{site.mesh_product_name}} provides are quite unique in the Service Mesh landscape and have been developed thanks to the guidance of our enterprise users, especially when it comes to the distributed one.

--- a/app/_src/production/deployment/multi-zone.md
+++ b/app/_src/production/deployment/multi-zone.md
@@ -1,6 +1,11 @@
 ---
 title: Multi-zone deployment
 content_type: explanation
+description: Understand multi-zone deployment architecture, components, and failure modes for distributed service mesh environments.
+keywords:
+  - multi-zone
+  - architecture
+  - zones
 ---
 
 ## About

--- a/app/_src/production/deployment/networking.md
+++ b/app/_src/production/deployment/networking.md
@@ -1,6 +1,11 @@
 ---
 title: Default ports
 content_type: reference
+description: Reference of default ports used by control planes and data plane proxies for various deployment modes.
+keywords:
+  - ports
+  - networking
+  - reference
 ---
 
 {{site.mesh_product_name}} - being an application that wants to improve the underlying connectivity between your services by making the underlying network more reliable - also comes with some networking requirements itself.


### PR DESCRIPTION
## Motivation

Add SEO metadata (description and keywords) to production docs for better search indexing.

## Implementation information

Add `description:` and `keywords:` frontmatter to 12 production/ docs:
- cp-deployment: kubernetes, multi-zone, single-zone, stand-alone, systemd, zone-ingress, zoneegress, zoneproxy-auth
- deployment: high-availability, index, multi-zone, networking

## Supporting documentation

Part of Phase 2.2: Page Metadata (PR 12 of 14)