### PR TITLE
fix(ruby): path handling in Jekyll plugin file loaders

### DIFF
--- a/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/common/path_helpers.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/common/path_helpers.rb
@@ -1,18 +1,122 @@
 # frozen_string_literal: true
 
+require 'pathname'
+
 module Jekyll
   module KumaPlugins
     module Common
+      # Shared safe path handling for file reads rooted in configured asset directories.
       module PathHelpers
         PATHS_CONFIG = 'mesh_raw_generated_paths'
         DEFAULT_PATHS = ['app/assets'].freeze
 
-        def read_file(paths, file_name)
+        def optional_path_segment(segment)
+          value = segment.to_s.strip
+          value.empty? ? nil : value
+        end
+
+        def build_relative_path(*segments)
+          normalized_segments = segments.flatten.compact.map { |segment| sanitize_relative_path(segment) }
+          normalized_segments.reject!(&:empty?)
+          raise ArgumentError, 'file path must not be empty' if normalized_segments.empty?
+
+          File.join(*normalized_segments)
+        end
+
+        def find_file(paths, file_name)
+          relative_path = sanitize_relative_path(file_name)
+
           paths.each do |path|
-            file_path = File.join(path, file_name)
-            return File.open(file_path) if File.readable? file_path
+            root = canonical_path(path)
+            file_path = safe_join(root, relative_path)
+            next unless File.file?(file_path) && File.readable?(file_path)
+
+            validate_realpath!(file_path, root, relative_path)
+            return file_path
+          rescue Errno::ENOENT
+            next
           end
-          raise "couldn't read #{file_name} in any of these paths: #{paths}"
+
+          raise "couldn't read #{relative_path} in any of these paths: #{paths}"
+        end
+
+        def read_file(paths, file_name)
+          file = open_validated_file(paths, file_name)
+          file.read
+        ensure
+          file&.close
+        end
+
+        def read_file_content(paths, file_name)
+          read_file(paths, file_name)
+        end
+
+        private
+
+        def sanitize_relative_path(path)
+          candidate = path.to_s.strip
+          raise ArgumentError, 'file path must not be empty' if candidate.empty?
+
+          pathname = Pathname.new(candidate)
+          raise ArgumentError, "absolute paths are not allowed: #{path}" if pathname.absolute?
+
+          segments = pathname.each_filename.to_a
+          raise ArgumentError, "path traversal is not allowed: #{path}" if segments.any? { |segment| segment.empty? || %w[. ..].include?(segment) }
+
+          File.join(*segments)
+        end
+
+        def safe_join(root, relative_path)
+          candidate = File.expand_path(relative_path, root)
+          raise ArgumentError, "path traversal is not allowed: #{relative_path}" unless path_within_root?(candidate, root)
+
+          candidate
+        end
+
+        def validate_realpath!(path, root, relative_path)
+          resolved_candidate = File.realpath(path)
+          raise ArgumentError, "path traversal is not allowed: #{relative_path}" unless path_within_root?(resolved_candidate, root)
+        end
+
+        def open_validated_file(paths, file_name)
+          relative_path = sanitize_relative_path(file_name)
+          file = nil
+
+          paths.each do |path|
+            root = canonical_path(path)
+            file_path = safe_join(root, relative_path)
+            next unless File.file?(file_path) && File.readable?(file_path)
+
+            file = File.new(file_path)
+            validate_realpath!(file.path, root, relative_path)
+            return file
+          rescue Errno::ENOENT
+            file&.close
+            next
+          end
+
+          raise "couldn't read #{relative_path} in any of these paths: #{paths}"
+        ensure
+          file&.close if $ERROR_INFO
+        end
+
+        def canonical_path(path)
+          canonical_paths.fetch(path.to_s) do
+            expanded_path = File.expand_path(path.to_s)
+            canonical_paths[path.to_s] = File.exist?(expanded_path) ? File.realpath(expanded_path) : expanded_path
+          end
+        end
+
+        def path_within_root?(candidate, root)
+          candidate == root || candidate.start_with?(root_prefix(root))
+        end
+
+        def canonical_paths
+          @canonical_paths ||= {}
+        end
+
+        def root_prefix(root)
+          root.end_with?(File::SEPARATOR) ? root : "#{root}#{File::SEPARATOR}"
         end
       end
     end

--- a/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/common/path_helpers.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/common/path_helpers.rb
@@ -31,8 +31,7 @@ module Jekyll
             file_path = safe_join(root, relative_path)
             next unless File.file?(file_path) && File.readable?(file_path)
 
-            validate_realpath!(file_path, root, relative_path)
-            return file_path
+            return validate_realpath!(file_path, root, relative_path)
           rescue Errno::ENOENT
             next
           end
@@ -76,6 +75,8 @@ module Jekyll
         def validate_realpath!(path, root, relative_path)
           resolved_candidate = File.realpath(path)
           raise ArgumentError, "path traversal is not allowed: #{relative_path}" unless path_within_root?(resolved_candidate, root)
+
+          resolved_candidate
         end
 
         def open_validated_file(paths, file_name)
@@ -87,8 +88,8 @@ module Jekyll
             file_path = safe_join(root, relative_path)
             next unless File.file?(file_path) && File.readable?(file_path)
 
-            file = File.new(file_path)
-            validate_realpath!(file.path, root, relative_path)
+            resolved_file_path = validate_realpath!(file_path, root, relative_path)
+            file = File.new(resolved_file_path)
             return file
           rescue Errno::ENOENT
             file&.close

--- a/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/embed.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/embed.rb
@@ -34,13 +34,12 @@ module Jekyll
           def read_and_filter_content(site_config, release)
             file_path = resolve_embed_path(release)
             base_paths = site_config.fetch(PATHS_CONFIG, DEFAULT_PATHS)
-            content = read_file(base_paths, file_path).read
+            content = read_file_content(base_paths, file_path)
             apply_link_filter(content, site_config)
           end
 
           def resolve_embed_path(release)
-            version_prefix = @versioned ? release : ''
-            File.join(version_prefix, 'raw', @file)
+            build_relative_path(@versioned ? optional_path_segment(release) : nil, 'raw', @file)
           end
 
           def apply_link_filter(content, site_config)

--- a/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/jsonschema.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/jsonschema.rb
@@ -82,20 +82,23 @@ module Jekyll
 
           def proto_loader(name)
             lambda do |paths, release|
-              JSON.parse(read_file(paths, File.join(release.to_s, 'raw', 'protos', "#{name}.json")).read)
+              JSON.parse(read_file_content(paths, build_relative_path(optional_path_segment(release), 'raw', 'protos', "#{name}.json")))
             end
           end
 
           def crd_loader(name)
             lambda do |paths, release|
-              d = YAML.safe_load(read_file(paths, File.join(release.to_s, 'raw', 'crds', "#{name}.yaml")).read)
+              d = YAML.safe_load(read_file_content(paths, build_relative_path(optional_path_segment(release), 'raw', 'crds', "#{name}.yaml")))
               d['spec']['versions'][0]['schema']['openAPIV3Schema']
             end
           end
 
           def policy_loader(name)
             lambda do |paths, release|
-              d = YAML.safe_load(read_file(paths, File.join(release.to_s, 'raw', 'crds', "kuma.io_#{name.downcase}.yaml")).read)
+              d = YAML.safe_load(
+                read_file_content(paths, build_relative_path(optional_path_segment(release), 'raw', 'crds',
+                                                             "kuma.io_#{name.downcase}.yaml"))
+              )
               d['spec']['versions'][0]['schema']['openAPIV3Schema']['properties']['spec']
             end
           end

--- a/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/rbacresources.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/rbacresources.rb
@@ -12,7 +12,10 @@
 #    in the site's `_config.yml`. If not set, it defaults to: ['app/assets'].
 # 3. For each base path, it checks if the file exists at:
 #       {{ base_path }}/{{ release }}/raw/{{ filename }}
-# 4. If still not found, the plugin raises an error.
+#    When `page.release` is blank, it falls back to:
+#       {{ base_path }}/raw/{{ filename }}
+# 4. If still not found in the configured paths, the plugin raises an error.
+#    It does not fall back to arbitrary absolute or relative filesystem paths.
 #
 # Usage examples:
 #   {% rbacresources %}                            # uses default filename `rbac.yaml`
@@ -25,10 +28,15 @@ module Jekyll
   module KumaPlugins
     module Liquid
       module Tags
+        # Renders RBAC resources from a YAML file rooted in the configured raw asset paths.
         class RbacResources < ::Liquid::Tag
           include Jekyll::KumaPlugins::Common::PathHelpers
 
           DEFAULT_FILENAME = 'rbac.yaml'
+          SAFE_YAML_OPTIONS = {
+            permitted_classes: [],
+            aliases: false
+          }.freeze
 
           def initialize(tag_name, text, tokens)
             super
@@ -44,7 +52,7 @@ module Jekyll
           RBAC_KINDS = %w[ClusterRole ClusterRoleBinding Role RoleBinding].freeze
 
           def render(context)
-            yaml_content = YAML.load_stream(read_rbac_file(context))
+            yaml_content = YAML.safe_load_stream(read_rbac_file(context), **SAFE_YAML_OPTIONS)
             grouped = filter_rbac_resources(yaml_content)
             tab_output = grouped.map { |kind, docs| generate_kind_tab(kind, docs) }.join("\n")
 

--- a/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/rbacresources.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/rbacresources.rb
@@ -12,22 +12,22 @@
 #    in the site's `_config.yml`. If not set, it defaults to: ['app/assets'].
 # 3. For each base path, it checks if the file exists at:
 #       {{ base_path }}/{{ release }}/raw/{{ filename }}
-# 4. If not found, it falls back to checking if the provided filename is an absolute or relative path.
-# 5. If still not found, the plugin raises an error.
+# 4. If still not found, the plugin raises an error.
 #
 # Usage examples:
 #   {% rbacresources %}                            # uses default filename `rbac.yaml`
 #   {% rbacresources filename=custom-rbac.yaml %}  # uses a custom filename
 
 require 'yaml'
+require_relative '../../common/path_helpers'
 
 module Jekyll
   module KumaPlugins
     module Liquid
       module Tags
         class RbacResources < ::Liquid::Tag
-          PATHS_CONFIG = 'mesh_raw_generated_paths'
-          DEFAULT_PATHS = ['app/assets'].freeze
+          include Jekyll::KumaPlugins::Common::PathHelpers
+
           DEFAULT_FILENAME = 'rbac.yaml'
 
           def initialize(tag_name, text, tokens)
@@ -44,8 +44,7 @@ module Jekyll
           RBAC_KINDS = %w[ClusterRole ClusterRoleBinding Role RoleBinding].freeze
 
           def render(context)
-            filename = resolve_file_path(context)
-            yaml_content = YAML.load_stream(File.read(filename))
+            yaml_content = YAML.load_stream(read_rbac_file(context))
             grouped = filter_rbac_resources(yaml_content)
             tab_output = grouped.map { |kind, docs| generate_kind_tab(kind, docs) }.join("\n")
 
@@ -90,22 +89,17 @@ module Jekyll
             SUBTAB
           end
 
-          def resolve_file_path(context)
+          def read_rbac_file(context)
             site_config = context.registers[:site].config
             page_data = context.registers[:page]
-            release = page_data['release'].to_s.strip
+            release = optional_path_segment(page_data['release'])
             base_paths = site_config.fetch(PATHS_CONFIG, DEFAULT_PATHS)
 
-            base_paths.each do |base_path|
-              candidate = File.join(base_path, release, 'raw', @params['filename'])
-              return candidate if File.exist?(candidate)
-            end
+            read_file_content(base_paths, build_relative_path(release, 'raw', @params['filename']))
+          rescue RuntimeError => e
+            raise unless e.message.start_with?("couldn't read ")
 
-            fallback = @params['filename']
-            return fallback if File.exist?(fallback)
-
-            raise ArgumentError,
-                  "File not found: #{@params['filename']} (searched in configured paths and as absolute path)"
+            raise ArgumentError, "File not found: #{@params['filename']} (searched in configured paths: #{base_paths})"
           end
         end
       end

--- a/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/schema_viewer.rb
+++ b/jekyll-kuma-plugins/lib/jekyll/kuma_plugins/liquid/tags/schema_viewer.rb
@@ -75,20 +75,23 @@ module Jekyll
 
           def proto_loader(name)
             lambda do |paths, release|
-              JSON.parse(read_file(paths, File.join(release.to_s, 'raw', 'protos', "#{name}.json")).read)
+              JSON.parse(read_file_content(paths, build_relative_path(optional_path_segment(release), 'raw', 'protos', "#{name}.json")))
             end
           end
 
           def crd_loader(name)
             lambda do |paths, release|
-              d = YAML.safe_load(read_file(paths, File.join(release.to_s, 'raw', 'crds', "#{name}.yaml")).read)
+              d = YAML.safe_load(read_file_content(paths, build_relative_path(optional_path_segment(release), 'raw', 'crds', "#{name}.yaml")))
               d['spec']['versions'][0]['schema']['openAPIV3Schema']
             end
           end
 
           def policy_loader(name)
             lambda do |paths, release|
-              d = YAML.safe_load(read_file(paths, File.join(release.to_s, 'raw', 'crds', "kuma.io_#{name.downcase}.yaml")).read)
+              d = YAML.safe_load(
+                read_file_content(paths, build_relative_path(optional_path_segment(release), 'raw', 'crds',
+                                                             "kuma.io_#{name.downcase}.yaml"))
+              )
               d['spec']['versions'][0]['schema']['openAPIV3Schema']['properties']['spec']
             end
           end

--- a/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/common/path_helpers_spec.rb
+++ b/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/common/path_helpers_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'tmpdir'
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe Jekyll::KumaPlugins::Common::PathHelpers do
+  subject(:helper) { Class.new { include Jekyll::KumaPlugins::Common::PathHelpers }.new }
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @tmpdir = dir
+      example.run
+    end
+  end
+
+  let(:assets_path) { File.join(@tmpdir, 'app/assets') }
+  let(:raw_path) { File.join(assets_path, '1.0', 'raw') }
+  let(:allowed_path) { File.join(raw_path, 'allowed.txt') }
+  let(:secret_path) { File.join(@tmpdir, 'secret.txt') }
+
+  before do
+    FileUtils.mkdir_p(raw_path)
+    File.write(allowed_path, 'allowed')
+    File.write(secret_path, 'secret')
+  end
+
+  describe '#build_relative_path' do
+    it 'preserves nested paths inside the intended directory' do
+      expect(helper.build_relative_path('1.0', 'raw', 'nested/allowed.txt')).to eq(File.join('1.0', 'raw', 'nested/allowed.txt'))
+    end
+
+    it 'rejects traversal segments' do
+      expect do
+        helper.build_relative_path('1.0', 'raw', '../../secret.txt')
+      end.to raise_error(ArgumentError, /path traversal/)
+    end
+  end
+
+  describe '#read_file' do
+    it 'reads files inside the configured root' do
+      expect(helper.read_file([assets_path], helper.build_relative_path('1.0', 'raw', 'allowed.txt'))).to eq('allowed')
+    end
+
+    it 'closes the file handle after reading' do
+      file = File.new(allowed_path)
+      allow(helper).to receive(:open_validated_file).and_return(file)
+
+      expect(helper.read_file([assets_path], 'allowed.txt')).to eq('allowed')
+      expect(file).to be_closed
+    end
+
+    it 'rejects symlink escapes inside the configured root' do
+      File.symlink(secret_path, File.join(raw_path, 'linked.txt'))
+
+      expect do
+        helper.read_file([assets_path], helper.build_relative_path('1.0', 'raw', 'linked.txt'))
+      end.to raise_error(ArgumentError, /path traversal/)
+    end
+
+    it 'memoizes canonical paths for configured roots' do
+      realpath_calls = []
+      allow(File).to receive(:realpath).and_wrap_original do |original, path|
+        realpath_calls << path
+        original.call(path)
+      end
+
+      2.times do
+        helper.read_file([assets_path], helper.build_relative_path('1.0', 'raw', 'allowed.txt'))
+      end
+
+      expect(realpath_calls.count { |path| path == assets_path }).to eq(1)
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/common/path_helpers_spec.rb
+++ b/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/common/path_helpers_spec.rb
@@ -51,11 +51,14 @@ RSpec.describe Jekyll::KumaPlugins::Common::PathHelpers do
     end
 
     it 'rejects symlink escapes inside the configured root' do
-      File.symlink(secret_path, File.join(raw_path, 'linked.txt'))
+      linked_path = File.join(raw_path, 'linked.txt')
+      File.symlink(secret_path, linked_path)
+      allow(File).to receive(:new).and_call_original
 
       expect do
         helper.read_file([assets_path], helper.build_relative_path('1.0', 'raw', 'linked.txt'))
       end.to raise_error(ArgumentError, /path traversal/)
+      expect(File).not_to have_received(:new).with(linked_path)
     end
 
     it 'memoizes canonical paths for configured roots' do

--- a/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/embed_spec.rb
+++ b/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/embed_spec.rb
@@ -15,15 +15,18 @@ RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::Embed do
   end
 
   let(:assets_path) { File.join(@tmpdir, 'app/assets') }
-  let(:release) { '1.0' }
+  let(:versioned_release) { '1.0' }
+  let(:release) { versioned_release }
   let(:site) { Struct.new(:config).new({ 'mesh_raw_generated_paths' => [assets_path] }) }
   let(:context) { Liquid::Context.new({}, {}, { site: site, page: { 'release' => release } }) }
+  let(:versioned_content) { 'kind: Deployment # versioned' }
+  let(:unversioned_content) { 'kind: Deployment # unversioned' }
 
   before do
-    FileUtils.mkdir_p(File.join(assets_path, release, 'raw'))
+    FileUtils.mkdir_p(File.join(assets_path, versioned_release, 'raw'))
     FileUtils.mkdir_p(File.join(assets_path, 'raw'))
-    File.write(File.join(assets_path, release, 'raw', 'kuma-cp.yaml'), 'kind: Deployment')
-    File.write(File.join(assets_path, 'raw', 'kuma-cp.yaml'), 'kind: Deployment')
+    File.write(File.join(assets_path, versioned_release, 'raw', 'kuma-cp.yaml'), versioned_content)
+    File.write(File.join(assets_path, 'raw', 'kuma-cp.yaml'), unversioned_content)
     File.write(File.join(@tmpdir, 'secret.txt'), 'secret')
   end
 
@@ -31,7 +34,7 @@ RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::Embed do
     let(:markup) { 'kuma-cp.yaml versioned' }
 
     it 'reads the file from the release raw directory' do
-      expect(tag.render(context)).to eq('kind: Deployment')
+      expect(tag.render(context)).to eq(versioned_content)
     end
   end
 
@@ -48,7 +51,7 @@ RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::Embed do
     let(:markup) { 'kuma-cp.yaml versioned' }
 
     it 'falls back to the unversioned raw directory' do
-      expect(tag.render(context)).to eq('kind: Deployment')
+      expect(tag.render(context)).to eq(unversioned_content)
     end
   end
 end

--- a/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/embed_spec.rb
+++ b/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/embed_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'tmpdir'
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::Embed do
+  subject(:tag) { described_class.send(:new, 'embed', markup, Liquid::ParseContext.new) }
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @tmpdir = dir
+      example.run
+    end
+  end
+
+  let(:assets_path) { File.join(@tmpdir, 'app/assets') }
+  let(:release) { '1.0' }
+  let(:site) { Struct.new(:config).new({ 'mesh_raw_generated_paths' => [assets_path] }) }
+  let(:context) { Liquid::Context.new({}, {}, { site: site, page: { 'release' => release } }) }
+
+  before do
+    FileUtils.mkdir_p(File.join(assets_path, release, 'raw'))
+    FileUtils.mkdir_p(File.join(assets_path, 'raw'))
+    File.write(File.join(assets_path, release, 'raw', 'kuma-cp.yaml'), 'kind: Deployment')
+    File.write(File.join(assets_path, 'raw', 'kuma-cp.yaml'), 'kind: Deployment')
+    File.write(File.join(@tmpdir, 'secret.txt'), 'secret')
+  end
+
+  context 'with a valid versioned file' do
+    let(:markup) { 'kuma-cp.yaml versioned' }
+
+    it 'reads the file from the release raw directory' do
+      expect(tag.render(context)).to eq('kind: Deployment')
+    end
+  end
+
+  context 'with a traversal attempt' do
+    let(:markup) { '../../../../secret.txt versioned' }
+
+    it 'returns nil instead of reading outside the raw directory' do
+      expect(tag.render(context)).to be_nil
+    end
+  end
+
+  context 'with a blank release on a versioned tag' do
+    let(:release) { '' }
+    let(:markup) { 'kuma-cp.yaml versioned' }
+
+    it 'falls back to the unversioned raw directory' do
+      expect(tag.render(context)).to eq('kind: Deployment')
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/jsonschema_spec.rb
+++ b/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/jsonschema_spec.rb
@@ -16,15 +16,18 @@ RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::JsonSchema do
   end
 
   let(:assets_path) { File.join(@tmpdir, 'app/assets') }
-  let(:release) { '1.0' }
+  let(:versioned_release) { '1.0' }
+  let(:release) { versioned_release }
   let(:site) { Struct.new(:config).new({ 'mesh_raw_generated_paths' => [assets_path] }) }
   let(:context) { Liquid::Context.new({}, {}, { site: site, page: { 'release' => release } }) }
+  let(:versioned_schema) { { 'title' => 'Mesh versioned', 'type' => 'object' } }
+  let(:unversioned_schema) { { 'title' => 'Mesh unversioned', 'type' => 'object' } }
 
   before do
-    FileUtils.mkdir_p(File.join(assets_path, release, 'raw', 'protos'))
+    FileUtils.mkdir_p(File.join(assets_path, versioned_release, 'raw', 'protos'))
     FileUtils.mkdir_p(File.join(assets_path, 'raw', 'protos'))
-    File.write(File.join(assets_path, release, 'raw', 'protos', 'Mesh.json'), JSON.dump({ 'title' => 'Mesh', 'type' => 'object' }))
-    File.write(File.join(assets_path, 'raw', 'protos', 'Mesh.json'), JSON.dump({ 'title' => 'Mesh', 'type' => 'object' }))
+    File.write(File.join(assets_path, versioned_release, 'raw', 'protos', 'Mesh.json'), JSON.dump(versioned_schema))
+    File.write(File.join(assets_path, 'raw', 'protos', 'Mesh.json'), JSON.dump(unversioned_schema))
     File.write(File.join(@tmpdir, 'secret.json'), JSON.dump({ 'title' => 'Secret' }))
   end
 
@@ -32,7 +35,10 @@ RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::JsonSchema do
     let(:markup) { 'Mesh type=proto' }
 
     it 'renders the schema from the release raw directory' do
-      expect(tag.render(context)).to include('const data = {"title":"Mesh","type":"object"};')
+      output = tag.render(context)
+
+      expect(output).to include("const data = #{JSON.dump(versioned_schema)};")
+      expect(output).not_to include(JSON.dump(unversioned_schema))
     end
   end
 
@@ -49,7 +55,10 @@ RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::JsonSchema do
     let(:markup) { 'Mesh type=proto' }
 
     it 'loads the schema from the unversioned raw directory' do
-      expect(tag.render(context)).to include('const data = {"title":"Mesh","type":"object"};')
+      output = tag.render(context)
+
+      expect(output).to include("const data = #{JSON.dump(unversioned_schema)};")
+      expect(output).not_to include(JSON.dump(versioned_schema))
     end
   end
 end

--- a/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/jsonschema_spec.rb
+++ b/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/jsonschema_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+require 'tmpdir'
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::JsonSchema do
+  subject(:tag) { described_class.send(:new, 'json_schema', markup, Liquid::ParseContext.new) }
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @tmpdir = dir
+      example.run
+    end
+  end
+
+  let(:assets_path) { File.join(@tmpdir, 'app/assets') }
+  let(:release) { '1.0' }
+  let(:site) { Struct.new(:config).new({ 'mesh_raw_generated_paths' => [assets_path] }) }
+  let(:context) { Liquid::Context.new({}, {}, { site: site, page: { 'release' => release } }) }
+
+  before do
+    FileUtils.mkdir_p(File.join(assets_path, release, 'raw', 'protos'))
+    FileUtils.mkdir_p(File.join(assets_path, 'raw', 'protos'))
+    File.write(File.join(assets_path, release, 'raw', 'protos', 'Mesh.json'), JSON.dump({ 'title' => 'Mesh', 'type' => 'object' }))
+    File.write(File.join(assets_path, 'raw', 'protos', 'Mesh.json'), JSON.dump({ 'title' => 'Mesh', 'type' => 'object' }))
+    File.write(File.join(@tmpdir, 'secret.json'), JSON.dump({ 'title' => 'Secret' }))
+  end
+
+  context 'with a valid proto schema' do
+    let(:markup) { 'Mesh type=proto' }
+
+    it 'renders the schema from the release raw directory' do
+      expect(tag.render(context)).to include('const data = {"title":"Mesh","type":"object"};')
+    end
+  end
+
+  context 'with a traversal attempt' do
+    let(:markup) { '../../../../../secret type=proto' }
+
+    it 'returns nil instead of reading outside the raw directory' do
+      expect(tag.render(context)).to be_nil
+    end
+  end
+
+  context 'with a blank release' do
+    let(:release) { '' }
+    let(:markup) { 'Mesh type=proto' }
+
+    it 'loads the schema from the unversioned raw directory' do
+      expect(tag.render(context)).to include('const data = {"title":"Mesh","type":"object"};')
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/rbacresources_spec.rb
+++ b/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/rbacresources_spec.rb
@@ -15,31 +15,40 @@ RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::RbacResources do
   end
 
   let(:assets_path) { File.join(@tmpdir, 'app/assets') }
-  let(:release) { '1.0' }
+  let(:versioned_release) { '1.0' }
+  let(:release) { versioned_release }
   let(:site) { Struct.new(:config).new({ 'mesh_raw_generated_paths' => [assets_path] }) }
   let(:context) { Liquid::Context.new({}, {}, { site: site, page: { 'release' => release } }) }
   let(:template) { instance_double(Liquid::Template, render: 'rendered tabs') }
+  let(:versioned_rbac_name) { 'kuma-control-plane-versioned' }
+  let(:unversioned_rbac_name) { 'kuma-control-plane-unversioned' }
+  let(:versioned_rbac_content) do
+    <<~YAML
+      ---
+      kind: ClusterRole
+      metadata:
+        name: #{versioned_rbac_name}
+    YAML
+  end
+  let(:unversioned_rbac_content) do
+    <<~YAML
+      ---
+      kind: ClusterRole
+      metadata:
+        name: #{unversioned_rbac_name}
+    YAML
+  end
 
   before do
-    FileUtils.mkdir_p(File.join(assets_path, release, 'raw'))
+    FileUtils.mkdir_p(File.join(assets_path, versioned_release, 'raw'))
     FileUtils.mkdir_p(File.join(assets_path, 'raw'))
     File.write(
-      File.join(assets_path, release, 'raw', 'rbac.yaml'),
-      <<~YAML
-        ---
-        kind: ClusterRole
-        metadata:
-          name: kuma-control-plane
-      YAML
+      File.join(assets_path, versioned_release, 'raw', 'rbac.yaml'),
+      versioned_rbac_content
     )
     File.write(
       File.join(assets_path, 'raw', 'rbac.yaml'),
-      <<~YAML
-        ---
-        kind: ClusterRole
-        metadata:
-          name: kuma-control-plane
-      YAML
+      unversioned_rbac_content
     )
     File.write(
       File.join(@tmpdir, 'secret.yaml'),
@@ -50,13 +59,18 @@ RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::RbacResources do
           name: top-secret
       YAML
     )
-    allow(Liquid::Template).to receive(:parse).and_return(template)
   end
 
   context 'with the default filename' do
     let(:markup) { '' }
 
     it 'reads RBAC resources from the release raw directory' do
+      expect(Liquid::Template).to receive(:parse) do |output|
+        expect(output).to include(versioned_rbac_name)
+        expect(output).not_to include(unversioned_rbac_name)
+        template
+      end
+
       expect(tag.render(context)).to eq('rendered tabs')
     end
   end
@@ -74,7 +88,22 @@ RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::RbacResources do
     let(:markup) { '' }
 
     it 'loads the default RBAC file from the unversioned raw directory' do
+      expect(Liquid::Template).to receive(:parse) do |output|
+        expect(output).to include(unversioned_rbac_name)
+        expect(output).not_to include(versioned_rbac_name)
+        template
+      end
+
       expect(tag.render(context)).to eq('rendered tabs')
+    end
+  end
+
+  context 'with unsafe YAML object tags' do
+    let(:markup) { '' }
+    let(:versioned_rbac_content) { "--- !ruby/object:Object {}\n" }
+
+    it 'rejects deserialization of Ruby objects' do
+      expect { tag.render(context) }.to raise_error(Psych::DisallowedClass, /Object/)
     end
   end
 end

--- a/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/rbacresources_spec.rb
+++ b/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/rbacresources_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'tmpdir'
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::RbacResources do
+  subject(:tag) { described_class.send(:new, 'rbacresources', markup, Liquid::ParseContext.new) }
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @tmpdir = dir
+      example.run
+    end
+  end
+
+  let(:assets_path) { File.join(@tmpdir, 'app/assets') }
+  let(:release) { '1.0' }
+  let(:site) { Struct.new(:config).new({ 'mesh_raw_generated_paths' => [assets_path] }) }
+  let(:context) { Liquid::Context.new({}, {}, { site: site, page: { 'release' => release } }) }
+  let(:template) { instance_double(Liquid::Template, render: 'rendered tabs') }
+
+  before do
+    FileUtils.mkdir_p(File.join(assets_path, release, 'raw'))
+    FileUtils.mkdir_p(File.join(assets_path, 'raw'))
+    File.write(
+      File.join(assets_path, release, 'raw', 'rbac.yaml'),
+      <<~YAML
+        ---
+        kind: ClusterRole
+        metadata:
+          name: kuma-control-plane
+      YAML
+    )
+    File.write(
+      File.join(assets_path, 'raw', 'rbac.yaml'),
+      <<~YAML
+        ---
+        kind: ClusterRole
+        metadata:
+          name: kuma-control-plane
+      YAML
+    )
+    File.write(
+      File.join(@tmpdir, 'secret.yaml'),
+      <<~YAML
+        ---
+        kind: Secret
+        metadata:
+          name: top-secret
+      YAML
+    )
+    allow(Liquid::Template).to receive(:parse).and_return(template)
+  end
+
+  context 'with the default filename' do
+    let(:markup) { '' }
+
+    it 'reads RBAC resources from the release raw directory' do
+      expect(tag.render(context)).to eq('rendered tabs')
+    end
+  end
+
+  context 'with a traversal attempt' do
+    let(:markup) { 'filename=../../../../secret.yaml' }
+
+    it 'raises instead of reading outside the raw directory' do
+      expect { tag.render(context) }.to raise_error(ArgumentError, /path traversal/)
+    end
+  end
+
+  context 'with a blank release' do
+    let(:release) { '' }
+    let(:markup) { '' }
+
+    it 'loads the default RBAC file from the unversioned raw directory' do
+      expect(tag.render(context)).to eq('rendered tabs')
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/schema_viewer_spec.rb
+++ b/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/schema_viewer_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+require 'tmpdir'
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::SchemaViewer do
+  subject(:tag) { described_class.send(:new, 'schema_viewer', markup, Liquid::ParseContext.new) }
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @tmpdir = dir
+      example.run
+    end
+  end
+
+  let(:assets_path) { File.join(@tmpdir, 'app/assets') }
+  let(:release) { '1.0' }
+  let(:site) { Struct.new(:config).new({ 'mesh_raw_generated_paths' => [assets_path] }) }
+  let(:context) { Liquid::Context.new({}, {}, { site: site, page: { 'release' => release } }) }
+
+  before do
+    FileUtils.mkdir_p(File.join(assets_path, release, 'raw', 'protos'))
+    FileUtils.mkdir_p(File.join(assets_path, 'raw', 'protos'))
+    File.write(
+      File.join(assets_path, release, 'raw', 'protos', 'Mesh.json'),
+      JSON.dump({
+                  'properties' => {
+                    'mesh' => {
+                      'type' => 'string',
+                      'description' => 'Mesh name'
+                    }
+                  }
+                })
+    )
+    File.write(
+      File.join(assets_path, 'raw', 'protos', 'Mesh.json'),
+      JSON.dump({
+                  'properties' => {
+                    'mesh' => {
+                      'type' => 'string',
+                      'description' => 'Mesh name'
+                    }
+                  }
+                })
+    )
+    File.write(
+      File.join(@tmpdir, 'secret.json'),
+      JSON.dump({
+                  'properties' => {
+                    'stolen' => {
+                      'type' => 'string'
+                    }
+                  }
+                })
+    )
+  end
+
+  context 'with a valid proto schema' do
+    let(:markup) { 'Mesh type=proto' }
+
+    it 'renders schema properties from the release raw directory' do
+      expect(tag.render(context)).to include('schema-viewer__name">mesh<')
+    end
+  end
+
+  context 'with a traversal attempt' do
+    let(:markup) { '../../../../../secret type=proto' }
+
+    it 'renders an error instead of reading outside the raw directory' do
+      output = tag.render(context)
+
+      expect(output).to include('Error loading schema')
+      expect(output).not_to include('stolen')
+      expect(output).to include('path traversal')
+    end
+  end
+
+  context 'with a blank release' do
+    let(:release) { '' }
+    let(:markup) { 'Mesh type=proto' }
+
+    it 'loads the schema from the unversioned raw directory' do
+      expect(tag.render(context)).to include('schema-viewer__name">mesh<')
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/schema_viewer_spec.rb
+++ b/jekyll-kuma-plugins/spec/jekyll/kuma_plugins/liquid/tags/schema_viewer_spec.rb
@@ -16,34 +16,41 @@ RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::SchemaViewer do
   end
 
   let(:assets_path) { File.join(@tmpdir, 'app/assets') }
-  let(:release) { '1.0' }
+  let(:versioned_release) { '1.0' }
+  let(:release) { versioned_release }
   let(:site) { Struct.new(:config).new({ 'mesh_raw_generated_paths' => [assets_path] }) }
   let(:context) { Liquid::Context.new({}, {}, { site: site, page: { 'release' => release } }) }
+  let(:versioned_schema) do
+    {
+      'properties' => {
+        'versioned' => {
+          'type' => 'string',
+          'description' => 'Versioned schema'
+        }
+      }
+    }
+  end
+  let(:unversioned_schema) do
+    {
+      'properties' => {
+        'fallback' => {
+          'type' => 'string',
+          'description' => 'Fallback schema'
+        }
+      }
+    }
+  end
 
   before do
-    FileUtils.mkdir_p(File.join(assets_path, release, 'raw', 'protos'))
+    FileUtils.mkdir_p(File.join(assets_path, versioned_release, 'raw', 'protos'))
     FileUtils.mkdir_p(File.join(assets_path, 'raw', 'protos'))
     File.write(
-      File.join(assets_path, release, 'raw', 'protos', 'Mesh.json'),
-      JSON.dump({
-                  'properties' => {
-                    'mesh' => {
-                      'type' => 'string',
-                      'description' => 'Mesh name'
-                    }
-                  }
-                })
+      File.join(assets_path, versioned_release, 'raw', 'protos', 'Mesh.json'),
+      JSON.dump(versioned_schema)
     )
     File.write(
       File.join(assets_path, 'raw', 'protos', 'Mesh.json'),
-      JSON.dump({
-                  'properties' => {
-                    'mesh' => {
-                      'type' => 'string',
-                      'description' => 'Mesh name'
-                    }
-                  }
-                })
+      JSON.dump(unversioned_schema)
     )
     File.write(
       File.join(@tmpdir, 'secret.json'),
@@ -61,7 +68,10 @@ RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::SchemaViewer do
     let(:markup) { 'Mesh type=proto' }
 
     it 'renders schema properties from the release raw directory' do
-      expect(tag.render(context)).to include('schema-viewer__name">mesh<')
+      output = tag.render(context)
+
+      expect(output).to include('schema-viewer__name">versioned<')
+      expect(output).not_to include('schema-viewer__name">fallback<')
     end
   end
 
@@ -82,7 +92,10 @@ RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::SchemaViewer do
     let(:markup) { 'Mesh type=proto' }
 
     it 'loads the schema from the unversioned raw directory' do
-      expect(tag.render(context)).to include('schema-viewer__name">mesh<')
+      output = tag.render(context)
+
+      expect(output).to include('schema-viewer__name">fallback<')
+      expect(output).not_to include('schema-viewer__name">versioned<')
     end
   end
 end

--- a/spec/kuma_plugins/liquid/tags/rbacresources_spec.rb
+++ b/spec/kuma_plugins/liquid/tags/rbacresources_spec.rb
@@ -1,14 +1,43 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+require 'tmpdir'
+
 RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::RbacResources do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @tmpdir = dir
+      example.run
+    end
+  end
+
+  let(:release) do
+    Jekyll::GeneratorSingleSource::Product::Release.new(
+      {
+        'release' => '2.11.x',
+        'edition' => 'kuma'
+      }
+    )
+  end
+
+  let(:assets_path) { File.join(@tmpdir, 'app/assets') }
+
+  before do
+    FileUtils.mkdir_p(File.join(assets_path, release.to_s, 'raw'))
+    FileUtils.cp('spec/fixtures/rbac.yaml', File.join(assets_path, release.to_s, 'raw', 'rbac.yaml'))
+  end
+
   shared_examples 'rbac resources rendering' do |input_file, golden_file|
     it "renders correctly for #{input_file}" do
-      site = Jekyll::Site.new(Jekyll.configuration({}))
+      site = Jekyll::Site.new(Jekyll.configuration(
+                                {
+                                  'mesh_raw_generated_paths' => [assets_path]
+                                }
+                              ))
       context = Liquid::Context.new({}, {}, {
                                       page: {
                                         'edition' => 'kuma',
-                                        'release' => Jekyll::GeneratorSingleSource::Product::Release.new({ 'release' => '2.11.x',
-                                                                                                           'edition' => 'kuma' })
+                                        'release' => release
                                       },
                                       site: site
                                     })
@@ -23,7 +52,7 @@ RSpec.describe Jekyll::KumaPlugins::Liquid::Tags::RbacResources do
 
   describe 'rendering test' do
     include_examples 'rbac resources rendering',
-                     'spec/fixtures/rbac.yaml',
+                     'rbac.yaml',
                      'spec/fixtures/rbac.golden.html'
   end
 end


### PR DESCRIPTION
## Summary

This tightens file loading in `jekyll-kuma-plugins` so the affected Liquid tags only read from the configured raw asset roots.

The change centralizes path validation in `PathHelpers`, blocks traversal attempts and symlink escapes, removes the `rbacresources` fallback to arbitrary filesystem paths, and keeps valid nested raw paths working.

I also kept blank `page.release` compatible with the previous behavior by treating it as an unversioned lookup under `raw/` instead of turning it into an error.

## Testing

- `bundle exec rspec` in `jekyll-kuma-plugins`