### PR TITLE
docs(meshservice): document label propagation

### DIFF
--- a/app/_src/networking/meshservice.md
+++ b/app/_src/networking/meshservice.md
@@ -142,12 +142,14 @@ for `test-server` from these two inbounds.
 {% if_version gte:2.14.x %}
 #### Label propagation
 
-Non-reserved `Dataplane` inbound tags and `Dataplane` resource labels are
-propagated into the generated `MeshService`'s `metadata.labels`. This lets you
-select generated `MeshServices` (for example with
+In Universal zones, non-reserved `Dataplane` inbound tags and `Dataplane`
+resource labels are propagated into the generated `MeshService`'s
+`metadata.labels`. This lets you select generated `MeshServices` (for example
+with
 [`MeshMultiZoneService`](/docs/{{ page.release }}/networking/meshmultizoneservice/))
 by custom labels such as `team` or `version` without patching each
-`MeshService` manually.
+`MeshService` manually. It does not apply to Kubernetes zones, where
+`MeshServices` are generated from `Services`.
 
 This is opt-in. Enable it via the control plane configuration:
 
@@ -155,7 +157,8 @@ This is opt-in. Enable it via the control plane configuration:
 experimental:
   meshServiceLabelPropagation:
     enabled: true
-    # optional allow-list; when set, only these keys are propagated
+    # optional allow-list of label keys; when set, only these keys are
+    # propagated. When empty, all non-reserved keys are propagated.
     allowedLabelKeys: []
 ```
 
@@ -174,7 +177,7 @@ Rules:
 When the `Dataplanes` backing one `MeshService` disagree on the value of a
 non-reserved key:
 
-- **Within a single `Dataplane`** (inbounds disagree on a tag): the key is
+- **Within a single `Dataplane`** (inbounds disagree on a label): the key is
   dropped, a warning is logged, and a metric is bumped. Inbounds of the same
   `Dataplane` disagreeing is a configuration error.
 - **Across different `Dataplanes`**: per-key **majority wins**. The value

--- a/app/_src/networking/meshservice.md
+++ b/app/_src/networking/meshservice.md
@@ -139,6 +139,61 @@ since there's no way to create a coherent `MeshService`
 for `test-server` from these two inbounds.
 {% endif_version %}
 
+{% if_version gte:2.14.x %}
+#### Label propagation
+
+Non-reserved `Dataplane` inbound tags and `Dataplane` resource labels are
+propagated into the generated `MeshService`'s `metadata.labels`. This lets you
+select generated `MeshServices` (for example with
+[`MeshMultiZoneService`](/docs/{{ page.release }}/networking/meshmultizoneservice/))
+by custom labels such as `team` or `version` without patching each
+`MeshService` manually.
+
+This is opt-in. Enable it via the control plane configuration:
+
+```yaml
+experimental:
+  meshServiceLabelPropagation:
+    enabled: true
+    # optional allow-list; when set, only these keys are propagated
+    allowedLabelKeys: []
+```
+
+Rules:
+
+- `kuma.io/*` and `k8s.kuma.io/*` keys are never propagated. System labels
+  (`kuma.io/mesh`, `kuma.io/display-name`, `kuma.io/managed-by`, `kuma.io/env`,
+  `kuma.io/zone`, `kuma.io/origin`) are always set by the generator and win.
+- Invalid label keys or values are skipped and logged. They do not fail
+  `Dataplane` validation.
+- Label removal propagates: removing a tag or label from the backing
+  `Dataplanes` removes it from the generated `MeshService`.
+
+##### Conflict resolution
+
+When the `Dataplanes` backing one `MeshService` disagree on the value of a
+non-reserved key:
+
+- **Within a single `Dataplane`** (inbounds disagree on a tag): the key is
+  dropped, a warning is logged, and a metric is bumped. Inbounds of the same
+  `Dataplane` disagreeing is a configuration error.
+- **Across different `Dataplanes`**: per-key **majority wins**. The value
+  carried by the most `Dataplanes` is used.
+- **Ties** (for example exactly two `Dataplanes` with different values, one
+  vote each): the **newest `Dataplane` wins**, compared by creation time. If
+  creation times are identical, the value is chosen by lexicographic sort.
+
+{% warning %}
+With only two backing `Dataplanes`, every key conflict is a tie, so the
+propagated value tracks whichever `Dataplane` was created most recently and can
+flip when a `Dataplane` is replaced. During a rolling deploy the value switches
+at the ~50% crossover point. If you use these labels as `MeshMultiZoneService`
+selectors, update the selectors in lockstep, or give workloads that must be
+routed separately distinct `kuma.io/service` values so they generate separate
+`MeshServices`.
+{% endwarning %}
+{% endif_version %}
+
 ## hostnames
 
 Because of various shortcomings, the existing `VirtualOutbound` does not work

--- a/app/_src/networking/meshservice.md
+++ b/app/_src/networking/meshservice.md
@@ -164,7 +164,7 @@ Rules:
 
 When the `Dataplanes` backing one `MeshService` disagree on the value of a non-reserved key:
 
-- **Within a single `Dataplane`** (inbounds disagree on a label): the key is dropped, a warning is logged, and a metric is bumped. Inbounds of the same `Dataplane` disagreeing is a configuration error.
+- **Within a single `Dataplane`** (inbounds disagree on a tag): the key is dropped, a warning is logged, and a metric is bumped. Inbounds of the same `Dataplane` disagreeing is a configuration error.
 - **Across different `Dataplanes`**: per-key **majority wins**. The value carried by the most `Dataplanes` is used.
 - **Ties** (for example exactly two `Dataplanes` with different values, one vote each): the **newest `Dataplane` wins**, compared by creation time. If creation times are identical, the value is chosen by lexicographic sort.
 

--- a/app/_src/networking/meshservice.md
+++ b/app/_src/networking/meshservice.md
@@ -142,14 +142,7 @@ for `test-server` from these two inbounds.
 {% if_version gte:2.14.x %}
 #### Label propagation
 
-In Universal zones, non-reserved `Dataplane` inbound tags and `Dataplane`
-resource labels are propagated into the generated `MeshService`'s
-`metadata.labels`. This lets you select generated `MeshServices` (for example
-with
-[`MeshMultiZoneService`](/docs/{{ page.release }}/networking/meshmultizoneservice/))
-by custom labels such as `team` or `version` without patching each
-`MeshService` manually. It does not apply to Kubernetes zones, where
-`MeshServices` are generated from `Services`.
+In Universal zones, non-reserved `Dataplane` inbound tags and `Dataplane` resource labels are propagated into the generated `MeshService`'s `metadata.labels`. This lets you select generated `MeshServices` (for example with [`MeshMultiZoneService`](/docs/{{ page.release }}/networking/meshmultizoneservice/)) by custom labels such as `team` or `version` without patching each `MeshService` manually. It does not apply to Kubernetes zones, where `MeshServices` are generated from `Services`.
 
 This is opt-in. Enable it via the control plane configuration:
 
@@ -157,43 +150,26 @@ This is opt-in. Enable it via the control plane configuration:
 experimental:
   meshServiceLabelPropagation:
     enabled: true
-    # optional allow-list of label keys; when set, only these keys are
-    # propagated. When empty, all non-reserved keys are propagated.
+    # optional allow-list of label keys; when set, only these keys are propagated; when empty, all non-reserved keys are propagated
     allowedLabelKeys: []
 ```
 
 Rules:
 
-- `kuma.io/*` and `k8s.kuma.io/*` keys are never propagated. System labels
-  (`kuma.io/mesh`, `kuma.io/display-name`, `kuma.io/managed-by`, `kuma.io/env`,
-  `kuma.io/zone`, `kuma.io/origin`) are always set by the generator and win.
-- Invalid label keys or values are skipped and logged. They do not fail
-  `Dataplane` validation.
-- Label removal propagates: removing a tag or label from the backing
-  `Dataplanes` removes it from the generated `MeshService`.
+- `kuma.io/*` and `k8s.kuma.io/*` keys are never propagated. System labels (`kuma.io/mesh`, `kuma.io/display-name`, `kuma.io/managed-by`, `kuma.io/env`, `kuma.io/zone`, `kuma.io/origin`) are always set by the generator and win.
+- Invalid label keys or values are skipped and logged. They do not fail `Dataplane` validation.
+- Label removal propagates: removing a tag or label from the backing `Dataplanes` removes it from the generated `MeshService`.
 
 ##### Conflict resolution
 
-When the `Dataplanes` backing one `MeshService` disagree on the value of a
-non-reserved key:
+When the `Dataplanes` backing one `MeshService` disagree on the value of a non-reserved key:
 
-- **Within a single `Dataplane`** (inbounds disagree on a label): the key is
-  dropped, a warning is logged, and a metric is bumped. Inbounds of the same
-  `Dataplane` disagreeing is a configuration error.
-- **Across different `Dataplanes`**: per-key **majority wins**. The value
-  carried by the most `Dataplanes` is used.
-- **Ties** (for example exactly two `Dataplanes` with different values, one
-  vote each): the **newest `Dataplane` wins**, compared by creation time. If
-  creation times are identical, the value is chosen by lexicographic sort.
+- **Within a single `Dataplane`** (inbounds disagree on a label): the key is dropped, a warning is logged, and a metric is bumped. Inbounds of the same `Dataplane` disagreeing is a configuration error.
+- **Across different `Dataplanes`**: per-key **majority wins**. The value carried by the most `Dataplanes` is used.
+- **Ties** (for example exactly two `Dataplanes` with different values, one vote each): the **newest `Dataplane` wins**, compared by creation time. If creation times are identical, the value is chosen by lexicographic sort.
 
 {% warning %}
-With only two backing `Dataplanes`, every key conflict is a tie, so the
-propagated value tracks whichever `Dataplane` was created most recently and can
-flip when a `Dataplane` is replaced. During a rolling deploy the value switches
-at the ~50% crossover point. If you use these labels as `MeshMultiZoneService`
-selectors, update the selectors in lockstep, or give workloads that must be
-routed separately distinct `kuma.io/service` values so they generate separate
-`MeshServices`.
+With only two backing `Dataplanes`, every key conflict is a tie, so the propagated value tracks whichever `Dataplane` was created most recently and can flip when a `Dataplane` is replaced. During a rolling deploy the value switches at the ~50% crossover point. If you use these labels as `MeshMultiZoneService` selectors, update the selectors in lockstep, or give workloads that must be routed separately distinct `kuma.io/service` values so they generate separate `MeshServices`.
 {% endwarning %}
 {% endif_version %}
 

--- a/app/_src/networking/meshservice.md
+++ b/app/_src/networking/meshservice.md
@@ -24,6 +24,7 @@ the analog of a Kubernetes `Service`.
 A basic example follows to illustrate the structure:
 
 {% policy_yaml namespace=kuma-demo %}
+
 ```yaml
 type: MeshService
 name: redis
@@ -52,6 +53,7 @@ status:
   vips:
   - ip: 10.0.1.1 # kuma VIP or Kubernetes cluster IP
 ```
+
 {% endpolicy_yaml %}
 
 The MeshService represents a destination for traffic from elsewhere in the mesh.
@@ -102,7 +104,7 @@ generated from the `port` value.
 The only restriction in this case is that
 the port numbers match. For example an inbound:
 
-```
+```yaml
       inbound:
       - name: main
         port: 80
@@ -112,7 +114,7 @@ the port numbers match. For example an inbound:
 
 would result in a `MeshService`:
 
-```
+```yaml
 type: MeshService
 name: test-server
 spec:
@@ -127,7 +129,7 @@ spec:
 
 but you can't also have on a different `Dataplane`:
 
-```
+```yaml
       inbound:
       - name: main
         port: 8080
@@ -140,6 +142,7 @@ for `test-server` from these two inbounds.
 {% endif_version %}
 
 {% if_version gte:2.14.x %}
+
 #### Label propagation
 
 In Universal zones, non-reserved `Dataplane` inbound tags and `Dataplane` resource labels are propagated into the generated `MeshService`'s `metadata.labels`. This lets you select generated `MeshServices` (for example with [`MeshMultiZoneService`](/docs/{{ page.release }}/networking/meshmultizoneservice/)) by custom labels such as `team` or `version` without patching each `MeshService` manually. It does not apply to Kubernetes zones, where `MeshServices` are generated from `Services`.
@@ -186,7 +189,7 @@ The `ports` field lists the ports exposed by the `Dataplanes` that
 the `MeshService` matches. `targetPort` can refer to a port directly or by the
 name of the `Dataplane` port.
 
-```
+```yaml
   ports:
   - name: redis-non-tls
     port: 16739
@@ -195,6 +198,7 @@ name of the `Dataplane` port.
 ```
 
 {% if_version gte:2.9.x %}
+
 ## Multizone
 
 The main difference at the data plane level between `kuma.io/service` and
@@ -208,8 +212,8 @@ If it _is_ enabled, destinations in the local zone are prioritized.
 
 So when moving to `MeshService`, the choice needs to be made between:
 
-* keeping this behavior, which means moving to [`MeshMultiZoneService`](/docs/{{ page.release }}/networking/meshmultizoneservice/).
-* using `MeshService` instead, either from the local zone or one synced from
+- keeping this behavior, which means moving to [`MeshMultiZoneService`](/docs/{{ page.release }}/networking/meshmultizoneservice/).
+- using `MeshService` instead, either from the local zone or one synced from
   a remote zone.
 
 This is noted in the [migration outline](#migration).
@@ -221,7 +225,7 @@ This is noted in the [migration outline](#migration).
 A `MeshService` resource can be used as the destination target of a policy by
 putting it in a `to[].targetRef` entry. For example:
 
-```
+```yaml
 spec:
   to:
   - targetRef:
@@ -242,7 +246,7 @@ In order to direct traffic to a given `MeshService`, it must be used as a
 `backendRefs` entry.
 In `backendRefs`, ports are optionally referred to by their number:
 
-```
+```yaml
 spec:
   targetRef:
     kind: Mesh
@@ -274,7 +278,7 @@ Note that with `backendRefs` only one resource is allowed to be selected.
 
 If this field is set, resources are selected via their `labels`.
 
-```
+```yaml
 - kind: MeshService
   labels:
     kuma.io/display-name: test-server-v2
@@ -289,7 +293,7 @@ Only one resource will be selected.
 But if we leave out the namespace, _any_ resource named `test-server-v2` in the
 `east` zone is selected, regardless of its namespace.
 
-```
+```yaml
 - kind: MeshService
   labels:
     kuma.io/display-name: test-server-v2
@@ -301,7 +305,7 @@ But if we leave out the namespace, _any_ resource named `test-server-v2` in the
 MeshService is opt-in and involves a migration process. Every `Mesh` must enable
 `MeshServices` in some form:
 
-```
+```yaml
 spec:
   meshServices:
     mode: Disabled # or Everywhere, ReachableBackends, Exclusive
@@ -349,17 +353,22 @@ solely with `MeshService` resources and no longer via `kuma.io/service` tags and
 1. Decide whether you want to set `mode: Everywhere` or whether you
    enable `MeshService` consumer by consumer with `mode: ReachableBackends`.
 1. For every usage of a `kuma.io/service`, decide how it should be consumed:
+
 - as `MeshService`: only ever from one single zone
   - these are created automatically
 - as `MeshMultiZoneService`: combined with all "same" services in other zones
   - these have to be created manually
+
 1. Update your MeshHTTPRoutes/MeshTCPRoutes to refer to
    `MeshService`/`MeshMultiZoneService` directly.
-  - this is required
+
+- this is required
+
 1. Set `mode: Exclusive` to stop receiving configuration based on
    `kuma.io/service`.
 1. Update `targetRef.kind: MeshService` references to use the real name of the
    `MeshService` as opposed to the `kuma.io/service`.
-  - this is not strictly required
+
+- this is not strictly required
 
 {% endif_version %}

--- a/app/_src/networking/meshservice.md
+++ b/app/_src/networking/meshservice.md
@@ -147,29 +147,59 @@ for `test-server` from these two inbounds.
 
 In Universal zones, non-reserved `Dataplane` inbound tags and `Dataplane` resource labels are propagated into the generated `MeshService`'s `metadata.labels`. This lets you select generated `MeshServices` (for example with [`MeshMultiZoneService`](/docs/{{ page.release }}/networking/meshmultizoneservice/)) by custom labels such as `team` or `version` without patching each `MeshService` manually. It does not apply to Kubernetes zones, where `MeshServices` are generated from `Services`.
 
+For example, a `Dataplane` carrying a custom `team` label:
+
+```yaml
+type: Dataplane
+mesh: default
+name: backend-1
+labels:
+  team: payments
+networking:
+  address: 10.0.0.1
+  inbound:
+  - port: 80
+    tags:
+      kuma.io/service: backend
+```
+
+produces a generated `MeshService` that carries the same label:
+
+```yaml
+type: MeshService
+name: backend
+mesh: default
+labels:
+  team: payments
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: backend
+```
+
 This is opt-in. Enable it via the control plane configuration:
 
 ```yaml
 experimental:
   meshServiceLabelPropagation:
     enabled: true
-    # optional allow-list of label keys; when set, only these keys are propagated; when empty, all non-reserved keys are propagated
-    allowedLabelKeys: []
+    allowedLabelKeys: []  # empty = propagate all non-reserved keys
 ```
 
 Rules:
 
-- `kuma.io/*` and `k8s.kuma.io/*` keys are never propagated. System labels (`kuma.io/mesh`, `kuma.io/display-name`, `kuma.io/managed-by`, `kuma.io/env`, `kuma.io/zone`, `kuma.io/origin`) are always set by the generator and win.
-- Invalid label keys or values are skipped and logged. They do not fail `Dataplane` validation.
-- Label removal propagates: removing a tag or label from the backing `Dataplanes` removes it from the generated `MeshService`.
+- `kuma.io/*` and `k8s.kuma.io/*` keys are never propagated. The generator writes system labels (`kuma.io/mesh`, `kuma.io/zone`, `kuma.io/origin`, `kuma.io/managed-by`, `kuma.io/display-name`, `kuma.io/env`) itself, and `Dataplane` tags or labels cannot override them.
+- `allowedLabelKeys` restricts propagation to an explicit set of keys. When empty, all non-reserved keys are propagated.
+- Keys and values must be valid [Kubernetes label keys and values](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set) (63-character limit, restricted character set). Invalid entries are skipped and logged. They do not fail `Dataplane` validation.
+- Label removal propagates: removing a tag or label from the backing `Dataplanes` removes it from the generated `MeshService`. Removal only takes effect once the last `Dataplane` carrying the value is gone.
 
 ##### Conflict resolution
 
 When the `Dataplanes` backing one `MeshService` disagree on the value of a non-reserved key:
 
-- **Within a single `Dataplane`** (inbounds disagree on a tag): the key is dropped, a warning is logged, and a metric is bumped. Inbounds of the same `Dataplane` disagreeing is a configuration error.
-- **Across different `Dataplanes`**: per-key **majority wins**. The value carried by the most `Dataplanes` is used.
-- **Ties** (for example exactly two `Dataplanes` with different values, one vote each): the **newest `Dataplane` wins**, compared by creation time. If creation times are identical, the value is chosen by lexicographic sort.
+- **Within a single `Dataplane`** (its inbounds disagree on a tag): the generator drops the key, logs a warning, and increments `component_meshservice_generator_dropped_labels_total`. Disagreement between inbounds on the same `Dataplane` is a configuration error.
+- **Across different `Dataplanes`**: per-key majority wins.
+- **Ties**: the newest `Dataplane` wins by creation time. On identical timestamps, the lexicographically smallest value wins.
 
 {% warning %}
 With only two backing `Dataplanes`, every key conflict is a tie, so the propagated value tracks whichever `Dataplane` was created most recently and can flip when a `Dataplane` is replaced. During a rolling deploy the value switches at the ~50% crossover point. If you use these labels as `MeshMultiZoneService` selectors, update the selectors in lockstep, or give workloads that must be routed separately distinct `kuma.io/service` values so they generate separate `MeshServices`.


### PR DESCRIPTION
## Motivation

Universal-mode `MeshService` auto-generation will propagate non-reserved Dataplane inbound tags and resource labels into the generated `MeshService` (kumahq/kuma#16542). Operators need the conflict-resolution rules documented before relying on label-based `MeshMultiZoneService` selectors.

> Changelog: skip

## Implementation information

Adds a `#### Label propagation` subsection under `### Universal` in `networking/meshservice.md`, gated to `{% if_version gte:2.14.x %}`:

- opt-in `experimental.meshServiceLabelPropagation` config flag
- reserved-prefix deny rule, invalid-label skip, removal propagation
- conflict resolution: within-DP drop, across-DP majority-wins, ties -> newest DP wins
- warning on the 2-DP tie edge case (value flips on DP replacement / rolling-deploy crossover)

## Supporting documentation

- kumahq/kuma#16542