### PR TITLE
refactor(plugins): extract methods in cpinstall, cpinstallfile, embed

### DIFF
--- a/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/cpinstall.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/cpinstall.rb
@@ -20,44 +20,52 @@ module Jekyll
             @prefixed = params['prefixed'].downcase == 'true'
           end
 
-          # TODO: refactor to reduce complexity
           def render(context)
             content = super
             return '' if content.empty?
 
             site_data = context.registers[:site].config
             page = context.environments.first['page']
-
-            opts = content.strip.split("\n").map do |x|
-              x = site_data['set_flag_values_prefix'] + x if @prefixed
-              "--set \"#{x}\""
-            end
-            res = opts.join(" \\\n  ")
-
-            html_content = "
-{% tabs codeblock %}
-{% tab kumactl %}
-```shell
-kumactl install control-plane \\
-  #{res} \\
-  | kubectl apply -f -
-```
-{:.no-line-numbers}
-{% endtab %}
-{% tab Helm %}
-```shell
-# Before installing {{ site.mesh_product_name }} with Helm, configure your local Helm repository:
-# {{ site.links.web }}/#{product_url_segment(page)}/{{ page.release }}/production/cp-deployment/kubernetes/#helm
-helm install \\
-  --create-namespace \\
-  --namespace {{ site.mesh_namespace }} \\
-  #{res} \\
-  {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }}
-```
-{:.no-line-numbers}
-{% endtab %}
-{% endtabs %}"
+            helm_flags = process_helm_flags(content, site_data)
+            html_content = generate_install_tabs(helm_flags, page)
             ::Liquid::Template.parse(html_content).render(context)
+          end
+
+          private
+
+          def process_helm_flags(content, site_data)
+            opts = content.strip.split("\n").map do |line|
+              line = site_data['set_flag_values_prefix'] + line if @prefixed
+              "--set \"#{line}\""
+            end
+            opts.join(" \\\n  ")
+          end
+
+          def generate_install_tabs(helm_flags, page)
+            <<~LIQUID
+              {% tabs codeblock %}
+              {% tab kumactl %}
+              ```shell
+              kumactl install control-plane \\
+                #{helm_flags} \\
+                | kubectl apply -f -
+              ```
+              {:.no-line-numbers}
+              {% endtab %}
+              {% tab Helm %}
+              ```shell
+              # Before installing {{ site.mesh_product_name }} with Helm, configure your local Helm repository:
+              # {{ site.links.web }}/#{product_url_segment(page)}/{{ page.release }}/production/cp-deployment/kubernetes/#helm
+              helm install \\
+                --create-namespace \\
+                --namespace {{ site.mesh_namespace }} \\
+                #{helm_flags} \\
+                {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }}
+              ```
+              {:.no-line-numbers}
+              {% endtab %}
+              {% endtabs %}
+            LIQUID
           end
 
           def product_url_segment(page)

--- a/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/cpinstallfile.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/cpinstallfile.rb
@@ -26,24 +26,35 @@ module Jekyll
           end
 
           def render(context)
-            ::Liquid::Template.parse(content).render(context)
+            ::Liquid::Template.parse(generate_install_tabs).render(context)
           end
 
           private
 
-          # TODO: refactor to reduce method length
-          def content
+          def generate_install_tabs
             filename = @params['filename']
-
-            <<~MARKDOWN
+            <<~LIQUID
               {% tabs %}
+              #{kumactl_tab(filename)}
+              #{helm_tab(filename)}
+              {% endtabs %}
+            LIQUID
+          end
+
+          def kumactl_tab(filename)
+            <<~LIQUID.chomp
               {% tab kumactl %}
               ```sh
               kumactl install control-plane --values #{filename} | kubectl apply -f -
               ```
               {% endtab %}
+            LIQUID
+          end
+
+          def helm_tab(filename)
+            <<~LIQUID.chomp
               {% tab Helm %}
-              Before using {{site.mesh_product_name}} with Helm, ensure that you’ve followed [these steps](/docs/{{ page.release }}/production/cp-deployment/kubernetes/#helm) to configure your local Helm repository.
+              Before using {{site.mesh_product_name}} with Helm, ensure that you've followed [these steps](/docs/{{ page.release }}/production/cp-deployment/kubernetes/#helm) to configure your local Helm repository.
 
               ```sh
               helm install \\
@@ -53,8 +64,7 @@ module Jekyll
                 {{site.mesh_helm_install_name}} {{site.mesh_helm_repo}}
               ```
               {% endtab %}
-              {% endtabs %}
-            MARKDOWN
+            LIQUID
           end
         end
       end


### PR DESCRIPTION
## Motivation

Reduce complexity in small tag files as part of rubocop refactoring plan (PR 5).

## Implementation information

- **cpinstall.rb**: Extract `process_helm_flags` and `generate_install_tabs` methods
- **cpinstallfile.rb**: Extract `generate_install_tabs`, `kumactl_tab`, `helm_tab` methods  
- **embed.rb**: Extract `resolve_embed_path`, `apply_link_filter` methods

All methods marked private. No functional changes.

## Supporting documentation

Part of rubocop refactoring plan in `rubocop-plan.md` (PR 5).