### PR TITLE
docs(workload): clarify automatic kuma.io/workload label generation

### DIFF
--- a/app/_src/resources/workload.md
+++ b/app/_src/resources/workload.md
@@ -229,7 +229,7 @@ The `kuma.io/workload` label determines which Workload resource a data plane pro
 {{site.mesh_product_name}} automatically generates the `kuma.io/workload` label for each pod using this logic:
 
 1. **Automatic from pod labels:** If `runtime.kubernetes.workloadLabels` is configured in the control plane, {{site.mesh_product_name}} checks each pod label in the configured priority order and uses the first non-empty value
-2. **Fallback to ServiceAccount:** If no configured labels exist or all are empty, uses the pod's ServiceAccount name
+2. **Fallback to ServiceAccount:** If no configured labels exist or all are empty, {{site.mesh_product_name}} uses the pod's ServiceAccount name
 3. **Default behavior:** By default, `workloadLabels` is empty, so ServiceAccount name is used
 
 **Protection:** Cannot be manually set as a label on pods; {{site.mesh_product_name}} will reject pod creation/updates with this label


### PR DESCRIPTION
## Motivation

Workload docs incorrectly implied that `kuma.io/workload` annotation is manually added to pods. Actually, label is automatically generated by control plane from pod labels (configurable via `runtime.kubernetes.workloadLabels`) with fallback to ServiceAccount name.

## Implementation information

- Updated example to show ServiceAccount as default source of workload identifier
- Clarified "Workload label management" section with step-by-step logic
- Removed references to manual annotation
- Kept protection note about label (not annotation) being rejected

## Supporting documentation

Based on Kuma source code:
- `pkg/config/plugins/runtime/k8s/config.go:159-162` - WorkloadLabels config
- `pkg/plugins/runtime/k8s/controllers/pod_converter.go:469-476` - computeWorkloadName logic