### PR TITLE
fix(mise): run clean before dev/serve sequentially

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -24,7 +24,10 @@ run = "bundle exec foreman start"
 
 [tasks."dev:clean"]
 description = "Clean then run dev server"
-depends = ["clean", "dev"]
+run = """
+mise run clean
+mise run dev
+"""
 
 [tasks.test]
 description = "Run tests"
@@ -45,7 +48,10 @@ run = "yarn netlify serve"
 
 [tasks."serve:clean"]
 description = "Clean then serve"
-depends = ["clean", "serve"]
+run = """
+mise run clean
+mise run serve
+"""
 
 [tasks.clean]
 description = "Clean build artifacts"


### PR DESCRIPTION
## Motivation

`mise dev:clean` and `mise serve:clean` were running `clean` and `dev`/`serve` in parallel because `depends` executes tasks concurrently. Clean should finish before starting dev server.

## Implementation information

Replace `depends = ["clean", "dev"]` with shell commands that run mise tasks sequentially:
```toml
run = """
mise run clean
mise run dev
"""
```

## Supporting documentation

- [mise task configuration docs](https://mise.jdx.dev/tasks/task-configuration.html)