### PR TITLE
fix(mise): add UTF-8 encoding to dev task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -33,6 +33,7 @@ bundle install
 
 [tasks.dev]
 description = "Run local development server"
+env = { LANG = "en_US.UTF-8", LC_ALL = "en_US.UTF-8" }
 run = "bundle exec foreman start"
 
 [tasks."dev:clean"]


### PR DESCRIPTION
## Motivation

`mise dev` fails with "invalid byte sequence in US-ASCII" error when Jekyll processes docs files containing non-ASCII characters.

## Implementation information

Added `LANG` and `LC_ALL` UTF-8 environment variables to `[tasks.dev]` in mise.toml. This ensures Ruby/Jekyll use UTF-8 encoding when processing files.

Alternative considered: setting env vars globally in mise.toml, but task-specific is more targeted.

## Supporting documentation

N/A