### PR TITLE
docs(production): add description and keywords metadata (PR 14)

### DIFF
--- a/app/_src/production/secure-deployment/api-access-control.md
+++ b/app/_src/production/secure-deployment/api-access-control.md
@@ -1,5 +1,10 @@
 ---
 title: Kuma API access control
+description: Configure access control for administrative actions on the API server, including managing secrets, generating tokens, and viewing Envoy configuration.
+keywords:
+  - API access control
+  - token generation
+  - admin resources
 content_type: reference
 ---
 

--- a/app/_src/production/secure-deployment/api-server-auth.md
+++ b/app/_src/production/secure-deployment/api-server-auth.md
@@ -1,5 +1,10 @@
 ---
 title: Authentication with the API server
+description: Authenticate users and automation tools to the control plane API server using user tokens, including token generation, rotation, and revocation.
+keywords:
+  - API authentication
+  - user tokens
+  - signing keys
 content_type: how-to
 ---
 

--- a/app/_src/production/secure-deployment/certificates.md
+++ b/app/_src/production/secure-deployment/certificates.md
@@ -1,5 +1,10 @@
 ---
 title: Secure access across services
+description: Configure TLS encryption and authentication for communication between data plane proxies, users, and control planes in single-zone and multizone deployments.
+keywords:
+  - TLS certificates
+  - secure communication
+  - control plane security
 content_type: how-to
 ---
 

--- a/app/_src/production/secure-deployment/dp-auth.md
+++ b/app/_src/production/secure-deployment/dp-auth.md
@@ -1,5 +1,10 @@
 ---
 title: Authentication with the data plane proxy
+description: Authenticate data plane proxies with the control plane using service account tokens on Kubernetes or data plane proxy tokens on Universal deployments.
+keywords:
+  - data plane authentication
+  - proxy tokens
+  - service account
 content_type: reference
 ---
 

--- a/app/_src/production/secure-deployment/dp-membership.md
+++ b/app/_src/production/secure-deployment/dp-membership.md
@@ -1,5 +1,10 @@
 ---
 title: Configure data plane proxy membership
+description: Define requirements and restrictions for data plane proxies joining a mesh using membership constraints based on tags, namespaces, or zones.
+keywords:
+  - mesh membership
+  - proxy constraints
+  - access control
 content_type: how-to
 ---
 

--- a/app/_src/production/secure-deployment/manage-control-plane-permissions-on-kubernetes.md
+++ b/app/_src/production/secure-deployment/manage-control-plane-permissions-on-kubernetes.md
@@ -1,5 +1,10 @@
 ---
 title: Manage control plane permissions on Kubernetes
+description: Restrict control plane access to specific namespaces and manually manage RBAC resources for enhanced security in production Kubernetes environments.
+keywords:
+  - Kubernetes RBAC
+  - namespace permissions
+  - control plane security
 content_type: how-to
 ---
 

--- a/app/_src/production/secure-deployment/secrets.md
+++ b/app/_src/production/secure-deployment/secrets.md
@@ -1,5 +1,10 @@
 ---
 title: Manage secrets
+description: Store and manage sensitive data like TLS keys, tokens, and passwords using mesh-scoped and global-scoped secrets in Kubernetes and Universal deployments.
+keywords:
+  - secrets management
+  - sensitive data
+  - TLS keys
 content_type: how-to
 ---
 

--- a/app/_src/production/upgrades-tuning/fine-tuning.md
+++ b/app/_src/production/upgrades-tuning/fine-tuning.md
@@ -1,5 +1,10 @@
 ---
 title: Performance fine-tuning
+description: Optimize control plane and data plane proxy performance using reachable services, config trimming, Postgres tuning, Envoy concurrency, and profiling.
+keywords:
+  - performance tuning
+  - reachable services
+  - Envoy optimization
 content_type: reference
 ---
 

--- a/app/_src/production/upgrades-tuning/upgrade-notes.md
+++ b/app/_src/production/upgrades-tuning/upgrade-notes.md
@@ -1,5 +1,10 @@
 ---
 title: Version specific upgrade notes
+description: Review breaking changes, migration steps, and important considerations for each version when upgrading your deployment.
+keywords:
+  - upgrade notes
+  - breaking changes
+  - migration guide
 content_type: reference
 ---
 

--- a/app/_src/production/upgrades-tuning/upgrades.md
+++ b/app/_src/production/upgrades-tuning/upgrades.md
@@ -1,5 +1,10 @@
 ---
 title: Upgrade Kuma
+description: Upgrade control planes and data plane proxies following the supported version compatibility rules for single-zone and multizone deployments.
+keywords:
+  - upgrade guide
+  - version compatibility
+  - control plane upgrade
 content_type: reference
 ---
 

--- a/app/_src/production/use-mesh.md
+++ b/app/_src/production/use-mesh.md
@@ -1,5 +1,10 @@
 ---
 title: Use Kuma
+description: Access and interact with the control plane using the GUI, HTTP API, kumactl CLI, or kubectl, and understand the ports exposed by each control plane mode.
+keywords:
+  - control plane access
+  - kumactl
+  - HTTP API
 ---
 
 After {{site.mesh_product_name}} is installed, you can access the control plane via the following methods:


### PR DESCRIPTION
## Motivation

Add `description:` and `keywords:` frontmatter metadata to production docs for SEO and search indexing (Phase 2.2, PR 14 of 14).

## Implementation information

Added metadata to 11 files in production/:
- secure-deployment/: api-access-control, api-server-auth, certificates, dp-auth, dp-membership, manage-control-plane-permissions-on-kubernetes, secrets
- upgrades-tuning/: fine-tuning, upgrade-notes, upgrades
- use-mesh

## Supporting documentation

Part of Phase 2.2 page metadata initiative per `frontmatter_plan.md`.