### PR TITLE
feat: add shellcheck for tools scripts

### DIFF
--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -1,4 +1,4 @@
-name: Test tools
+name: Lint and test tools
 on:
   push:
     branches: [master]
@@ -6,13 +6,15 @@ on:
   pull_request:
     paths: [tools/**]
 jobs:
-  test-tools:
-    name: Test tool scripts
+  lint-and-test-tools:
+    name: Lint and test tool scripts
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: jdx/mise-action@be3be2260bc02bc3fbf94c5e2fed8b7964baf074 # v3.4.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - name: Shellcheck
+        run: mise shellcheck
       - name: Run tool tests
         run: mise test:tools

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,7 @@ ruby = "3.4.7"
 node = "24.11.1"
 yarn = "1.22.22"
 vale = "3.13.0"
+shellcheck = "0.10.0"
 "go:github.com/raviqqe/muffet/v2" = "v2.11.0"
 
 [tasks.install]
@@ -113,6 +114,10 @@ run = "tools/validate-frontmatter.sh"
 [tasks."test:tools"]
 description = "Run all tool tests (tools/test-*.sh)"
 run = "for f in tools/test-*.sh; do [ -x \"$f\" ] && \"$f\"; done"
+
+[tasks.shellcheck]
+description = "Run shellcheck on tools/*.sh"
+run = "shellcheck tools/*.sh"
 
 [tasks.check]
 description = "Run necessary checks"


### PR DESCRIPTION
## Motivation

Add linting for shell scripts in tools/ to catch common issues early.

## Implementation information

- Added shellcheck 0.10.0 to mise tools
- Added `mise shellcheck` task to run shellcheck on tools/*.sh
- Added shellcheck step to test-tools.yml CI workflow
- Renamed workflow from "Test tools" to "Lint and test tools"

## Supporting documentation

N/A