### PR TITLE
fix(docs): fix dp auth file liquid warnings

### DIFF
--- a/app/_src/production/secure-deployment/dp-auth.md
+++ b/app/_src/production/secure-deployment/dp-auth.md
@@ -104,7 +104,7 @@ When a token includes a workload value, the data plane proxy must have a matchin
 
 If a data plane proxy connects with a workload token, it must have the `kuma.io/workload` label with a value matching the token. Connection attempts without the matching label will be rejected.
 
-Additionally, if a [MeshIdentity](/docs/{{ page.release }}/policies/meshidentity/) resource references the `kuma.io/workload` label in its SPIFFE ID path template (for example, `/workload/{{ label "kuma.io/workload" }}`), then:
+Additionally, if a [MeshIdentity](/docs/{{ page.release }}/policies/meshidentity/) resource references the `kuma.io/workload` label in its SPIFFE ID path template (for example, `/workload/{% raw %}{{ label "kuma.io/workload" }}{% endraw %}`), then:
 
 - The data plane proxy must have the `kuma.io/workload` label
 - The label can be provided either via the token or on the data plane proxy resource
@@ -387,10 +387,10 @@ When using workload labels in tokens or MeshIdentity resources, you may encounte
 #### Missing required workload label
 
 ```text
-missing required label 'kuma.io/workload' - dataplane is selected by MeshIdentity 'backend-identity' with path template '/workload/{{ label "kuma.io/workload" }}'
+missing required label 'kuma.io/workload' - dataplane is selected by MeshIdentity 'backend-identity' with path template '/workload/{% raw %}{{ label "kuma.io/workload" }}{% endraw %}'
 ```
 
-Cause: A [MeshIdentity](/docs/{{ page.release }}/policies/meshidentity/) resource uses `{{ label "kuma.io/workload" }}` in its SPIFFE ID path template, but the connecting data plane proxy lacks the `kuma.io/workload` label.
+Cause: A [MeshIdentity](/docs/{{ page.release }}/policies/meshidentity/) resource uses `{% raw %}{{ label "kuma.io/workload" }}{% endraw %}` in its SPIFFE ID path template, but the connecting data plane proxy lacks the `kuma.io/workload` label.
 
 Solution: Add the `kuma.io/workload` label to your data plane proxy. You can do this by:
 


### PR DESCRIPTION
## Motivation

Fix Liquid syntax warnings during Jekyll build for {{ label "..." }} expressions in dp-auth.md

## Implementation information

Wrapped {{ label "kuma.io/workload" }} occurrences with {% raw %}...{% endraw %} tags to prevent Jekyll from parsing them as Liquid template expressions

## Supporting documentation

Fixes warnings:

```
Liquid Warning: Liquid syntax error (line 97): Expected end_of_string but found string in "{{ label "kuma.io/workload" }}"
```