### PR TITLE
docs(production): add description and keywords metadata

### DIFF
--- a/app/_src/production/deployment/single-zone.md
+++ b/app/_src/production/deployment/single-zone.md
@@ -1,5 +1,10 @@
 ---
 title: Single-zone deployment
+description: Deploy the service mesh in a single Kubernetes cluster or data center with all proxies connecting to one control plane.
+keywords:
+  - single-zone
+  - deployment topology
+  - control plane
 content_type: explanation
 ---
 

--- a/app/_src/production/deployment/stand-alone.md
+++ b/app/_src/production/deployment/stand-alone.md
@@ -1,5 +1,10 @@
 ---
 title: Standalone deployment
+description: Deploy the service mesh in standalone mode where all data plane proxies connect directly to a single control plane.
+keywords:
+  - standalone
+  - deployment topology
+  - control plane
 content_type: explanation
 ---
 

--- a/app/_src/production/dp-config/cni.md
+++ b/app/_src/production/dp-config/cni.md
@@ -1,5 +1,10 @@
 ---
 title: Configure the Kuma CNI
+description: Install and configure the CNI plugin to set up transparent proxying without requiring elevated privileges on application pods.
+keywords:
+  - CNI
+  - transparent proxying
+  - Kubernetes
 content_type: how-to
 ---
 

--- a/app/_src/production/dp-config/dpp-on-kubernetes.md
+++ b/app/_src/production/dp-config/dpp-on-kubernetes.md
@@ -1,5 +1,10 @@
 ---
 title: Data plane on Kubernetes
+description: Configure data plane proxies on Kubernetes with automatic sidecar injection, tag generation, and custom container settings.
+keywords:
+  - sidecar injection
+  - Kubernetes
+  - data plane proxy
 content_type: how-to
 ---
 

--- a/app/_src/production/dp-config/dpp-on-universal.md
+++ b/app/_src/production/dp-config/dpp-on-universal.md
@@ -1,5 +1,10 @@
 ---
 title: Data plane on Universal
+description: Configure data plane proxies on VMs or bare metal with manual Dataplane resource definitions and lifecycle management.
+keywords:
+  - Universal
+  - data plane proxy
+  - VM
 content_type: how-to
 ---
 

--- a/app/_src/production/dp-config/dpp.md
+++ b/app/_src/production/dp-config/dpp.md
@@ -1,5 +1,10 @@
 ---
 title: Data plane proxy
+description: Understand data plane proxy components, Dataplane entities, inbounds, outbounds, tags, and how proxies receive configuration.
+keywords:
+  - data plane proxy
+  - sidecar
+  - Envoy
 content_type: explanation
 ---
 

--- a/app/_src/production/dp-config/ipv6.md
+++ b/app/_src/production/dp-config/ipv6.md
@@ -1,5 +1,10 @@
 ---
 title: IPv6 support
+description: Configure the service mesh to run in IPv6-only or dual-stack environments, including how to disable IPv6 when needed.
+keywords:
+  - IPv6
+  - networking
+  - dual-stack
 content_type: how-to
 ---
 

--- a/app/_src/production/dp-config/transparent-proxying.md
+++ b/app/_src/production/dp-config/transparent-proxying.md
@@ -1,5 +1,10 @@
 ---
 title: Configure transparent proxying
+description: Set up iptables-based transparent proxying to automatically intercept traffic without application code changes.
+keywords:
+  - transparent proxying
+  - iptables
+  - traffic interception
 content_type: how-to
 ---
 

--- a/app/_src/production/gui.md
+++ b/app/_src/production/gui.md
@@ -1,5 +1,10 @@
 ---
 title: Kuma user interface (GUI)
+description: Use the web-based GUI to visualize meshes, data plane proxies, services, and traffic policies.
+keywords:
+  - GUI
+  - dashboard
+  - visualization
 content_type: explanation
 ---
 

--- a/app/_src/production/index.md
+++ b/app/_src/production/index.md
@@ -1,5 +1,10 @@
 ---
 title: Kuma in Production
+description: Deploy, configure, and operate the service mesh in production with guidance on topologies, security, and maintenance.
+keywords:
+  - production
+  - deployment
+  - operations
 content_type: explanation
 ---
 

--- a/app/_src/production/install-kumactl.md
+++ b/app/_src/production/install-kumactl.md
@@ -1,5 +1,10 @@
 ---
 title: Install kumactl
+description: Download and install the kumactl CLI tool to manage resources and interact with the control plane HTTP API.
+keywords:
+  - kumactl
+  - CLI
+  - installation
 content_type: how-to
 ---
 

--- a/app/_src/production/mesh.md
+++ b/app/_src/production/mesh.md
@@ -1,5 +1,10 @@
 ---
 title: Configuring your Mesh and multi-tenancy
+description: Create and configure Mesh resources to isolate services, enable mTLS, and support multi-tenancy across teams.
+keywords:
+  - Mesh
+  - multi-tenancy
+  - isolation
 content_type: how-to
 ---
 


### PR DESCRIPTION
## Motivation

Add SEO metadata to production docs pages per Phase 2.2 plan.

## Implementation information

Added `description:` and `keywords:` frontmatter to 12 production files:
- deployment/single-zone.md
- deployment/stand-alone.md
- dp-config/cni.md
- dp-config/dpp-on-kubernetes.md
- dp-config/dpp-on-universal.md
- dp-config/dpp.md
- dp-config/ipv6.md
- dp-config/transparent-proxying.md
- gui.md
- index.md
- install-kumactl.md
- mesh.md

## Supporting documentation

Part of page metadata rollout (PR 13 of 14).