### PR TITLE
refactor: migrate json_schema to schema_viewer tag

### DIFF
--- a/app/_src/networking/meshexternalservice.md
+++ b/app/_src/networking/meshexternalservice.md
@@ -417,4 +417,4 @@ grpcurl -plaintext -v mes-grpcs.svc.meshext.local:9001 list # this is using plai
 
 ## All policy configuration settings
 
-{% json_schema MeshExternalServices %}
+{% schema_viewer MeshExternalServices %}

--- a/app/_src/networking/meshmultizoneservice.md
+++ b/app/_src/networking/meshmultizoneservice.md
@@ -71,4 +71,4 @@ ports:
 If available, the local zone is always preferred when a client sends a request.
 Otherwise, the request is load balanced equally for each zone. You can customize this behavior with [MeshLoadBalancingStrategy](/docs/{{ page.release }}/policies/meshloadbalancingstrategy), by targeting MeshMultiZoneService in `to` section.
 
-{% json_schema MeshMultiZoneServices %}
+{% schema_viewer MeshMultiZoneServices %}

--- a/app/_src/policies/circuit-breaker.md
+++ b/app/_src/policies/circuit-breaker.md
@@ -256,4 +256,4 @@ Read more about [Non-mesh traffic](/docs/{{ page.release }}/networking/non-mesh-
 
 ## All policy options
 
-{% json_schema CircuitBreaker type=proto %}
+{% schema_viewer CircuitBreaker type=proto %}

--- a/app/_src/policies/external-services.md
+++ b/app/_src/policies/external-services.md
@@ -247,4 +247,4 @@ Note that before gateway becomes generally available this behaviour will change 
 
 ## All options
 
-{% json_schema ExternalService type=proto %}
+{% schema_viewer ExternalService type=proto %}

--- a/app/_src/policies/fault-injection.md
+++ b/app/_src/policies/fault-injection.md
@@ -117,4 +117,4 @@ You can use all the tags in both `sources` and `destinations` sections.
 
 ## All options
 
-{% json_schema FaultInjection type=proto %}
+{% schema_viewer FaultInjection type=proto %}

--- a/app/_src/policies/health-check.md
+++ b/app/_src/policies/health-check.md
@@ -160,4 +160,4 @@ The only supported value for `destinations.match` is `kuma.io/service`.
 
 ## All options
 
-{% json_schema HealthCheck type=proto %}
+{% schema_viewer HealthCheck type=proto %}

--- a/app/_src/policies/meshaccesslog.md
+++ b/app/_src/policies/meshaccesslog.md
@@ -1228,4 +1228,4 @@ You can select a built-in gateway using the `kuma.io/service` value. A current l
 
 ## All policy options
 
-{% json_schema MeshAccessLogs %}
+{% schema_viewer MeshAccessLogs %}

--- a/app/_src/policies/meshcircuitbreaker.md
+++ b/app/_src/policies/meshcircuitbreaker.md
@@ -704,4 +704,4 @@ spec:
 
 ## All policy options
 
-{% json_schema MeshCircuitBreakers %}
+{% schema_viewer MeshCircuitBreakers %}

--- a/app/_src/policies/meshfaultinjection.md
+++ b/app/_src/policies/meshfaultinjection.md
@@ -528,4 +528,4 @@ spec:
 
 ## All policy options
 
-{% json_schema MeshFaultInjections %}
+{% schema_viewer MeshFaultInjections %}

--- a/app/_src/policies/meshfaultinjection_experimental.md
+++ b/app/_src/policies/meshfaultinjection_experimental.md
@@ -186,4 +186,4 @@ spec:
 
 ## All policy options
 
-{% json_schema MeshFaultInjections %}
+{% schema_viewer MeshFaultInjections %}

--- a/app/_src/policies/meshgateway.md
+++ b/app/_src/policies/meshgateway.md
@@ -261,4 +261,4 @@ EOF
 
 ## All options
 
-{% json_schema MeshGateway type=proto %}
+{% schema_viewer MeshGateway type=proto %}

--- a/app/_src/policies/meshgatewayinstance.md
+++ b/app/_src/policies/meshgatewayinstance.md
@@ -108,4 +108,4 @@ spec:
 
 ## Schema
 
-{% json_schema kuma.io_meshgatewayinstances type=crd %}
+{% schema_viewer kuma.io_meshgatewayinstances type=crd %}

--- a/app/_src/policies/meshgatewayroute.md
+++ b/app/_src/policies/meshgatewayroute.md
@@ -118,4 +118,4 @@ For example, the following filters match `/prefix`, trim it from the path and se
 
 ## Reference
 
-{% json_schema MeshGatewayRoute type=proto %}
+{% schema_viewer MeshGatewayRoute type=proto %}

--- a/app/_src/policies/meshhealthcheck.md
+++ b/app/_src/policies/meshhealthcheck.md
@@ -485,4 +485,4 @@ HTTP health checks are executed using HTTP2
 
 ## All policy options
 
-{% json_schema MeshHealthChecks %}
+{% schema_viewer MeshHealthChecks %}

--- a/app/_src/policies/meshhttproute.md
+++ b/app/_src/policies/meshhttproute.md
@@ -774,4 +774,4 @@ rules:
 - [MeshTimeout](/docs/{{ page.release }}/policies/meshtimeout) - Configure HTTP route-specific timeouts
 - [MeshRetry](/docs/{{ page.release }}/policies/meshretry) - Configure HTTP route-specific retries
 
-{% json_schema MeshHttpRoutes %}
+{% schema_viewer MeshHttpRoutes %}

--- a/app/_src/policies/meshloadbalancingstrategy.md
+++ b/app/_src/policies/meshloadbalancingstrategy.md
@@ -786,4 +786,4 @@ The downside is that we now have to establish and maintain more TCP connections.
 
 ## All policy options
 
-{% json_schema MeshLoadBalancingStrategies %}
+{% schema_viewer MeshLoadBalancingStrategies %}

--- a/app/_src/policies/meshmetric.md
+++ b/app/_src/policies/meshmetric.md
@@ -811,4 +811,4 @@ spec:
 
 ## All policy options
 
-{% json_schema MeshMetrics %}
+{% schema_viewer MeshMetrics %}

--- a/app/_src/policies/meshpassthrough.md
+++ b/app/_src/policies/meshpassthrough.md
@@ -340,4 +340,4 @@ spec:
 
 ## All policy options
 
-{% json_schema MeshPassthroughs %}
+{% schema_viewer MeshPassthroughs %}

--- a/app/_src/policies/meshproxypatch.md
+++ b/app/_src/policies/meshproxypatch.md
@@ -1158,4 +1158,4 @@ spec:
 
 ## All policy options
 
-{% json_schema MeshProxyPatches %}
+{% schema_viewer MeshProxyPatches %}

--- a/app/_src/policies/meshratelimit.md
+++ b/app/_src/policies/meshratelimit.md
@@ -368,4 +368,4 @@ spec:
 
 ## All policy options
 
-{% json_schema MeshRateLimits %}
+{% schema_viewer MeshRateLimits %}

--- a/app/_src/policies/meshretry.md
+++ b/app/_src/policies/meshretry.md
@@ -519,4 +519,4 @@ spec:
 
 ## All policy options
 
-{% json_schema MeshRetries %}
+{% schema_viewer MeshRetries %}

--- a/app/_src/policies/meshtcproute.md
+++ b/app/_src/policies/meshtcproute.md
@@ -617,4 +617,4 @@ Depending on the `backend`'s protocol:
 
 ## All policy configuration settings
 
-{% json_schema MeshTCPRoutes %}
+{% schema_viewer MeshTCPRoutes %}

--- a/app/_src/policies/meshtimeout.md
+++ b/app/_src/policies/meshtimeout.md
@@ -693,4 +693,4 @@ is [a known bug](https://github.com/kumahq/kuma/issues/5850) and is fixed in the
 
 ## All policy options
 
-{% json_schema MeshTimeouts %}
+{% schema_viewer MeshTimeouts %}

--- a/app/_src/policies/meshtls.md
+++ b/app/_src/policies/meshtls.md
@@ -156,4 +156,4 @@ spec:
 
 ## All policy options
 
-{% json_schema MeshTLSes %}
+{% schema_viewer MeshTLSes %}

--- a/app/_src/policies/meshtrace.md
+++ b/app/_src/policies/meshtrace.md
@@ -911,4 +911,4 @@ spec:
 
 ## All policy options
 
-{% json_schema MeshTraces %}
+{% schema_viewer MeshTraces %}

--- a/app/_src/policies/meshtrafficpermission.md
+++ b/app/_src/policies/meshtrafficpermission.md
@@ -595,4 +595,4 @@ This is because the rule with `Deny` is later in the `from` array than any `Allo
 
 ## All policy options
 
-{% json_schema MeshTrafficPermissions %}
+{% schema_viewer MeshTrafficPermissions %}

--- a/app/_src/policies/meshtrafficpermission_experimental.md
+++ b/app/_src/policies/meshtrafficpermission_experimental.md
@@ -160,4 +160,4 @@ and denies requests from clients in `observability` namespace on `backend-admin-
 
 ## All policy options
 
-{% json_schema MeshTrafficPermissions %}
+{% schema_viewer MeshTrafficPermissions %}

--- a/app/_src/policies/rate-limit.md
+++ b/app/_src/policies/rate-limit.md
@@ -175,4 +175,4 @@ Rate limits are configured on each Envoy route by selecting the best Rate Limit 
 
 ## All options
 
-{% json_schema RateLimit type=proto %}
+{% schema_viewer RateLimit type=proto %}

--- a/app/_src/policies/retry.md
+++ b/app/_src/policies/retry.md
@@ -250,4 +250,4 @@ Retries can be configured on each route by matching the `Retry` connection polic
 
 ## All options
 
-{% json_schema Retry type=proto %}
+{% schema_viewer Retry type=proto %}

--- a/app/_src/policies/timeout.md
+++ b/app/_src/policies/timeout.md
@@ -232,4 +232,4 @@ Read more about [Non-mesh traffic](/docs/{{ page.release }}/networking/non-mesh-
 
 ## All options
 
-{% json_schema Timeout type=proto %}
+{% schema_viewer Timeout type=proto %}

--- a/app/_src/policies/traffic-log.md
+++ b/app/_src/policies/traffic-log.md
@@ -247,4 +247,4 @@ If you need an access log with entries in `JSON` format, you have to provide a t
 ```
 ## All policy options
 
-{% json_schema TrafficLog type=proto %}
+{% schema_viewer TrafficLog type=proto %}

--- a/app/_src/policies/traffic-permissions.md
+++ b/app/_src/policies/traffic-permissions.md
@@ -162,4 +162,4 @@ Remember, the `ExternalService` follows [the same rules](/docs/{{ page.release }
 
 ## All options
 
-{% json_schema TrafficPermission type=proto %}
+{% schema_viewer TrafficPermission type=proto %}

--- a/app/_src/policies/traffic-route.md
+++ b/app/_src/policies/traffic-route.md
@@ -610,4 +610,4 @@ There are different load balancing algorithms that can be used to determine how 
 
 ## All options
 
-{% json_schema TrafficRoute type=proto %}
+{% schema_viewer TrafficRoute type=proto %}

--- a/app/_src/policies/traffic-trace.md
+++ b/app/_src/policies/traffic-trace.md
@@ -187,4 +187,4 @@ This is especially useful when we want traces to never leave a world region, or 
 
 ## All options
 
-{% json_schema TrafficTrace type=proto %}
+{% schema_viewer TrafficTrace type=proto %}

--- a/app/_src/policies/virtual-outbound.md
+++ b/app/_src/policies/virtual-outbound.md
@@ -309,4 +309,4 @@ conf:
 
 ## All options
 
-{% json_schema VirtualOutbound type=proto %}
+{% schema_viewer VirtualOutbound type=proto %}

--- a/app/_src/production/dp-config/dpp-on-kubernetes.md
+++ b/app/_src/production/dp-config/dpp-on-kubernetes.md
@@ -597,4 +597,4 @@ Accessing services by using `kuma.io/direct-access-services` annotation means an
 
 ### Schema
 
-{% json_schema kuma.io_containerpatches type=crd %}
+{% schema_viewer kuma.io_containerpatches type=crd %}

--- a/app/_src/production/dp-config/dpp-on-universal.md
+++ b/app/_src/production/dp-config/dpp-on-universal.md
@@ -222,4 +222,4 @@ If the `admin` section is empty or port is equal to zero then the default value 
 
 ## Dataplane configuration
 
-{% json_schema Dataplane type=proto %}
+{% schema_viewer Dataplane type=proto %}

--- a/app/_src/production/dp-config/dpp.md
+++ b/app/_src/production/dp-config/dpp.md
@@ -109,4 +109,4 @@ In addition to the service traffic ports, the data plane proxy also opens the fo
 
 ## Schema
 
-{% json_schema Dataplane type=proto %}
+{% schema_viewer Dataplane type=proto %}

--- a/app/_src/production/mesh.md
+++ b/app/_src/production/mesh.md
@@ -325,4 +325,4 @@ You can also skip creating the default mesh by setting the control-plane configu
 
 ## All options
 
-{% json_schema Mesh type=proto %}
+{% schema_viewer Mesh type=proto %}

--- a/app/_src/reference/proxy-template.md
+++ b/app/_src/reference/proxy-template.md
@@ -907,4 +907,4 @@ The origin name for matching template modifications is `gateway`.
 
 ## Schema
 
-{% json_schema ProxyTemplate type=proto %}
+{% schema_viewer ProxyTemplate type=proto %}

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-k8s.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-k8s.md
@@ -207,4 +207,4 @@ spec:
 
 ## Schema
 
-{% json_schema kuma.io_meshgatewayinstances type=crd %}
+{% schema_viewer kuma.io_meshgatewayinstances type=crd %}

--- a/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
+++ b/app/_src/using-mesh/managing-ingress-traffic/builtin-listeners.md
@@ -428,4 +428,4 @@ for a `MeshGateway` with `crossMesh: true`.
 
 ## All options
 
-{% json_schema MeshGateway type=proto %}
+{% schema_viewer MeshGateway type=proto %}

--- a/templates/policy.md
+++ b/templates/policy.md
@@ -84,4 +84,4 @@ spec:
 
 ## All policy options
 
-{% json_schema {{ .Env.POLICY_NAME }}s %}
+{% schema_viewer {{ .Env.POLICY_NAME }}s %}


### PR DESCRIPTION
## Motivation

Complete schema viewer migration (PR 6 of plan). All docs now use interactive schema_viewer tag with filtering/expand/collapse instead of plain json_schema.

## Implementation information

- Replaced `{% json_schema %}` → `{% schema_viewer %}` in 42 MD files + template  
- Build/tests pass with LC_ALL=en_US.UTF-8 (encoding fix)
- No functionality changes - schema_viewer tag already implemented in PRs 1-5

## Supporting documentation

- schema-plan.md (PR 6: Migration)
- Previous PRs created schema_viewer infrastructure