### PR TITLE
fix(quickstart): correct installer URL fallback

### DIFF
--- a/app/_src/quickstart/universal-docker-demo-meshidentity.md
+++ b/app/_src/quickstart/universal-docker-demo-meshidentity.md
@@ -26,8 +26,8 @@ keywords:
 {% assign tmp-colima = "/tmp/colima/" | append: kuma-demo %}
 
 {% capture edition %}{% if page.edition and page.edition != "kuma" %}/{{ page.edition }}{% endif %}{% endcapture %}
-{% assign url_installer = site.links.web | default: "<https://kuma.io>" | append: edition | append: "/installer.sh" %}
-{% assign url_installer_external = site.links.share | default: "<https://kuma.io>" | append: edition | append: "/installer.sh" %}
+{% assign url_installer = site.links.web | append: edition | append: "/installer.sh" %}
+{% assign url_installer_external = site.links.share | default: site.links.web | append: edition | append: "/installer.sh" %}
 
 {% capture MeshTrafficPermission %}[MeshTrafficPermission]({{ docs }}/policies/meshtrafficpermission/){% endcapture %}
 {% capture MeshGateway %}[MeshGateway]({{ docs }}/using-mesh/managing-ingress-traffic/builtin-listeners/){% endcapture %}


### PR DESCRIPTION
## Motivation

Fixes kumahq/kuma-website#2630.

The MeshIdentity universal quickstart rendered a broken installer command. The default installer URL was wrapped in angle brackets — `default: "<https://kuma.io>"` — to silence markdownlint `MD034` (bare URL). But that value lives inside a Liquid `default:` filter, not display markdown, so the brackets become literal text. When `site.links.share` is undefined (the case on kuma.io), `url_installer_external` rendered as:

```sh
curl --location <https://kuma.io>/installer.sh ...
```

breaking the instructions (matches the screenshot in the issue).

> Changelog: fix(quickstart): correct installer URL fallback

## Implementation information

- `url_installer`: dropped the redundant literal default — `site.links.web` is always set in `jekyll.yml` / `jekyll-dev.yml`.
- `url_installer_external`: falls back to `site.links.web` instead of a literal URL when `site.links.share` is undefined.

Both render `https://kuma.io/installer.sh` with no angle brackets, and neither line contains a bare-URL literal, so `MD034` passes without the brackets.

`mise run check` passes (vale, version-urls, frontmatter, mdlint, shellcheck).

## Supporting documentation

- Issue: kumahq/kuma-website#2630