### PR TITLE
feat: add schema_viewer liquid tag

### DIFF
--- a/app/_assets/styles/custom.scss
+++ b/app/_assets/styles/custom.scss
@@ -35,3 +35,4 @@
 @use '@/styles/custom/components/distribution-dropdown';
 @use '@/styles/custom/components/vuepress-tabs';
 @use '@/styles/custom/components/spinner';
+@use '@/styles/custom/components/schema-viewer';

--- a/app/_assets/styles/custom/components/_schema-viewer.scss
+++ b/app/_assets/styles/custom/components/_schema-viewer.scss
@@ -1,0 +1,162 @@
+@use '@/styles/config/index' as *;
+
+.schema-viewer {
+  font-family: inherit;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  border: 1px solid $borderColor;
+  border-radius: 4px;
+  background: $gray-1;
+  margin: 1rem 0;
+}
+
+.schema-viewer__properties {
+  padding: 0;
+}
+
+.schema-viewer__node {
+  border-bottom: 1px solid $borderColor;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.schema-viewer__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  cursor: default;
+  background: #fff;
+
+  .schema-viewer__node--expandable > & {
+    cursor: pointer;
+
+    &:hover {
+      background: $sky-light;
+    }
+  }
+}
+
+.schema-viewer__arrow {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 4px 0 4px 6px;
+  border-color: transparent transparent transparent $gray-5;
+  transition: transform 0.15s ease;
+  flex-shrink: 0;
+  margin-right: 0.35rem;
+
+  .schema-viewer__node:not(.schema-viewer__node--collapsed) > .schema-viewer__header > & {
+    transform: rotate(90deg);
+  }
+}
+
+.schema-viewer__arrow-placeholder {
+  display: inline-block;
+  width: 6px;
+  margin-right: 0.35rem;
+  flex-shrink: 0;
+}
+
+.schema-viewer__name {
+  font-weight: 600;
+  color: $textColor;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.schema-viewer__type {
+  font-size: 0.75rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  font-weight: 500;
+
+  &--string {
+    background: #e8f5e9;
+    color: #2e7d32;
+  }
+
+  &--boolean {
+    background: #fff3e0;
+    color: #e65100;
+  }
+
+  &--integer,
+  &--number {
+    background: #e3f2fd;
+    color: #1565c0;
+  }
+
+  &--object {
+    background: #f3e5f5;
+    color: #7b1fa2;
+  }
+
+  &--array {
+    background: #e0f7fa;
+    color: #00838f;
+  }
+
+  &--enum {
+    background: #fce4ec;
+    color: #c2185b;
+  }
+
+  &--any {
+    background: $gray-4;
+    color: $gray-5;
+  }
+}
+
+.schema-viewer__required {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  background: #ffebee;
+  color: #c62828;
+  font-weight: 500;
+}
+
+.schema-viewer__content {
+  padding: 0 0.75rem 0.6rem 2rem;
+}
+
+.schema-viewer__description {
+  color: $gray-7;
+  font-size: 0.85rem;
+  margin-bottom: 0.25rem;
+}
+
+.schema-viewer__enum {
+  font-size: 0.8rem;
+  color: $gray-5;
+
+  code {
+    background: #fce4ec;
+    color: #c2185b;
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+    font-size: 0.75rem;
+  }
+}
+
+.schema-viewer__children {
+  padding-left: 1.25rem;
+  border-left: 2px solid $borderColor;
+  margin-left: 0.75rem;
+
+  .schema-viewer__node--collapsed > & {
+    display: none;
+  }
+}
+
+.schema-viewer-error {
+  padding: 1rem;
+  background: #ffebee;
+  color: #c62828;
+  border-radius: 4px;
+  margin: 1rem 0;
+}

--- a/app/_src/resources/mesh.md
+++ b/app/_src/resources/mesh.md
@@ -414,4 +414,4 @@ meshServices:
 
 ## All options
 
-{% json_schema Mesh type=proto %}
+{% schema_viewer Mesh type=proto %}

--- a/jekyll-kuma-plugins/lib/jekyll/kuma_plugins.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma_plugins.rb
@@ -2,6 +2,7 @@
 
 require_relative 'kuma_plugins/version'
 require_relative 'kuma_plugins/liquid/tags/jsonschema'
+require_relative 'kuma_plugins/liquid/tags/schema_viewer'
 require_relative 'kuma_plugins/liquid/tags/embed'
 require_relative 'kuma_plugins/liquid/tags/policyyaml'
 require_relative 'kuma_plugins/liquid/tags/cpinstall'

--- a/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/schema_viewer.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/schema_viewer.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'yaml'
+require 'cgi'
+require_relative '../../common/path_helpers'
+
+module Jekyll
+  module KumaPlugins
+    module Liquid
+      module Tags
+        # Renders JSON schema as interactive HTML viewer
+        class SchemaViewer < ::Liquid::Tag
+          include Jekyll::KumaPlugins::Common::PathHelpers
+
+          TYPE_BADGES = %w[string boolean integer number object array enum].freeze
+
+          def initialize(tag_name, markup, options)
+            super
+            name, *params_list = @markup.split
+            params = { 'type' => 'policy' }
+            params_list.each do |item|
+              sp = item.split('=')
+              params[sp[0]] = sp[1] unless sp[1].to_s.empty?
+            end
+            @load = create_loader(params['type'], name)
+          end
+
+          def render(context)
+            release = context.registers[:page]['release']
+            base_paths = context.registers[:site].config.fetch(PATHS_CONFIG, DEFAULT_PATHS)
+            data = @load.call(base_paths, release)
+            SchemaRenderer.new(data).render
+          rescue StandardError => e
+            Jekyll.logger.warn('Failed reading schema_viewer', e)
+            "<div class='schema-viewer-error'>Error loading schema: #{CGI.escapeHTML(e.message)}</div>"
+          end
+
+          private
+
+          def create_loader(type, name)
+            case type
+            when 'proto' then proto_loader(name)
+            when 'crd' then crd_loader(name)
+            when 'policy' then policy_loader(name)
+            else
+              raise "Invalid type: #{type}"
+            end
+          end
+
+          def proto_loader(name)
+            lambda do |paths, release|
+              JSON.parse(read_file(paths, File.join(release.to_s, 'raw', 'protos', "#{name}.json")).read)
+            end
+          end
+
+          def crd_loader(name)
+            lambda do |paths, release|
+              d = YAML.safe_load(read_file(paths, File.join(release.to_s, 'raw', 'crds', "#{name}.yaml")).read)
+              d['spec']['versions'][0]['schema']['openAPIV3Schema']
+            end
+          end
+
+          def policy_loader(name)
+            lambda do |paths, release|
+              d = YAML.safe_load(read_file(paths, File.join(release.to_s, 'raw', 'crds', "kuma.io_#{name.downcase}.yaml")).read)
+              d['spec']['versions'][0]['schema']['openAPIV3Schema']['properties']['spec']
+            end
+          end
+        end
+
+        # Renders schema data to HTML
+        class SchemaRenderer
+          def initialize(schema)
+            @definitions = schema['definitions'] || {}
+            @root_schema = resolve_ref(schema)
+          end
+
+          def render
+            <<~HTML
+              <div class="schema-viewer">
+                #{render_properties(@root_schema, 0)}
+              </div>
+            HTML
+          end
+
+          private
+
+          def resolve_ref(schema)
+            return schema unless schema.is_a?(Hash) && schema['$ref']
+
+            ref_path = schema['$ref']
+            return schema unless ref_path.start_with?('#/definitions/')
+
+            def_name = ref_path.sub('#/definitions/', '')
+            @definitions[def_name] || schema
+          end
+
+          def render_properties(schema, depth)
+            schema = resolve_ref(schema)
+            return '' unless schema.is_a?(Hash) && schema['properties'].is_a?(Hash)
+
+            required_fields = schema['required'] || []
+            props = schema['properties'].map do |name, prop|
+              render_property(name, prop, required_fields.include?(name), depth)
+            end
+            "<div class=\"schema-viewer__properties\">#{props.join}</div>"
+          end
+
+          def render_property(name, prop, required, depth)
+            prop = resolve_ref(prop)
+            return '' unless prop.is_a?(Hash)
+
+            build_property_html(name, prop, required, depth)
+          end
+
+          def build_property_html(name, prop, required, depth)
+            has_children = nested_properties?(prop)
+            html = [render_node_open(name, prop, required, depth, has_children)]
+            html << render_content_section(prop)
+            html << render_children_section(prop, depth) if has_children
+            html << '</div>'
+            html.join
+          end
+
+          def render_node_open(name, prop, required, depth, has_children)
+            collapsed = depth.positive? ? 'schema-viewer__node--collapsed' : nil
+            expandable = has_children ? 'schema-viewer__node--expandable' : nil
+            arrow = has_children ? '<span class="schema-viewer__arrow"></span>' : '<span class="schema-viewer__arrow-placeholder"></span>'
+            required_badge = required ? '<span class="schema-viewer__required">required</span>' : nil
+
+            <<~HTML
+              <div class="schema-viewer__node #{collapsed} #{expandable}" data-depth="#{depth}">
+                <div class="schema-viewer__header">
+                  #{arrow}
+                  <span class="schema-viewer__name">#{CGI.escapeHTML(name)}</span>
+                  #{render_type_badge(determine_type(prop))}
+                  #{required_badge}
+                </div>
+            HTML
+          end
+
+          def render_content_section(prop)
+            description = clean_description(prop['description'])
+            enum_values = extract_enum_values(prop)
+            return '' unless description || enum_values
+
+            content = []
+            content << "<div class=\"schema-viewer__description\">#{CGI.escapeHTML(description)}</div>" if description
+            content << render_enum_values(enum_values) if enum_values
+            "<div class=\"schema-viewer__content\">#{content.join}</div>"
+          end
+
+          def render_children_section(prop, depth)
+            "<div class=\"schema-viewer__children\">#{render_nested_content(prop, depth + 1)}</div>"
+          end
+
+          def determine_type(prop)
+            return 'enum' if prop['enum']
+
+            type = prop['type']
+            return type if type && SchemaViewer::TYPE_BADGES.include?(type)
+            return 'object' if prop['properties']
+            return 'array' if prop['items']
+
+            'any'
+          end
+
+          def render_type_badge(type)
+            badge_class = SchemaViewer::TYPE_BADGES.include?(type) ? "schema-viewer__type--#{type}" : 'schema-viewer__type--any'
+            "<span class=\"schema-viewer__type #{badge_class}\">#{CGI.escapeHTML(type)}</span>"
+          end
+
+          def nested_properties?(prop)
+            return true if prop['properties']
+            return true if prop['items'] && resolve_ref(prop['items'])['properties']
+
+            false
+          end
+
+          def render_nested_content(prop, depth)
+            return render_properties(prop, depth) if prop['properties']
+            return render_properties(resolve_ref(prop['items']), depth) if prop['items']
+
+            ''
+          end
+
+          def clean_description(desc)
+            return nil unless desc
+
+            desc.gsub('+optional', '').gsub("\n", ' ').strip
+          end
+
+          def extract_enum_values(prop)
+            return nil unless prop['enum']
+
+            prop['enum'].select { |v| v.is_a?(String) }
+          end
+
+          def render_enum_values(values)
+            return '' if values.empty?
+
+            formatted = values.map { |v| "<code>#{CGI.escapeHTML(v)}</code>" }.join(' | ')
+            "<div class=\"schema-viewer__enum\">Values: #{formatted}</div>"
+          end
+        end
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('schema_viewer', Jekyll::KumaPlugins::Liquid::Tags::SchemaViewer)

--- a/spec/fixtures/schema-viewer-mesh.golden.html
+++ b/spec/fixtures/schema-viewer-mesh.golden.html
@@ -1,0 +1,357 @@
+<link rel="stylesheet" href="http://localhost:8000/dist/vite/assets/application.css" />
+<script src="http://localhost:8000/dist/vite/assets/application.js" crossorigin="anonymous" type="module"></script>
+
+
+<div class="schema-viewer">
+  <div class="schema-viewer__properties"><div class="schema-viewer__node  schema-viewer__node--expandable" data-depth="0">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">mtls</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">mTLS settings of a Mesh.</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">enabledBackend</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Name of the enabled backend</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">backends</span>
+    <span class="schema-viewer__type schema-viewer__type--array">array</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">List of available Certificate Authority backends</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">name</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Name of the backend</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">type</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Type of the backend. Has to be one of the loaded plugins (Kuma ships with builtin and provided)</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">dpCert</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">DpCert defines settings for certificates generated for Dataplanes</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">rotation</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Rotation defines rotation settings for Dataplane certificate</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="4">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">expiration</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Time after which generated certificate for Dataplane will expire</div></div></div></div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">requestTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Timeout on request to CA for DP certificate generation and retrieval</div></div></div></div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">conf</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Configuration of the backend</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">mode</span>
+    <span class="schema-viewer__type schema-viewer__type--enum">enum</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__enum">Values: <code>STRICT</code> | <code>PERMISSIVE</code></div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">rootChain</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">RootChain defines settings related to CA root certificate chain.</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">requestTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Timeout on request for to CA for root certificate chain. If not specified, defaults to 10s.</div></div></div></div></div></div></div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">skipValidation</span>
+    <span class="schema-viewer__type schema-viewer__type--boolean">boolean</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">If enabled, skips CA validation.</div></div></div></div></div></div><div class="schema-viewer__node  schema-viewer__node--expandable" data-depth="0">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">tracing</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Tracing defines tracing configuration of the mesh.</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">defaultBackend</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Name of the default backend</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">backends</span>
+    <span class="schema-viewer__type schema-viewer__type--array">array</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">List of available tracing backends</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">name</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Name of the backend, can be then used in Mesh.tracing.defaultBackend or in TrafficTrace</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">sampling</span>
+    <span class="schema-viewer__type schema-viewer__type--number">number</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Percentage of traces that will be sent to the backend (range 0.0 - 100.0). Empty value defaults to 100.0%</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">type</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Type of the backend (Kuma ships with &#39;zipkin&#39;)</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">conf</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Configuration of the backend</div></div></div></div></div></div></div></div></div><div class="schema-viewer__node  schema-viewer__node--expandable" data-depth="0">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">logging</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">defaultBackend</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Name of the default backend</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">backends</span>
+    <span class="schema-viewer__type schema-viewer__type--array">array</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">List of available logging backends</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">name</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Name of the backend, can be then used in Mesh.logging.defaultBackend or in TrafficLogging</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">format</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Format of access logs. Placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">type</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Type of the backend (Kuma ships with &#39;tcp&#39; and &#39;file&#39;)</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">conf</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Configuration of the backend</div></div></div></div></div></div></div></div></div><div class="schema-viewer__node  schema-viewer__node--expandable" data-depth="0">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">metrics</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Metrics defines configuration for metrics that should be collected and exposed by dataplanes.</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">enabledBackend</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Name of the enabled backend</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">backends</span>
+    <span class="schema-viewer__type schema-viewer__type--array">array</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">List of available Metrics backends</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">name</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Name of the backend, can be then used in Mesh.metrics.enabledBackend</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">type</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Type of the backend (Kuma ships with &#39;prometheus&#39;)</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">conf</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Configuration of the backend</div></div></div></div></div></div></div></div></div><div class="schema-viewer__node  schema-viewer__node--expandable" data-depth="0">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">networking</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Networking defines the networking configuration of the mesh</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">outbound</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Outbound describes the common mesh outbound settings</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">passthrough</span>
+    <span class="schema-viewer__type schema-viewer__type--boolean">boolean</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Control the passthrough cluster</div></div></div></div></div></div></div></div></div><div class="schema-viewer__node  schema-viewer__node--expandable" data-depth="0">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">routing</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Routing defines configuration for the routing in the mesh</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">localityAwareLoadBalancing</span>
+    <span class="schema-viewer__type schema-viewer__type--boolean">boolean</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Enable the Locality Aware Load Balancing</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">zoneEgress</span>
+    <span class="schema-viewer__type schema-viewer__type--boolean">boolean</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Enable routing traffic to services in other zone or external services through ZoneEgress. Default: false</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">defaultForbidMeshExternalServiceAccess</span>
+    <span class="schema-viewer__type schema-viewer__type--boolean">boolean</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">If true, blocks traffic to MeshExternalServices. Default: false</div></div></div></div></div></div><div class="schema-viewer__node  schema-viewer__node--expandable" data-depth="0">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">constraints</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Constraints to apply to the mesh and its entities</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">dataplaneProxy</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">requirements</span>
+    <span class="schema-viewer__type schema-viewer__type--array">array</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Requirements defines a set of requirements that data plane proxies must fulfill in order to join the mesh. A data plane proxy must fulfill at least one requirement in order to join the mesh. Empty list of allowed requirements means that any proxy that is not explicitly denied can join.</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">tags</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Tags defines set of required tags. You can specify &#39;*&#39; in value to require non empty value of tag</div></div></div></div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">restrictions</span>
+    <span class="schema-viewer__type schema-viewer__type--array">array</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Restrictions defines a set of restrictions that data plane proxies cannot fulfill in order to join the mesh. A data plane proxy cannot fulfill any requirement in order to join the mesh. Restrictions takes precedence over requirements.</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">tags</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Tags defines set of required tags. You can specify &#39;*&#39; in value to require non empty value of tag</div></div></div></div></div></div></div></div></div></div></div></div><div class="schema-viewer__node  " data-depth="0">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">skipCreatingInitialPolicies</span>
+    <span class="schema-viewer__type schema-viewer__type--array">array</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">List of policies to skip creating by default when the mesh is created. e.g. TrafficPermission, MeshRetry, etc. An &#39;*&#39; can be used to skip all policies.</div></div></div><div class="schema-viewer__node  schema-viewer__node--expandable" data-depth="0">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">meshServices</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">mode</span>
+    <span class="schema-viewer__type schema-viewer__type--enum">enum</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__enum">Values: <code>Disabled</code> | <code>Everywhere</code> | <code>ReachableBackends</code> | <code>Exclusive</code></div></div></div></div></div></div></div>
+</div>

--- a/spec/fixtures/schema-viewer-meshtimeouts.golden.html
+++ b/spec/fixtures/schema-viewer-meshtimeouts.golden.html
@@ -1,0 +1,406 @@
+<link rel="stylesheet" href="http://localhost:8000/dist/vite/assets/application.css" />
+<script src="http://localhost:8000/dist/vite/assets/application.js" crossorigin="anonymous" type="module"></script>
+
+
+<div class="schema-viewer">
+  <div class="schema-viewer__properties"><div class="schema-viewer__node  schema-viewer__node--expandable" data-depth="0">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">from</span>
+    <span class="schema-viewer__type schema-viewer__type--array">array</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">From list makes a match between clients and corresponding configurations</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">default</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Default is a configuration specific to the group of clients referenced in &#39;targetRef&#39;</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">connectionTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established. Default value is 5 seconds. Cannot be set to 0.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">http</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Http provides configuration for HTTP specific timeouts</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">maxConnectionDuration</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">MaxConnectionDuration is the time after which a connection will be drained and/or closed, starting from when it was first established. Setting this timeout to 0 will disable it. Disabled by default.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">maxStreamDuration</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">MaxStreamDuration is the maximum time that a stream’s lifetime will span. Setting this timeout to 0 will disable it. Disabled by default.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">requestHeadersTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">RequestHeadersTimeout The amount of time that proxy will wait for the request headers to be received. The timer is activated when the first byte of the headers is received, and is disarmed when the last byte of the headers has been received. If not specified or set to 0, this timeout is disabled. Disabled by default.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">requestTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">RequestTimeout The amount of time that proxy will wait for the entire request to be received. The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent, OR when the response is initiated. Setting this timeout to 0 will disable it. Default is 15s.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">streamIdleTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity. Setting this timeout to 0 will disable it. Default is 30m</div></div></div></div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">idleTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">IdleTimeout is defined as the period in which there are no bytes sent or received on connection Setting this timeout to 0 will disable it. Be cautious when disabling it because it can lead to connection leaking. Default value is 1h.</div></div></div></div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">targetRef</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    <span class="schema-viewer__required">required</span>
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">TargetRef is a reference to the resource that represents a group of clients.</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">kind</span>
+    <span class="schema-viewer__type schema-viewer__type--enum">enum</span>
+    <span class="schema-viewer__required">required</span>
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Kind of the referenced resource</div><div class="schema-viewer__enum">Values: <code>Mesh</code> | <code>MeshSubset</code> | <code>MeshGateway</code> | <code>MeshService</code> | <code>MeshExternalService</code> | <code>MeshMultiZoneService</code> | <code>MeshServiceSubset</code> | <code>MeshHTTPRoute</code> | <code>Dataplane</code></div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">labels</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Labels are used to select group of MeshServices that match labels. Either Labels or Name and Namespace can be used.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">mesh</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Mesh is reserved for future use to identify cross mesh resources.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">name</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">namespace</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Namespace specifies the namespace of target resource. If empty only resources in policy namespace will be targeted.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">proxyTypes</span>
+    <span class="schema-viewer__type schema-viewer__type--array">array</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">ProxyTypes specifies the data plane types that are subject to the policy. When not specified, all data plane types are targeted by the policy.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">sectionName</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">SectionName is used to target specific section of resource. For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">tags</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`</div></div></div></div></div></div></div></div></div><div class="schema-viewer__node  schema-viewer__node--expandable" data-depth="0">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">rules</span>
+    <span class="schema-viewer__type schema-viewer__type--array">array</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Rules defines inbound timeout configurations. Currently limited to exactly one rule containing default timeouts that apply to all inbound traffic, as L7 matching is not yet implemented.</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">default</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Default contains configuration of the inbound timeouts</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">connectionTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established. Default value is 5 seconds. Cannot be set to 0.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">http</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Http provides configuration for HTTP specific timeouts</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">maxConnectionDuration</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">MaxConnectionDuration is the time after which a connection will be drained and/or closed, starting from when it was first established. Setting this timeout to 0 will disable it. Disabled by default.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">maxStreamDuration</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">MaxStreamDuration is the maximum time that a stream’s lifetime will span. Setting this timeout to 0 will disable it. Disabled by default.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">requestHeadersTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">RequestHeadersTimeout The amount of time that proxy will wait for the request headers to be received. The timer is activated when the first byte of the headers is received, and is disarmed when the last byte of the headers has been received. If not specified or set to 0, this timeout is disabled. Disabled by default.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">requestTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">RequestTimeout The amount of time that proxy will wait for the entire request to be received. The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent, OR when the response is initiated. Setting this timeout to 0 will disable it. Default is 15s.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">streamIdleTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity. Setting this timeout to 0 will disable it. Default is 30m</div></div></div></div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">idleTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">IdleTimeout is defined as the period in which there are no bytes sent or received on connection Setting this timeout to 0 will disable it. Be cautious when disabling it because it can lead to connection leaking. Default value is 1h.</div></div></div></div></div></div></div></div></div><div class="schema-viewer__node  schema-viewer__node--expandable" data-depth="0">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">targetRef</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">TargetRef is a reference to the resource the policy takes an effect on. The resource could be either a real store object or virtual resource defined inplace.</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">kind</span>
+    <span class="schema-viewer__type schema-viewer__type--enum">enum</span>
+    <span class="schema-viewer__required">required</span>
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Kind of the referenced resource</div><div class="schema-viewer__enum">Values: <code>Mesh</code> | <code>MeshSubset</code> | <code>MeshGateway</code> | <code>MeshService</code> | <code>MeshExternalService</code> | <code>MeshMultiZoneService</code> | <code>MeshServiceSubset</code> | <code>MeshHTTPRoute</code> | <code>Dataplane</code></div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">labels</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Labels are used to select group of MeshServices that match labels. Either Labels or Name and Namespace can be used.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">mesh</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Mesh is reserved for future use to identify cross mesh resources.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">name</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">namespace</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Namespace specifies the namespace of target resource. If empty only resources in policy namespace will be targeted.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">proxyTypes</span>
+    <span class="schema-viewer__type schema-viewer__type--array">array</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">ProxyTypes specifies the data plane types that are subject to the policy. When not specified, all data plane types are targeted by the policy.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">sectionName</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">SectionName is used to target specific section of resource. For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">tags</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`</div></div></div></div></div></div><div class="schema-viewer__node  schema-viewer__node--expandable" data-depth="0">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">to</span>
+    <span class="schema-viewer__type schema-viewer__type--array">array</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">To list makes a match between the consumed services and corresponding configurations</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">default</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Default is a configuration specific to the group of destinations referenced in &#39;targetRef&#39;</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">connectionTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established. Default value is 5 seconds. Cannot be set to 0.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">http</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Http provides configuration for HTTP specific timeouts</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">maxConnectionDuration</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">MaxConnectionDuration is the time after which a connection will be drained and/or closed, starting from when it was first established. Setting this timeout to 0 will disable it. Disabled by default.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">maxStreamDuration</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">MaxStreamDuration is the maximum time that a stream’s lifetime will span. Setting this timeout to 0 will disable it. Disabled by default.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">requestHeadersTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">RequestHeadersTimeout The amount of time that proxy will wait for the request headers to be received. The timer is activated when the first byte of the headers is received, and is disarmed when the last byte of the headers has been received. If not specified or set to 0, this timeout is disabled. Disabled by default.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">requestTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">RequestTimeout The amount of time that proxy will wait for the entire request to be received. The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent, OR when the response is initiated. Setting this timeout to 0 will disable it. Default is 15s.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="3">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">streamIdleTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity. Setting this timeout to 0 will disable it. Default is 30m</div></div></div></div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">idleTimeout</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">IdleTimeout is defined as the period in which there are no bytes sent or received on connection Setting this timeout to 0 will disable it. Be cautious when disabling it because it can lead to connection leaking. Default value is 1h.</div></div></div></div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed schema-viewer__node--expandable" data-depth="1">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow"></span>
+    <span class="schema-viewer__name">targetRef</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    <span class="schema-viewer__required">required</span>
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">TargetRef is a reference to the resource that represents a group of destinations.</div></div><div class="schema-viewer__children"><div class="schema-viewer__properties"><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">kind</span>
+    <span class="schema-viewer__type schema-viewer__type--enum">enum</span>
+    <span class="schema-viewer__required">required</span>
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Kind of the referenced resource</div><div class="schema-viewer__enum">Values: <code>Mesh</code> | <code>MeshSubset</code> | <code>MeshGateway</code> | <code>MeshService</code> | <code>MeshExternalService</code> | <code>MeshMultiZoneService</code> | <code>MeshServiceSubset</code> | <code>MeshHTTPRoute</code> | <code>Dataplane</code></div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">labels</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Labels are used to select group of MeshServices that match labels. Either Labels or Name and Namespace can be used.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">mesh</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Mesh is reserved for future use to identify cross mesh resources.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">name</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">namespace</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Namespace specifies the namespace of target resource. If empty only resources in policy namespace will be targeted.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">proxyTypes</span>
+    <span class="schema-viewer__type schema-viewer__type--array">array</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">ProxyTypes specifies the data plane types that are subject to the policy. When not specified, all data plane types are targeted by the policy.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">sectionName</span>
+    <span class="schema-viewer__type schema-viewer__type--string">string</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">SectionName is used to target specific section of resource. For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.</div></div></div><div class="schema-viewer__node schema-viewer__node--collapsed " data-depth="2">
+  <div class="schema-viewer__header">
+    <span class="schema-viewer__arrow-placeholder"></span>
+    <span class="schema-viewer__name">tags</span>
+    <span class="schema-viewer__type schema-viewer__type--object">object</span>
+    
+  </div>
+<div class="schema-viewer__content"><div class="schema-viewer__description">Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`</div></div></div></div></div></div></div></div></div></div>
+</div>

--- a/spec/kuma_plugins/liquid/tags/schema_viewer_spec.rb
+++ b/spec/kuma_plugins/liquid/tags/schema_viewer_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::SchemaViewer do
+  shared_examples 'schema viewer rendering' do |schema_name, schema_type, golden_file|
+    it "renders correctly for #{schema_name} type=#{schema_type}" do
+      site = Jekyll::Site.new(Jekyll.configuration({
+                                                     mesh_raw_generated_paths: ['app/assets']
+                                                   }))
+      context = Liquid::Context.new({}, {}, {
+                                      page: {
+                                        'edition' => 'kuma',
+                                        'release' => Jekyll::GeneratorSingleSource::Product::Release.new({
+                                                                                                           'release' => 'dev',
+                                                                                                           'edition' => 'kuma'
+                                                                                                         })
+                                      },
+                                      site: site
+                                    })
+
+      tag = "{% schema_viewer #{schema_name} type=#{schema_type} %}"
+      template = Liquid::Template.parse(tag)
+      output = template.render(context)
+
+      GoldenFileManager.assert_output(output, golden_file, include_header: true)
+    end
+  end
+
+  describe 'rendering tests' do
+    include_examples 'schema viewer rendering',
+                     'Mesh',
+                     'proto',
+                     'spec/fixtures/schema-viewer-mesh.golden.html'
+
+    include_examples 'schema viewer rendering',
+                     'MeshTimeouts',
+                     'policy',
+                     'spec/fixtures/schema-viewer-meshtimeouts.golden.html'
+  end
+
+  describe 'error handling' do
+    it 'returns error div for missing schema' do
+      site = Jekyll::Site.new(Jekyll.configuration({
+                                                     mesh_raw_generated_paths: ['app/assets']
+                                                   }))
+      context = Liquid::Context.new({}, {}, {
+                                      page: {
+                                        'edition' => 'kuma',
+                                        'release' => Jekyll::GeneratorSingleSource::Product::Release.new({
+                                                                                                           'release' => 'dev',
+                                                                                                           'edition' => 'kuma'
+                                                                                                         })
+                                      },
+                                      site: site
+                                    })
+
+      tag = '{% schema_viewer NonExistentSchema type=proto %}'
+      template = Liquid::Template.parse(tag)
+      output = template.render(context)
+
+      expect(output).to include('schema-viewer-error')
+      expect(output).to include('Error loading schema')
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

Replace plain-text JSON schema rendering with interactive, styled schema viewer. Part 1 of schema-plan.md - creates basic structure.

## Implementation information

- New `{% schema_viewer %}` tag alongside existing `{% json_schema %}`
- Recursive HTML renderer with type badges (string, boolean, object, array, integer, enum)
- Required field indicators
- Nested expandable nodes (first level expanded, rest collapsed)
- CSS-only arrows for cross-browser compatibility
- Golden file test for Mesh proto schema

## Supporting documentation

See schema-plan.md for full implementation plan (PRs 2-6 pending).