### PR TITLE
fix(resources): escape Go template syntax in meshidentity

### DIFF
--- a/app/_src/resources/meshidentity.md
+++ b/app/_src/resources/meshidentity.md
@@ -54,9 +54,9 @@ Supported variables:
 
 * `.Mesh` - The mesh name
 * `.Zone` - The zone name
-* `{{ label "label-name" }}` - Any label from the data plane proxy resource
+* {% raw %}`{{ label "label-name" }}`{% endraw %} - Any label from the data plane proxy resource
 
-**Type:** `string` | **Required:** No | **Default:** `"{{ .Mesh }}.{{ .Zone }}.mesh.local"`
+**Type:** `string` | **Required:** No | **Default:** {% raw %}`"{{ .Mesh }}.{{ .Zone }}.mesh.local"`{% endraw %}
 
 #### Path
 
@@ -67,7 +67,7 @@ Supported variables:
 * `.Namespace` - The Kubernetes namespace
 * `.ServiceAccount` - The Kubernetes service account
 * `.Workload` - The workload identifier
-* `{{ label "label-name" }}` - Any label from the data plane proxy resource
+* {% raw %}`{{ label "label-name" }}`{% endraw %} - Any label from the data plane proxy resource
 
 When using `.Workload` in the path template, data plane proxies selected by this `MeshIdentity` must have the workload identifier. This can be provided either:
 
@@ -76,7 +76,7 @@ When using `.Workload` in the path template, data plane proxies selected by this
 
 Connections from data plane proxies lacking the required workload identifier will be rejected.
 
-**Type:** `string` | **Required:** No | **Default:** `"/ns/{{ .Namespace }}/sa/{{ .ServiceAccount }}"`
+**Type:** `string` | **Required:** No | **Default:** {% raw %}`"/ns/{{ .Namespace }}/sa/{{ .ServiceAccount }}"`{% endraw %}
 
 ### Provider
 


### PR DESCRIPTION
## Motivation

Jekyll build was generating 6 Liquid syntax warnings when parsing meshidentity.md. Go template syntax ({{ .Mesh }}, {{ .Zone }}, etc.) was being incorrectly parsed as Liquid template syntax.

## Implementation information

Wrapped Go template syntax in {% raw %} tags at 4 locations in the documentation text where template variables are documented. This tells Jekyll's Liquid parser to treat these as literal text instead of attempting to parse them as Liquid syntax.

Fixed warnings:
- Line 57: `{{ label "label-name" }}`
- Line 59: `{{ .Mesh }}`, `{{ .Zone }}`
- Line 70: `{{ label "label-name" }}`
- Line 79: `{{ .Namespace }}`, `{{ .ServiceAccount }}`

## Supporting documentation

N/A - Build fix