### PR TITLE
refactor(rubocop): enable metrics cops after refactoring

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,38 +13,20 @@ AllCops:
 Style/Documentation:
   Enabled: false
 
-
-# TODO: refactor large lambda blocks
 Metrics/BlockLength:
   Exclude:
     - '**/*_spec.rb'
-    - 'jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/policyyaml.rb'
 
-# TODO: refactor generator methods
 Metrics/AbcSize:
-  Enabled: false
+  Max: 50
+  Exclude:
+    - 'spec/**/*'
 
 Metrics/MethodLength:
-  Enabled: false
+  Max: 40
 
 Metrics/CyclomaticComplexity:
-  Enabled: false
-
-# TODO: rename predicate methods
-Naming/PredicateName:
-  Enabled: false
-
-# TODO: call super in InstallPage#initialize
-Lint/MissingSuper:
-  Enabled: false
-
-# TODO: replace OpenStruct with Struct
-Style/OpenStructUse:
-  Enabled: false
-
-# Disable requirement for rubocop:enable after rubocop:disable
-Lint/MissingCopEnableDirective:
-  Enabled: false
+  Max: 10
 
 Layout/LineLength:
   Max: 180


### PR DESCRIPTION
## Motivation

Enable RuboCop metrics cops that were previously disabled, completing the refactoring technical debt cleanup.

## Implementation information

Enable cops with reasonable thresholds based on current codebase state:
- Metrics/AbcSize: max 50, exclude spec/
- Metrics/MethodLength: max 40
- Metrics/CyclomaticComplexity: max 10
- Naming/PredicateName: default (enabled)
- Lint/MissingSuper: default (enabled)
- Style/OpenStructUse: default (enabled)

Removed:
- TODO comments for completed refactoring
- policyyaml.rb exclusion from BlockLength (no longer needed)
- Lint/MissingCopEnableDirective disable (no inline disables remain)

## Supporting documentation

Part of `.plans/rubocop-plan.md` PR 8