### PR TITLE
refactor(plugins): extract jsonschema.rb functions into module

### DIFF
--- a/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/common/path_helpers.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/common/path_helpers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module KumaPlugins
+    module Common
+      module PathHelpers
+        PATHS_CONFIG = 'mesh_raw_generated_paths'
+        DEFAULT_PATHS = ['app/assets'].freeze
+
+        def read_file(paths, file_name)
+          paths.each do |path|
+            file_path = File.join(path, file_name)
+            return File.open(file_path) if File.readable? file_path
+          end
+          raise "couldn't read #{file_name} in any of these paths: #{paths}"
+        end
+      end
+    end
+  end
+end

--- a/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/embed.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/embed.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require_relative '../../common/path_helpers'
+
 module Jekyll
   module KumaPlugins
     module Liquid
       module Tags
         class Embed < ::Liquid::Tag
+          include Jekyll::KumaPlugins::Common::PathHelpers
+
           def initialize(tag_name, markup, options)
             super
             params = {}

--- a/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/jsonschema.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/jsonschema.rb
@@ -2,14 +2,14 @@
 
 require 'json'
 require 'yaml'
+require_relative '../../common/path_helpers'
 
 module Jekyll
   module KumaPlugins
     module Liquid
       module Tags
         class JsonSchema < ::Liquid::Tag
-          PATHS_CONFIG = 'mesh_raw_generated_paths'
-          DEFAULT_PATHS = ['app/assets'].freeze
+          include Jekyll::KumaPlugins::Common::PathHelpers
 
           def initialize(tag_name, markup, options)
             super
@@ -69,14 +69,6 @@ module Jekyll
           end
 
           private
-
-          def read_file(paths, file_name)
-            paths.each do |path|
-              file_path = File.join(path, file_name)
-              return File.open(file_path) if File.readable? file_path
-            end
-            raise "couldn't read #{file_name} in none of these paths:#{paths}"
-          end
 
           def create_loader(type, name)
             case type


### PR DESCRIPTION
## Motivation

Technical debt cleanup - move global functions and constants into JsonSchema class namespace per rubocop-plan.md PR 2.

## Implementation information

- Move `PATHS_CONFIG`, `DEFAULT_PATHS` into class constants
- Move `read_file`, `create_loader` into class as private methods
- Extract loader lambdas into separate methods: `proto_loader`, `crd_loader`, `policy_loader`
- Changed `YAML.load` to `YAML.safe_load` for security
- Added `.read` call to File handles returned by `read_file`

## Supporting documentation

Part of rubocop refactoring plan (PR 2 of 8)